### PR TITLE
use ternary to set CleanupFieldsFilter ids to ids queryparam or None

### DIFF
--- a/project/utils/api.py
+++ b/project/utils/api.py
@@ -21,7 +21,9 @@ class CleanupFieldsFilter(InAssessmentFilter):
     """
     def filter_queryset(self, request, queryset, view):
         queryset = super(CleanupFieldsFilter, self).filter_queryset(request, queryset, view)
-        ids = request.query_params.get('ids')
+        ids = request.query_params.get('ids')\
+            if (request.query_params.get('ids') is not u'')\
+            else None
         try:
             ids = ids.split(',')
             filters = {'id__in': ids}


### PR DESCRIPTION
Fixes https://trello.com/c/l5vnR5kF/452-hotfix-null-endpoint-id-cleanup