### PR TITLE
make RobEditFinal view accessible to all Project Managers

### DIFF
--- a/project/riskofbias/views.py
+++ b/project/riskofbias/views.py
@@ -332,10 +332,14 @@ class RoBEdit(IsAuthorMixin, BaseUpdate):
         return context
 
 
-class RoBEditFinal(IsAuthorMixin, BaseDetail):
+class RoBEditFinal(ProjectManagerOrHigherMixin, BaseDetail):
     """
     Displays a form for editing the risk of bias metrics for the final review.
     Also displays the metrics for the other active risk of bias reviews.
     """
     model = models.RiskOfBias
     template_name = 'riskofbias/rob_edit_final.html'
+
+    def get_assessment(self, request, *args, **kwargs):
+        self.object = get_object_or_404(self.model, pk=kwargs['pk'])
+        return self.object.get_assessment()

--- a/project/templates/riskofbias/reviewers_list.html
+++ b/project/templates/riskofbias/reviewers_list.html
@@ -66,7 +66,7 @@
                         <td>
                     {% endif %}
                     {{rob.author}}
-                    {% if request.user == rob.author %}
+                    {% if request.user == rob.author or obj_perms.edit_assessment and rob.final %}
                         <a href="{{rob.get_edit_url}}">
                             <i title="Edit"
                                class="fa fa-pencil-square-o"


### PR DESCRIPTION
- replaces IsAuthorMixin with ProjectManagerOrHigerMixin on RoBEditFinal view.
- shows edit icon on ReviewerList if user is author, or if user is PM and rob is final.