### PR TITLE
alter BMD and Invitro initial migrations

### DIFF
--- a/project/bmd/migrations/0001_initial.py
+++ b/project/bmd/migrations/0001_initial.py
@@ -57,7 +57,7 @@ class Migration(migrations.Migration):
                 ('last_updated', models.DateTimeField(auto_now=True)),
                 ('bmrs', models.TextField(blank=True)),
                 ('notes', models.TextField()),
-                ('dose_units', models.ForeignKey(to='animal.DoseUnits')),
+                ('dose_units', models.ForeignKey(to='assessment.DoseUnits')),
                 ('endpoint', models.ForeignKey(related_name='BMD_session', to='animal.Endpoint', null=True)),
                 ('selected_model', models.OneToOneField(related_name='selected', null=True, blank=True, to='bmd.BMD_model_run')),
             ],

--- a/project/invitro/migrations/0001_initial.py
+++ b/project/invitro/migrations/0001_initial.py
@@ -139,7 +139,7 @@ class Migration(migrations.Migration):
                 ('vehicle_control', models.CharField(help_text=b'Vehicle control chemical or other notes', max_length=128, blank=True)),
                 ('control_notes', models.CharField(help_text=b'Additional details related to controls', max_length=256, blank=True)),
                 ('cell_type', models.ForeignKey(related_name='ivexperiments', to='invitro.IVCellType')),
-                ('dose_units', models.ForeignKey(related_name='ivexperiments', to='animal.DoseUnits')),
+                ('dose_units', models.ForeignKey(related_name='ivexperiments', to='assessment.DoseUnits')),
                 ('study', models.ForeignKey(related_name='ivexperiments', to='study.Study')),
             ],
             options={


### PR DESCRIPTION
Alters the 0001_initial migrations for the Invitro and BMD apps to have respective foreign keys IVExperiment.dose_units and BDM_session.dose_units relate to assessment.DoseUnits instead of animal.DoseUnits. 

This fixes the migration error `django.db.utils.ProgrammingError: relation "animal_doseunits" does not exist` that is encountered when installing HAWC from scratch.