### PR TITLE
Model managers

### DIFF
--- a/project/animal/api.py
+++ b/project/animal/api.py
@@ -31,17 +31,7 @@ class Endpoint(AssessmentViewset):
     list_actions = ['list', 'effects', 'rob_filter', ]
 
     def get_queryset(self):
-        return self.model.objects.all()\
-            .select_related(
-                'animal_group',
-                'animal_group__dosed_animals',
-                'animal_group__experiment',
-                'animal_group__experiment__study',
-            ).prefetch_related(
-                'groups',
-                'effects',
-                'animal_group__dosed_animals__doses',
-            )
+        return self.model.objects.optimized_qs()
 
     @list_route()
     def effects(self, request):

--- a/project/animal/api.py
+++ b/project/animal/api.py
@@ -46,7 +46,7 @@ class Endpoint(AssessmentViewset):
     @list_route()
     def effects(self, request):
         assessment_id = tryParseInt(self.request.query_params.get('assessment_id'), -1)
-        effects = models.Endpoint.get_effects(assessment_id)
+        effects = models.Endpoint.objects.get_effects(assessment_id)
         return Response(effects)
 
     @list_route()

--- a/project/animal/exports.py
+++ b/project/animal/exports.py
@@ -52,7 +52,7 @@ class EndpointFlatComplete(FlatFileExporter):
     """
 
     def _get_header_row(self):
-        self.doses = DoseUnits.get_animal_units(self.kwargs.get('assessment'))
+        self.doses = DoseUnits.objects.get_animal_units(self.kwargs.get('assessment'))
 
         header = []
         header.extend(Study.flat_complete_header_row())

--- a/project/animal/managers.py
+++ b/project/animal/managers.py
@@ -1,0 +1,51 @@
+from utils.models import BaseManager, get_distinct_charfield_opts, \
+    get_distinct_charfield
+
+
+class ExperimentManager(BaseManager):
+    assessment_relation = 'study__assessment'
+
+
+class AnimalGroupManager(BaseManager):
+    assessment_relation = 'experiment__study__assessment'
+
+
+class DosingRegimeManager(BaseManager):
+    assessment_relation = 'dosed_animals__experiment__study__assessment'
+
+
+class DoseGroupManager(BaseManager):
+    assessment_relation = 'dose_regime__dosed_animals__experiment__study__assessment'
+
+
+class EndpointManager(BaseManager):
+
+    def optimized_qs(self, **filters):
+        return self.get_queryset()\
+                    .filter(**filters)\
+                    .select_related(
+                        'animal_group',
+                        'animal_group__dosed_animals',
+                        'animal_group__experiment',
+                        'animal_group__experiment__study',
+                    ).prefetch_related(
+                        'groups',
+                        'effects',
+                        'animal_group__dosed_animals__doses',
+                    )
+
+    def get_system_choices(self, assessment_id):
+        return get_distinct_charfield_opts(self, assessment_id, 'system')
+
+    def get_organ_choices(self, assessment_id):
+        return get_distinct_charfield_opts(self, assessment_id, 'organ')
+
+    def get_effect_choices(self, assessment_id):
+        return get_distinct_charfield_opts(self, assessment_id, 'effect')
+
+    def get_effects(self, assessment_id):
+        return get_distinct_charfield(self, assessment_id, 'effect')
+
+
+class EndpointGroupManager(BaseManager):
+    assessment_relation = 'endpoint__assessment'

--- a/project/animal/models.py
+++ b/project/animal/models.py
@@ -22,6 +22,13 @@ from utils.models import get_crumbs
 from . import managers
 
 
+def getRelationID(rel):
+    if rel:
+        return str(rel['id'])
+    else:
+        return None
+
+
 class Experiment(models.Model):
     objects = managers.ExperimentManager()
 
@@ -348,16 +355,8 @@ class AnimalGroup(models.Model):
             "strain-name",
         )
 
-    @classmethod
-    def getRelatedAnimalGroupID(cls, rel):
-        if rel:
-            return str(rel['id'])
-        else:
-            return None
-
-    @classmethod
-    def flat_complete_data_row(cls, ser):
-
+    @staticmethod
+    def flat_complete_data_row(ser):
         return (
             ser['id'],
             ser['url'],
@@ -367,8 +366,8 @@ class AnimalGroup(models.Model):
             ser['lifestage_exposed'],
             ser['lifestage_assessed'],
             ser['duration_observation'],
-            cls.getRelatedAnimalGroupID(ser['siblings']),
-            '|'.join([cls.getRelatedAnimalGroupID(p) for p in ser['parents']]),
+            getRelationID(ser['siblings']),
+            '|'.join([getRelationID(p) for p in ser['parents']]),
             ser['generation'],
             cleanHTML(ser['comments']),
             ser['species'],
@@ -553,8 +552,8 @@ class DoseGroup(models.Model):
     def __unicode__(self):
         return u"{0} {1}".format(self.dose, self.dose_units)
 
-    @classmethod
-    def flat_complete_data_row(cls, ser_full, units, idx):
+    @staticmethod
+    def flat_complete_data_row(ser_full, units, idx):
         cols = []
         ser = [v for v in ser_full if v["dose_group_id"] == idx]
         for unit in units:
@@ -817,8 +816,8 @@ class Endpoint(BaseEndpoint):
             change += resps[i] - resps[0]
         return change >= 0
 
-    @classmethod
-    def flat_complete_header_row(cls):
+    @staticmethod
+    def flat_complete_header_row():
         return (
             "endpoint-id",
             "endpoint-url",
@@ -851,8 +850,8 @@ class Endpoint(BaseEndpoint):
             "endpoint-additional_fields",
         )
 
-    @classmethod
-    def flat_complete_data_row(cls, ser):
+    @staticmethod
+    def flat_complete_data_row(ser):
         return (
             ser['id'],
             ser['url'],
@@ -885,8 +884,8 @@ class Endpoint(BaseEndpoint):
             json.dumps(ser['additional_fields']),
         )
 
-    @classmethod
-    def get_docx_template_context(cls, assessment, queryset):
+    @staticmethod
+    def get_docx_template_context(assessment, queryset):
         """
         Given a queryset of endpoints, invert the cached results to build
         a top-down data hierarchy from study to endpoint. We use this
@@ -951,8 +950,8 @@ class Endpoint(BaseEndpoint):
             "studies": studies
         }
 
-    @classmethod
-    def setMaximumPercentControlChange(cls, ep):
+    @staticmethod
+    def setMaximumPercentControlChange(ep):
         """
         For each endpoint, return the maximum absolute-change percent control
         for that endpoint, or 0 if it cannot be calculated. Useful for
@@ -1193,8 +1192,8 @@ class EndpointGroup(ConfidenceIntervalsMixin, models.Model):
         else:
             return u"{}-{}".format(nmin, nmax)
 
-    @classmethod
-    def flat_complete_header_row(cls):
+    @staticmethod
+    def flat_complete_header_row():
         return (
             "endpoint_group-id",
             "endpoint_group-dose_group_id",
@@ -1211,8 +1210,8 @@ class EndpointGroup(ConfidenceIntervalsMixin, models.Model):
             "endpoint_group-FEL",
         )
 
-    @classmethod
-    def flat_complete_data_row(cls, ser, endpoint):
+    @staticmethod
+    def flat_complete_data_row(ser, endpoint):
         return (
             ser['id'],
             ser['dose_group_id'],

--- a/project/animal/models.py
+++ b/project/animal/models.py
@@ -22,12 +22,6 @@ from utils.models import get_crumbs
 from . import managers
 
 
-def getRelationID(rel):
-    if rel:
-        return str(rel['id'])
-    else:
-        return None
-
 
 class Experiment(models.Model):
     objects = managers.ExperimentManager()
@@ -355,8 +349,12 @@ class AnimalGroup(models.Model):
             "strain-name",
         )
 
-    @staticmethod
-    def flat_complete_data_row(ser):
+    @classmethod
+    def get_relation_id(cls, rel):
+        return str(rel['id']) if rel else None
+
+    @classmethod
+    def flat_complete_data_row(cls, ser):
         return (
             ser['id'],
             ser['url'],
@@ -366,8 +364,8 @@ class AnimalGroup(models.Model):
             ser['lifestage_exposed'],
             ser['lifestage_assessed'],
             ser['duration_observation'],
-            getRelationID(ser['siblings']),
-            '|'.join([getRelationID(p) for p in ser['parents']]),
+            cls.get_relation_id(ser['siblings']),
+            '|'.join([cls.get_relation_id(p) for p in ser['parents']]),
             ser['generation'],
             cleanHTML(ser['comments']),
             ser['species'],
@@ -503,7 +501,7 @@ class DosingRegime(models.Model):
     def flat_complete_data_row(ser):
         return (
             ser['id'],
-            AnimalGroup.getRelatedAnimalGroupID(ser['dosed_animals']),
+            AnimalGroup.get_relation_id(ser['dosed_animals']),
             ser['route_of_exposure'],
             ser['duration_exposure'],
             ser['duration_exposure_text'],

--- a/project/animal/views.py
+++ b/project/animal/views.py
@@ -130,7 +130,7 @@ class AnimalGroupCreate(CanCreateMixin, MessageMixin, CreateView):
         context["crud"] = self.crud
         context["experiment"] = self.experiment
         context["assessment"] = self.assessment
-        context["dose_types"] = DoseUnits.json_all()
+        context["dose_types"] = DoseUnits.objects.json_all()
 
         if hasattr(self, 'form_dosing_regime'):
             context['form_dosing_regime'] = self.form_dosing_regime
@@ -170,7 +170,7 @@ class AnimalGroupUpdate(AssessmentPermissionsMixin, MessageMixin, UpdateView):
         context = super(UpdateView, self).get_context_data(**kwargs)
         context["crud"] = self.crud
         context["assessment"] = context["object"].get_assessment()
-        context["dose_types"] = DoseUnits.json_all()
+        context["dose_types"] = DoseUnits.objects.json_all()
         return context
 
 
@@ -244,7 +244,7 @@ class DosingRegimeUpdate(AssessmentPermissionsMixin, MessageMixin, UpdateView):
         context = super(UpdateView, self).get_context_data(**kwargs)
         context["crud"] = self.crud
         context["assessment"] = context["object"].get_assessment()
-        context["dose_types"] = DoseUnits.json_all()
+        context["dose_types"] = DoseUnits.objects.json_all()
 
         if self.request.method == 'POST':  # send back dose-group errors
             context['dose_groups_json'] = self.request.POST['dose_groups_json']

--- a/project/animal/views.py
+++ b/project/animal/views.py
@@ -2,7 +2,7 @@ import json
 
 from django.db.models import Q
 from django.forms.models import modelformset_factory
-from django.http import HttpResponseRedirect, Http404
+from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.views.generic.edit import CreateView, UpdateView
 
@@ -219,7 +219,7 @@ class DosingRegimeUpdate(AssessmentPermissionsMixin, MessageMixin, UpdateView):
 
             # instead of checking existing vs. new, just delete all old
             # dose-groups, and save new formset
-            models.DoseGroup.objects.filter(dose_regime=self.object).delete()
+            models.DoseGroup.objects.by_dose_regime(self.object).delete()
 
             # now save dose-groups, one for each dosing regime
             for dose in fs.forms:
@@ -342,10 +342,8 @@ class EndpointList(BaseEndpointFilterList):
 
     def get_query(self, perms):
         query = Q(assessment=self.assessment)
-
         if not perms['edit']:
             query &= Q(animal_group__experiment__study__published=True)
-
         return query
 
     def get_context_data(self, **kwargs):
@@ -358,15 +356,7 @@ class EndpointTags(EndpointList):
     # List of Endpoints associated with an assessment and tag
 
     def get_queryset(self):
-        return self.model.objects\
-            .filter(effects__slug=self.kwargs['tag_slug'])\
-            .select_related('animal_group', 'animal_group__dosing_regime')\
-            .prefetch_related('animal_group__dosing_regime__doses')\
-            .filter(
-                animal_group__in=models.AnimalGroup.objects.filter(
-                    experiment__in=models.Experiment.objects.filter(
-                        study__in=Study.objects.filter(
-                            assessment=self.assessment.pk))))
+        return self.model.objects.tag_qs(self.assessment.pk, self.kwargs['tag_slug'])
 
 
 class EndpointRead(BaseDetail):
@@ -396,11 +386,10 @@ class EndpointsReport(GenerateReport):
     report_type = 2
 
     def get_queryset(self):
-        filters = {"assessment": self.assessment}
         perms = super(EndpointsReport, self).get_obj_perms()
         if not perms['edit'] or self.onlyPublished:
-            filters["animal_group__experiment__study__published"] = True
-        return self.model.objects.filter(**filters)
+            return self.model.objects.published(self.assessment)
+        return self.model.objects.get_qs(self.assessment)
 
     def get_filename(self):
         return "animal-bioassay.docx"
@@ -415,11 +404,10 @@ class EndpointsFixedReport(GenerateFixedReport):
     ReportClass = reports.EndpointDOCXReport
 
     def get_queryset(self):
-        filters = {"assessment": self.assessment}
         perms = super(EndpointsFixedReport, self).get_obj_perms()
         if not perms['edit']:
-            filters["animal_group__experiment__study__published"] = True
-        return self.model.objects.filter(**filters)
+            return self.model.objects.published(self.assessment)
+        return self.model.objects.get_qs(self.assessment)
 
     def get_filename(self):
         return "animal-bioassay.docx"
@@ -436,11 +424,10 @@ class FullExport(BaseList):
     model = models.Endpoint
 
     def get_queryset(self):
-        filters = Q(assessment=self.assessment)
         perms = self.get_obj_perms()
         if not perms['edit']:
-            filters &= Q(animal_group__experiment__study__published=True)
-        return self.model.objects.filter(filters)
+            return self.model.objects.published(self.assessment)
+        return self.model.objects.get_qs(self.assessment)
 
     def get(self, request, *args, **kwargs):
         self.object_list = self.get_queryset()

--- a/project/assessment/api.py
+++ b/project/assessment/api.py
@@ -45,7 +45,7 @@ class AssessmentLevelPermissions(permissions.BasePermission):
                 raise RequiresAssessmentID
 
             view.assessment = models.Assessment.objects\
-                .filter(id=assessment_id)\
+                .get_qs(assessment_id)\
                 .first()
 
             if view.assessment is None:
@@ -110,7 +110,7 @@ class AssessmentRootedTagTreeViewset(viewsets.ModelViewSet):
         # get an assessment
         assessment_id = tryParseInt(request.data.get('assessment_id'), -1)
         self.assessment = models.Assessment.objects\
-                .filter(id=assessment_id)\
+                .get_qs(assessment_id)\
                 .first()
         if self.assessment is None:
             raise RequiresAssessmentID
@@ -176,7 +176,7 @@ class AssessmentEndpointList(AssessmentViewset):
 
         count = apps.get_model('animal', 'Experiment')\
             .objects\
-            .filter(study__assessment=instance.id)\
+            .get_qs(instance.id)\
             .count()
         instance.items.append({
             "count": count,
@@ -187,7 +187,7 @@ class AssessmentEndpointList(AssessmentViewset):
 
         count = apps.get_model('animal', 'AnimalGroup')\
             .objects\
-            .filter(experiment__study__assessment=instance.id)\
+            .get_qs(instance.id)\
             .count()
         instance.items.append({
             "count": count,
@@ -214,7 +214,7 @@ class AssessmentEndpointList(AssessmentViewset):
 
         count = apps.get_model('invitro', 'ivchemical')\
             .objects\
-            .filter(study__assessment=instance.id)\
+            .get_qs(instance.id)\
             .count()
         instance.items.append({
             "count": count,
@@ -226,7 +226,7 @@ class AssessmentEndpointList(AssessmentViewset):
         # study
         count = apps.get_model('study', 'Study')\
             .objects\
-            .filter(assessment=instance.id)\
+            .get_qs(instance.id)\
             .count()
         instance.items.append({
             "count": count,
@@ -241,7 +241,7 @@ class AssessmentEndpointList(AssessmentViewset):
     def get_queryset(self):
         id_ = tryParseInt(self.request.GET.get('assessment_id'))
         queryset = self.model.objects\
-            .filter(id=id_)\
+            .get_qs(id_)\
             .annotate(endpoint_count=Count('baseendpoint__endpoint'))\
             .annotate(outcome_count=Count('baseendpoint__outcome'))\
             .annotate(ivendpoint_count=Count('baseendpoint__ivendpoint'))

--- a/project/assessment/managers.py
+++ b/project/assessment/managers.py
@@ -1,0 +1,127 @@
+import json
+
+from django.apps import apps
+from django.db import models
+from django.db.models import Q
+from django.contrib.contenttypes.models import ContentType
+
+from utils.helper import HAWCDjangoJSONEncoder
+from utils.models import BaseManager
+
+
+class AssessmentManager(BaseManager):
+    assessment_relation = 'id'
+
+    def get_viewable_assessments(self, user, exclusion_id=None, public=False):
+        """
+        Return queryset of all assessments which that user is able to view,
+        optionally excluding assessment exclusion_id,
+        not including public assessments
+        """
+        filters = (Q(project_manager=user) | Q(team_members=user) | Q(reviewers=user))
+        if public:
+            filters |= (Q(public=True) & Q(hide_from_public_page=False))
+        return self.filter(filters)\
+            .exclude(id=exclusion_id)\
+            .distinct()
+
+    def get_editable_assessments(self, user, exclusion_id=None):
+        """
+        Return queryset of all assessments which that user is able to edit,
+        optionally excluding assessment exclusion_id,
+        not including public assessments
+        """
+        return self.filter(Q(project_manager=user) | Q(team_members=user))\
+            .exclude(id=exclusion_id)\
+            .distinct()
+
+
+class AttachmentManager(BaseManager):
+
+    def get_attachments(self, obj, isPublic):
+        filters = {
+            "content_type": ContentType.objects.get_for_model(obj),
+            "object_id": obj.id
+        }
+        if isPublic:
+            filters["publicly_available"] = True
+        return self.filter(**filters)
+
+    def assessment_qs(self, assessment_id):
+        a = ContentType.objects\
+            .get(app_label="assessment", model="assessment").id
+        return self.filter(content_type=a, object_id=assessment_id)
+
+
+class DoseUnitManager(BaseManager):
+
+    def assessment_qs(self, assessment_id):
+        return self.all()
+
+    def json_all(self):
+        return json.dumps(list(self.all().values()), cls=HAWCDjangoJSONEncoder)
+
+    def get_animal_units(self, assessment):
+        """
+        Returns a list of the dose-units which are used in the selected
+        assessment for animal bioassay data.
+        """
+        Study = apps.get_model('study', 'Study')
+        Experiment = apps.get_model('animal', 'Experiment')
+        AnimalGroup = apps.get_model('animal', 'AnimalGroup')
+        DosingRegime = apps.get_model('animal', 'DosingRegime')
+        DoseGroup = apps.get_model('animal', 'DoseGroup')
+        return self.filter(
+            dosegroup__in=DoseGroup.objects.filter(
+                dose_regime__in=DosingRegime.objects.filter(
+                    dosed_animals__in=AnimalGroup.objects.filter(
+                        experiment__in=Experiment.objects.filter(
+                            study__in=Study.objects.filter(
+                                assessment=assessment))))))\
+            .values_list('name', flat=True)\
+            .distinct()
+
+
+class SpeciesManager(BaseManager):
+
+    def assessment_qs(self, assessment_id):
+        return self.all()
+
+
+class StrainManager(BaseManager):
+
+    def assessment_qs(self, assessment_id):
+        return self.all()
+
+
+class EffectTagManager(BaseManager):
+    assessment_relation = 'baseendpoint__assessment'
+
+    def assessment_qs(self, assessment_id):
+        return self.filter(baseendpoint__assessment_id=assessment_id)\
+            .distinct()
+
+    def get_choices(self, assessment_id):
+        return self.filter(baseendpoint__assessment_id=assessment_id)\
+                .values_list('id', 'name')\
+                .distinct()\
+                .order_by('name')
+
+
+class BaseEndpointManager(BaseManager):
+    assessment_relation = 'assessment'
+
+
+class ReportTemplateManager(BaseManager):
+    assessment_relation = 'assessment'
+
+    def get_template(self, template_id, assessment_id, report_type):
+        # Return a template object if one exists which matches the specified
+        # criteria, else throw an ObjectDoesNotExist error
+        qs = self.filter(id=template_id, report_type=report_type)\
+                .filter(Q(assessment=assessment_id) | Q(assessment=None))
+
+        if qs.count() == 1:
+            return qs[0]
+        else:
+            raise models.ObjectDoesNotExist()

--- a/project/assessment/models.py
+++ b/project/assessment/models.py
@@ -333,8 +333,8 @@ class EffectTag(models.Model):
         else:
             return d
 
-    @classmethod
-    def get_name_list(self, queryset):
+    @staticmethod
+    def get_name_list(queryset):
         return '|'.join(queryset.values_list("name", flat=True))
 
 

--- a/project/assessment/models.py
+++ b/project/assessment/models.py
@@ -4,13 +4,10 @@ import os
 from StringIO import StringIO
 
 from django.db import models
-from django.apps import apps
 from django.core.urlresolvers import reverse
-from django.core.serializers.json import DjangoJSONEncoder
 from django.conf import settings
 from django.contrib.contenttypes import fields
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import Q
 from django.utils.http import urlquote
 from django.shortcuts import HttpResponse
 
@@ -21,6 +18,8 @@ from utils.models import get_crumbs
 from utils.helper import HAWCDjangoJSONEncoder
 from myuser.models import HAWCUser
 
+from . import managers
+
 
 def get_cas_url(cas):
     if cas:
@@ -30,6 +29,8 @@ def get_cas_url(cas):
 
 
 class Assessment(models.Model):
+    objects = managers.AssessmentManager()
+
     name = models.CharField(
         max_length=80,
         verbose_name='Assessment Name',
@@ -121,10 +122,6 @@ class Assessment(models.Model):
     def get_absolute_url(self):
         return reverse('assessment:detail', args=[str(self.pk)])
 
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects.filter(id=assessment_id)
-
     @property
     def cas_url(self):
         return get_cas_url(self.cas)
@@ -201,38 +198,13 @@ class Assessment(models.Model):
                     (user in self.team_members.all()) or
                     (user in self.reviewers.all()))
 
-    @classmethod
-    def get_viewable_assessments(cls, user, exclusion_id=None, public=False):
-        """
-        Return queryset of all assessments which that user is able to view,
-        optionally excluding assessment exclusion_id,
-        not including public assessments
-        """
-        filters = (Q(project_manager=user) | Q(team_members=user) | Q(reviewers=user))
-        if public:
-            filters |= (Q(public=True) & Q(hide_from_public_page=False))
-        return Assessment.objects\
-            .filter(filters)\
-            .exclude(id=exclusion_id)\
-            .distinct()
-
-    @classmethod
-    def get_editable_assessments(cls, user, exclusion_id=None):
-        """
-        Return queryset of all assessments which that user is able to edit,
-        optionally excluding assessment exclusion_id,
-        not including public assessments
-        """
-        return Assessment.objects\
-            .filter(Q(project_manager=user) | Q(team_members=user))\
-            .exclude(id=exclusion_id)\
-            .distinct()
-
     def get_crumbs(self):
         return get_crumbs(self)
 
 
 class Attachment(models.Model):
+    objects = managers.AttachmentManager()
+
     content_type = models.ForeignKey(ContentType)
     object_id = models.PositiveIntegerField()
     content_object = fields.GenericForeignKey('content_type', 'object_id')
@@ -265,24 +237,10 @@ class Attachment(models.Model):
     def get_assessment(self):
         return self.content_object.get_assessment()
 
-    @classmethod
-    def get_attachments(cls, obj, isPublic):
-        filters = {
-            "content_type": ContentType.objects.get_for_model(obj),
-            "object_id": obj.id
-        }
-        if isPublic:
-            filters["publicly_available"] = True
-        return cls.objects.filter(**filters)
-
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        a = ContentType.objects\
-            .get(app_label="assessment", model="assessment").id
-        return cls.objects.filter(content_type=a, object_id=assessment_id)
-
 
 class DoseUnits(models.Model):
+    objects = managers.DoseUnitManager()
+
     name = models.CharField(
         max_length=20,
         unique=True)
@@ -294,10 +252,6 @@ class DoseUnits(models.Model):
     class Meta:
         verbose_name_plural = "dose units"
         ordering = ("name", )
-
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects.all()
 
     def __unicode__(self):
         return self.name
@@ -314,33 +268,10 @@ class DoseUnits(models.Model):
     def invitro_experiment_count(self):
         return self.ivexperiments.count()
 
-    @classmethod
-    def json_all(cls):
-        return json.dumps(list(cls.objects.all().values()), cls=HAWCDjangoJSONEncoder)
-
-    @classmethod
-    def get_animal_units(cls, assessment):
-        """
-        Returns a list of the dose-units which are used in the selected
-        assessment for animal bioassay data.
-        """
-        Study = apps.get_model('study', 'Study')
-        Experiment = apps.get_model('animal', 'Experiment')
-        AnimalGroup = apps.get_model('animal', 'AnimalGroup')
-        DosingRegime = apps.get_model('animal', 'DosingRegime')
-        DoseGroup = apps.get_model('animal', 'DoseGroup')
-        return cls.objects.filter(
-            dosegroup__in=DoseGroup.objects.filter(
-                dose_regime__in=DosingRegime.objects.filter(
-                    dosed_animals__in=AnimalGroup.objects.filter(
-                        experiment__in=Experiment.objects.filter(
-                            study__in=Study.objects.filter(
-                                assessment=assessment))))))\
-            .values_list('name', flat=True)\
-            .distinct()
-
 
 class Species(models.Model):
+    objects = managers.SpeciesManager()
+
     name = models.CharField(
         max_length=30,
         help_text="Enter species in singular (ex: Mouse, not Mice)",
@@ -354,15 +285,13 @@ class Species(models.Model):
         verbose_name_plural = "species"
         ordering = ("name", )
 
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects.all()
-
     def __unicode__(self):
         return self.name
 
 
 class Strain(models.Model):
+    objects = managers.StrainManager()
+
     species = models.ForeignKey(
         Species)
     name = models.CharField(
@@ -376,15 +305,13 @@ class Strain(models.Model):
         unique_together = (("species", "name"),)
         ordering = ("species", "name")
 
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects.all()
-
     def __unicode__(self):
         return self.name
 
 
 class EffectTag(models.Model):
+    objects = managers.EffectTagManager()
+
     name = models.CharField(max_length=128, unique=True)
     slug = models.SlugField(max_length=128, unique=True,
                             help_text="The URL (web address) used to describe this object (no spaces or special-characters).")
@@ -410,20 +337,6 @@ class EffectTag(models.Model):
     def get_name_list(self, queryset):
         return '|'.join(queryset.values_list("name", flat=True))
 
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects\
-            .filter(baseendpoint__assessment_id=assessment_id)\
-            .distinct()
-
-    @classmethod
-    def get_choices(cls, assessment_id):
-        return cls.objects\
-                .filter(baseendpoint__assessment_id=assessment_id)\
-                .values_list('id', 'name')\
-                .distinct()\
-                .order_by('name')
-
 
 class BaseEndpoint(models.Model):
     """
@@ -431,6 +344,8 @@ class BaseEndpoint(models.Model):
     in-vitro endpoints used in assessment. Not fully abstract so efficient
     queries can pull data from all three more-specific endpoint types.
     """
+    objects = managers.BaseEndpointManager()
+
     assessment = models.ForeignKey(Assessment, db_index=True)
     # Some denormalization but required for efficient capture of all endpoints
     # in assessment; major use case in HAWC.
@@ -442,10 +357,6 @@ class BaseEndpoint(models.Model):
 
     def __unicode__(self):
         return self.name
-
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects.filter(assessment=assessment_id)
 
     def get_assessment(self):
         return self.assessment
@@ -492,6 +403,7 @@ class ChangeLog(models.Model):
 
 
 class ReportTemplate(models.Model):
+    objects = managers.ReportTemplateManager()
 
     REPORT_TYPE_CHOICES = (
         (0, 'Literature search'),
@@ -559,19 +471,6 @@ class ReportTemplate(models.Model):
             templates[obj.report_type].append(obj)
 
         return templates
-
-    @classmethod
-    def get_template(cls, template_id, assessment_id, report_type):
-        # Return a template object if one exists which matches the specified
-        # criteria, else throw an ObjectDoesNotExist error
-        qs = cls.objects\
-                .filter(id=template_id, report_type=report_type)\
-                .filter(Q(assessment=assessment_id) | Q(assessment=None))
-
-        if qs.count() == 1:
-            return qs[0]
-        else:
-            raise models.ObjectDoesNotExist()
 
 
 reversion.register(Assessment)

--- a/project/assessment/views.py
+++ b/project/assessment/views.py
@@ -107,7 +107,7 @@ class AssessmentRead(BaseDetail):
 
     def get_context_data(self, **kwargs):
         context = super(AssessmentRead, self).get_context_data(**kwargs)
-        context['attachments'] = models.Attachment.get_attachments(
+        context['attachments'] = models.Attachment.objects.get_attachments(
             self.object,
             not context['obj_perms']['edit']
         )
@@ -350,11 +350,11 @@ class CleanExtractedData(TeamMemberOrHigherMixin, BaseEndpointList):
     To add a model to clean,
      - add TEXT_CLEANUP_FIELDS = {...fields} to the model
      - add model count dict to assessment.views.AssessmentEndpointList
-     - add model serializer that uses utils.api.DynamicFieldsMixin 
+     - add model serializer that uses utils.api.DynamicFieldsMixin
      - add api view that inherits from assessment.api.CleanupFieldsBaseViewSet
         with model={model} & serializer_class={new serializer}
      - add url for api view to urls.py
-     - add url and model title to templates/assessment/clean_extracted_data.html config object 
+     - add url and model title to templates/assessment/clean_extracted_data.html config object
     '''
 
     template_name = 'assessment/clean_extracted_data.html'

--- a/project/assessment/views.py
+++ b/project/assessment/views.py
@@ -90,10 +90,7 @@ class AssessmentPublicList(ListView):
     model = models.Assessment
 
     def get_queryset(self):
-        return self.model.objects.filter(
-            public=True,
-            hide_from_public_page=False
-        ).order_by('name')
+        return self.model.objects.get_public_assessments()
 
 
 class AssessmentCreate(LoginRequiredMixin, MessageMixin, CreateView):
@@ -143,8 +140,7 @@ class AssessmentReports(BaseList):
     def get_queryset(self):
         # Get report-templates associated with no assessment (global) and
         # those associated with selected assessment
-        return self.model.objects.filter(
-            Q(assessment=None) | Q(assessment=self.assessment))
+        return self.model.objects.with_global(self.assessment)
 
     def get_context_data(self, **kwargs):
         context = super(AssessmentReports, self).get_context_data(**kwargs)
@@ -238,7 +234,7 @@ class ReportTemplateList(BaseList):
     model = models.ReportTemplate
 
     def get_queryset(self):
-        return self.model.objects.filter(assessment=self.assessment)
+        return self.model.objects.get_qs(self.assessment)
 
 
 class ReportTemplateDetail(BaseDetail):
@@ -314,22 +310,22 @@ class BaseEndpointList(BaseList):
 
         eps = self.model.endpoint\
             .related.related_model.objects\
-            .filter(assessment_id=self.assessment.id)\
+            .get_qs(self.assessment.id)\
             .count()
 
         os = self.model.outcome\
             .related.related_model.objects\
-            .filter(assessment_id=self.assessment.id)\
+            .get_qs(self.assessment.id)\
             .count()
 
         mrs = apps.get_model('epimeta', 'metaresult')\
             .objects\
-            .filter(protocol__study__assessment_id=self.assessment.id)\
+            .get_qs(self.assessment.id)\
             .count()
 
         iveps = self.model.ivendpoint\
             .related.related_model.objects\
-            .filter(assessment_id=self.assessment.id)\
+            .get_qs(self.assessment.id)\
             .count()
 
         alleps = eps + os + mrs + iveps

--- a/project/epi/managers.py
+++ b/project/epi/managers.py
@@ -1,0 +1,95 @@
+from django.db.models import Q
+from utils.models import BaseManager, get_distinct_charfield_opts
+
+
+class CriteriaManager(BaseManager):
+    assessment_relation = 'assessment'
+
+
+class CountryManager(BaseManager):
+    assessment_relation = 'studypopulation__study__assessment'
+
+    def assessment_qs(self, assessment_id):
+        qs = super(CountryManager, self).assessment_qs(assessment_id)
+        return qs.distinct()
+
+
+class AdjustmentFactorManager(BaseManager):
+    assessment_relation = 'assessment'
+
+
+class EthnicityManger(BaseManager):
+
+    def assessment_qs(self, assessment_id):
+        return self.all()
+
+
+class StudyPopulationCriteriaManager(BaseManager):
+    assessment_relation = 'criteria__assessment'
+
+
+class StudyPopulationManager(BaseManager):
+    assessment_relation = 'study__assessment'
+
+
+class OutcomeManager(BaseManager):
+    assessment_relation = 'assessment'
+
+    def published(self, assessment_id=None):
+        return self.get_qs(assessment_id)\
+                    .filter(study_population__study__published=True)
+
+    def get_system_choices(self, assessment_id):
+        return get_distinct_charfield_opts(self, assessment_id, 'system')
+
+    def get_effect_choices(self, assessment_id):
+        return get_distinct_charfield_opts(self, assessment_id, 'effect')
+
+
+class ComparisonSetManager(BaseManager):
+
+    def assessment_qs(self, assessment_id):
+        return self.filter(
+            Q(study_population__study__assessment=assessment_id) |
+            Q(outcome__assessment=assessment_id))
+
+
+class GroupManager(BaseManager):
+
+    def assessment_qs(self, assessment_id):
+        return self.filter(
+            Q(comparison_set__study_population__study__assessment=assessment_id) |  # noqa
+            Q(comparison_set__outcome__assessment=assessment_id))
+
+
+class ExposureManager(BaseManager):
+    assessment_relation = 'study_population__study__assessment'
+
+
+class GroupNumericalDescriptionsManager(BaseManager):
+
+    def assessment_qs(self, assessment_id):
+        return self.filter(
+            Q(group__comparison_set__study_population__study__assessment=assessment_id) |  # noqa
+            Q(group__comparison_set__outcome__assessment=assessment_id))
+
+
+class ResultMetricManager(BaseManager):
+
+    def assessment_qs(self, assessment_id):
+        return self.filter(
+                        Q(results__outcome__assessment=assessment_id) |
+                        Q(metaresult__protocol__study__assessment=assessment_id))\
+                    .distinct()
+
+
+class ResultAdjustmentFactorManager(BaseManager):
+    assessment_relation = 'adjustment_factor__assessment'
+
+
+class ResultManager(BaseManager):
+    assessment_relation = 'outcome__assessment'
+
+
+class GroupResultManager(BaseManager):
+    assessment_relation = 'results__outcome__assessment'

--- a/project/epi/models.py
+++ b/project/epi/models.py
@@ -1284,7 +1284,8 @@ class GroupResult(models.Model):
             "result_group-p_value",
             "result_group-is_main_finding",
             "result_group-main_finding_support",
-            "result_group-created",            "result_group-last_updated",
+            "result_group-created",
+            "result_group-last_updated",
         )
 
     @staticmethod

--- a/project/epi/models.py
+++ b/project/epi/models.py
@@ -17,8 +17,12 @@ from study.models import Study
 from utils.models import get_crumbs, get_distinct_charfield_opts
 from utils.helper import SerializerHelper, HAWCDjangoJSONEncoder
 
+from . import managers
+
 
 class Criteria(models.Model):
+    objects = managers.CriteriaManager()
+
     assessment = models.ForeignKey(
         'assessment.Assessment')
     description = models.TextField()
@@ -43,12 +47,10 @@ class Criteria(models.Model):
             description=self.description)
         cw[self.COPY_NAME][self.id] = new_obj.id
 
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects.filter(assessment=assessment_id)
-
 
 class Country(models.Model):
+    objects = managers.CountryManager()
+
     code = models.CharField(
         blank=True,
         max_length=2)
@@ -62,12 +64,6 @@ class Country(models.Model):
 
     def __unicode__(self):
         return self.name
-
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects\
-            .filter(studypopulation__study__assessment=assessment_id)\
-            .distinct()
 
 
 class AdjustmentFactor(models.Model):
@@ -94,12 +90,10 @@ class AdjustmentFactor(models.Model):
             description=self.description)
         cw[self.COPY_NAME][self.id] = new_obj.id
 
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects.filter(assessment=assessment_id)
-
 
 class Ethnicity(models.Model):
+    objects = managers.EthnicityManger()
+
     name = models.CharField(
         max_length=64,
         unique=True)
@@ -114,12 +108,10 @@ class Ethnicity(models.Model):
     def __unicode__(self):
         return self.name
 
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects.all()
-
 
 class StudyPopulationCriteria(models.Model):
+    objects = managers.StudyPopulationCriteriaManager()
+
     CRITERIA_TYPE = (
         ("I", "Inclusion"),
         ("E", "Exclusion"),
@@ -145,12 +137,9 @@ class StudyPopulationCriteria(models.Model):
         self.save()
         cw[self.COPY_NAME][old_id] = self.id
 
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects.filter(criteria__assessment=assessment_id)
-
 
 class StudyPopulation(models.Model):
+    objects = managers.StudyPopulationManager()
 
     DESIGN_CHOICES = (
         ('CO', 'Cohort'),
@@ -218,10 +207,6 @@ class StudyPopulation(models.Model):
         auto_now=True)
 
     COPY_NAME = "study_populations"
-
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects.filter(study__assessment=assessment_id)
 
     @staticmethod
     def flat_complete_header_row():
@@ -323,6 +308,7 @@ class StudyPopulation(models.Model):
 
 
 class Outcome(BaseEndpoint):
+    objects = managers.OutcomeManager()
 
     TEXT_CLEANUP_FIELDS = (
         'name',
@@ -393,10 +379,6 @@ class Outcome(BaseEndpoint):
             return json.dumps(outcomes, cls=HAWCDjangoJSONEncoder)
         else:
             return outcomes
-
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects.filter(assessment=assessment_id)
 
     @classmethod
     def delete_caches(cls, ids):
@@ -481,16 +463,10 @@ class Outcome(BaseEndpoint):
         for child in children:
             child.copy_across_assessments(cw)
 
-    @classmethod
-    def get_system_choices(cls, assessment_id):
-        return get_distinct_charfield_opts(cls, assessment_id, 'system')
-
-    @classmethod
-    def get_effect_choices(cls, assessment_id):
-        return get_distinct_charfield_opts(cls, assessment_id, 'effect')
-
 
 class ComparisonSet(models.Model):
+    objects = managers.ComparisonSetManager()
+
     study_population = models.ForeignKey(
         StudyPopulation,
         related_name='comparison_sets',
@@ -518,12 +494,6 @@ class ComparisonSet(models.Model):
 
     class Meta:
         ordering = ('name', )
-
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects.filter(
-            models.Q(study_population__study__assessment=assessment_id) |
-            models.Q(outcome__assessment=assessment_id))
 
     def save(self, *args, **kwargs):
         if not xor(self.outcome is None, self.study_population is None):
@@ -587,6 +557,8 @@ class ComparisonSet(models.Model):
 
 
 class Group(models.Model):
+    objects = managers.GroupManager()
+
     SEX_CHOICES = (
         ("U", "Not reported"),
         ("M", "Male"),
@@ -654,12 +626,6 @@ class Group(models.Model):
     class Meta:
         ordering = ('comparison_set', 'group_id', )
 
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects.filter(
-            models.Q(comparison_set__study_population__study__assessment=assessment_id) |  # noqa
-            models.Q(comparison_set__outcome__assessment=assessment_id))
-
     def get_absolute_url(self):
         return reverse('epi:g_detail', kwargs={'pk': self.pk})
 
@@ -722,6 +688,8 @@ class Group(models.Model):
 
 
 class Exposure(models.Model):
+    objects = managers.ExposureManager()
+
     study_population = models.ForeignKey(
         StudyPopulation,
         related_name='exposures')
@@ -800,11 +768,6 @@ class Exposure(models.Model):
     def __unicode__(self):
         return self.name
 
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects\
-            .filter(study_population__study__assessment=assessment_id)
-
     def get_assessment(self):
         return self.study_population.get_assessment()
 
@@ -880,6 +843,7 @@ class Exposure(models.Model):
 
 
 class GroupNumericalDescriptions(models.Model):
+    objects = managers.GroupNumericalDescriptionsManager()
 
     MEAN_TYPE_CHOICES = (
         (0, None),
@@ -949,12 +913,6 @@ class GroupNumericalDescriptions(models.Model):
     def __unicode__(self):
         return self.description
 
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects.filter(
-            models.Q(group__comparison_set__study_population__study__assessment=assessment_id) |  # noqa
-            models.Q(group__comparison_set__outcome__assessment=assessment_id))
-
     def copy_across_assessments(self, cw):
         children = list(self.descriptions.all())
         old_id = self.id
@@ -967,6 +925,8 @@ class GroupNumericalDescriptions(models.Model):
 
 
 class ResultMetric(models.Model):
+    objects = managers.ResultMetricManager()
+
     metric = models.CharField(
         max_length=128,
         unique=True)
@@ -994,17 +954,10 @@ class ResultMetric(models.Model):
     def __unicode__(self):
         return self.metric
 
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects\
-            .filter(
-                models.Q(results__outcome__assessment=assessment_id) |
-                models.Q(metaresult__protocol__study__assessment=assessment_id)
-            )\
-            .distinct()
-
 
 class ResultAdjustmentFactor(models.Model):
+    objects = managers.ResultAdjustmentFactorManager()
+
     adjustment_factor = models.ForeignKey('AdjustmentFactor',
         related_name='resfactors')
     result = models.ForeignKey('Result',
@@ -1021,13 +974,9 @@ class ResultAdjustmentFactor(models.Model):
         self.save()
         cw[self.COPY_NAME][old_id] = self.id
 
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects\
-            .filter(adjustment_factor__assessment=assessment_id)
-
 
 class Result(models.Model):
+    objects = managers.ResultManager()
 
     DOSE_RESPONSE_CHOICES = (
         (0, "not-applicable"),
@@ -1149,11 +1098,6 @@ class Result(models.Model):
         return self.adjustment_factors\
             .filter(resfactors__included_in_final_model=False)
 
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects\
-            .filter(outcome__assessment=assessment_id)
-
     def __unicode__(self):
         return self.name
 
@@ -1243,6 +1187,7 @@ class Result(models.Model):
 
 
 class GroupResult(models.Model):
+    objects = managers.GroupResultManager()
 
     P_VALUE_QUALIFIER_CHOICES = (
         (' ', '-'),
@@ -1326,11 +1271,6 @@ class GroupResult(models.Model):
 
         return txt
 
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects\
-            .filter(result__outcome__assessment=assessment_id)
-
     @staticmethod
     def flat_complete_header_row():
         return (
@@ -1344,8 +1284,7 @@ class GroupResult(models.Model):
             "result_group-p_value",
             "result_group-is_main_finding",
             "result_group-main_finding_support",
-            "result_group-created",
-            "result_group-last_updated",
+            "result_group-created",            "result_group-last_updated",
         )
 
     @staticmethod

--- a/project/epi/views.py
+++ b/project/epi/views.py
@@ -134,10 +134,9 @@ class OutcomeExport(BaseList):
 
     def get_queryset(self):
         perms = self.get_obj_perms()
-        filters = Q(assessment=self.assessment)
         if not perms['edit']:
-            filters &= Q(study_population__study__published=True)
-        return self.model.objects.filter(filters)
+            return self.model.objects.published(self.assessment)
+        return self.model.objects.get_qs(self.assessment)
 
     def get(self, request, *args, **kwargs):
         self.object_list = self.get_queryset()

--- a/project/epimeta/managers.py
+++ b/project/epimeta/managers.py
@@ -8,6 +8,10 @@ class MetaProtocolManager(BaseManager):
 class MetaResultManager(BaseManager):
     assessment_relation = 'protocol__study__assessment'
 
+    def published(self, assessment_id):
+        return self.assessment_qs(assessment_id)\
+                    .filter(protocol__study__published=True)
+
 
 class SingleResultManager(BaseManager):
     assessment_relation = 'meta_result__protocol__study__assessment'

--- a/project/epimeta/managers.py
+++ b/project/epimeta/managers.py
@@ -1,0 +1,13 @@
+from utils.models import BaseManager
+
+
+class MetaProtocolManager(BaseManager):
+    assessment_relation = 'study__assessment'
+
+
+class MetaResultManager(BaseManager):
+    assessment_relation = 'protocol__study__assessment'
+
+
+class SingleResultManager(BaseManager):
+    assessment_relation = 'meta_result__protocol__study__assessment'

--- a/project/epimeta/models.py
+++ b/project/epimeta/models.py
@@ -265,8 +265,8 @@ class MetaResult(models.Model):
             ser['notes'],
         )
 
-    @classmethod
-    def get_docx_template_context(cls, assessment, queryset):
+    @staticmethod
+    def get_docx_template_context(assessment, queryset):
         """
         Given a queryset of meta-results, invert the cached results to build
         a top-down data hierarchy from study to meta-result. We use this

--- a/project/epimeta/models.py
+++ b/project/epimeta/models.py
@@ -13,8 +13,11 @@ from epi.models import Criteria, ResultMetric, AdjustmentFactor
 from utils.helper import SerializerHelper, HAWCDjangoJSONEncoder
 from utils.models import get_crumbs
 
+from . import managers
+
 
 class MetaProtocol(models.Model):
+    objects = managers.MetaProtocolManager()
 
     META_PROTOCOL_CHOICES = (
         (0, "Meta-analysis"),
@@ -74,11 +77,6 @@ class MetaProtocol(models.Model):
     def __unicode__(self):
         return self.name
 
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects\
-            .filter(study__assessment=assessment_id)
-
     def get_assessment(self):
         return self.study.get_assessment()
 
@@ -129,6 +127,8 @@ class MetaProtocol(models.Model):
 
 
 class MetaResult(models.Model):
+    objects = managers.MetaResultManager()
+
     protocol = models.ForeignKey(
         MetaProtocol,
         related_name="results")
@@ -183,11 +183,6 @@ class MetaResult(models.Model):
 
     def __unicode__(self):
         return self.label
-
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects\
-            .filter(protocol__study__assessment=assessment_id)
 
     def get_crumbs(self):
         return get_crumbs(self, self.protocol)
@@ -353,6 +348,8 @@ class MetaResult(models.Model):
 
 
 class SingleResult(models.Model):
+    objects = managers.SingleResultManager()
+
     meta_result = models.ForeignKey(
         MetaResult,
         related_name="single_results")
@@ -403,11 +400,6 @@ class SingleResult(models.Model):
 
     def __unicode__(self):
         return self.exposure_name
-
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects\
-            .filter(meta_result__protocol__study__assessment=assessment_id)
 
     @property
     def estimate_formatted(self):

--- a/project/epimeta/views.py
+++ b/project/epimeta/views.py
@@ -116,11 +116,10 @@ class MetaResultReport(GenerateReport):
     report_type = 4
 
     def get_queryset(self):
-        filters = {"protocol__study__assessment": self.assessment}
         perms = super(MetaResultReport, self).get_obj_perms()
         if not perms['edit'] or self.onlyPublished:
-            filters["protocol__study__published"] = True
-        return self.model.objects.filter(**filters)
+            return self.model.objects.published(self.assessment)
+        return self.model.objects.get_qs(self.assessment)
 
     def get_filename(self):
         return "meta-results.docx"
@@ -147,10 +146,9 @@ class MetaResultFullExport(BaseList):
 
     def get_queryset(self):
         perms = self.get_obj_perms()
-        filters = Q(protocol__study__assessment=self.assessment)
         if not perms['edit']:
-            filters &= Q(protocol__study__published=True)
-        return self.model.objects.filter(filters)
+            return self.model.objects.published(self.assessment)
+        return self.model.objects.get_qs(self.assessment)
 
     def get(self, request, *args, **kwargs):
         self.object_list = self.get_queryset()

--- a/project/invitro/managers.py
+++ b/project/invitro/managers.py
@@ -5,7 +5,7 @@ class IVChemicalManager(BaseManager):
     assessment_relation = 'study__assessment'
 
     def get_choices(self, assessment_id):
-        return self.filter(study__assessment_id=assessment_id)\
+        return self.get_qs(assessment_id)\
             .order_by('name')\
             .distinct('name')\
             .values_list('name', 'name')

--- a/project/invitro/managers.py
+++ b/project/invitro/managers.py
@@ -1,0 +1,35 @@
+from utils.models import BaseManager
+
+
+class IVChemicalManager(BaseManager):
+    assessment_relation = 'study__assessment'
+
+    def get_choices(self, assessment_id):
+        return self.filter(study__assessment_id=assessment_id)\
+            .order_by('name')\
+            .distinct('name')\
+            .values_list('name', 'name')
+
+
+class IVCellTypeManager(BaseManager):
+    assessment_relation = 'study__assessment'
+
+
+class IVExperimentManager(BaseManager):
+    assessment_relation = 'study__assessment'
+
+
+class IVEndpointManager(BaseManager):
+    assessment_relation = 'assessment'
+
+    def published(self, assessment_id=None):
+        return self.get_qs(assessment_id)\
+                    .filter(experiment__study__published=True)
+
+
+class IVEndpointGroupManager(BaseManager):
+    assessment_relation = 'endpoint__assessment'
+
+
+class IVBenchmarkManager(BaseManager):
+    assessment_relation = 'endpoint__assessment'

--- a/project/invitro/models.py
+++ b/project/invitro/models.py
@@ -13,8 +13,11 @@ from animal.models import ConfidenceIntervalsMixin
 from utils.helper import SerializerHelper, HAWCDjangoJSONEncoder
 from utils.models import get_crumbs, AssessmentRootedTagTree
 
+from . import managers
 
 class IVChemical(models.Model):
+    objects = managers.IVChemicalManager()
+
     study = models.ForeignKey(
         'study.Study',
         related_name='ivchemicals')
@@ -56,10 +59,6 @@ class IVChemical(models.Model):
     def __unicode__(self):
         return self.name
 
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects.filter(study__assessment=assessment_id)
-
     def get_crumbs(self):
         return get_crumbs(self, self.study)
 
@@ -83,16 +82,9 @@ class IVChemical(models.Model):
             .values_list('id', flat=True)
         )
 
-    @classmethod
-    def get_choices(cls, assessment_id):
-        return cls.objects\
-            .filter(study__assessment_id=assessment_id)\
-            .order_by('name')\
-            .distinct('name')\
-            .values_list('name', 'name')
-
 
 class IVCellType(models.Model):
+    objects = managers.IVCellTypeManager()
 
     SEX_CHOICES = (
         ('m', 'Male'),
@@ -143,10 +135,6 @@ class IVCellType(models.Model):
     def __unicode__(self):
         return "{} {} {}".format(self.cell_type, self.species, self.tissue)
 
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects.filter(study__assessment=assessment_id)
-
     def get_crumbs(self):
         return get_crumbs(self, self.study)
 
@@ -167,6 +155,7 @@ class IVCellType(models.Model):
 
 
 class IVExperiment(models.Model):
+    objects = managers.IVExperimentManager()
 
     METABOLIC_ACTIVATION_CHOICES = (
         ('+',  'with metabolic activation'),
@@ -233,10 +222,6 @@ class IVExperiment(models.Model):
     def __unicode__(self):
         return self.name
 
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects.filter(study__assessment=assessment_id)
-
     def get_assessment(self):
         return self.study.assessment
 
@@ -285,6 +270,7 @@ class IVEndpointCategory(AssessmentRootedTagTree):
 
 
 class IVEndpoint(BaseEndpoint):
+    objects = managers.IVEndpointManager()
 
     VARIANCE_TYPE_CHOICES = (
         (0, "NA"),
@@ -421,10 +407,6 @@ class IVEndpoint(BaseEndpoint):
     additional_fields = models.TextField(
         default="{}")
 
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects.filter(assessment=assessment_id)
-
     def get_json(self, json_encode=True):
         return SerializerHelper.get_serialized(self, json=json_encode)
 
@@ -482,6 +464,7 @@ class IVEndpoint(BaseEndpoint):
 
 
 class IVEndpointGroup(ConfidenceIntervalsMixin, models.Model):
+    objects = managers.IVEndpointGroupManager()
 
     DIFFERENCE_CONTROL_CHOICES = (
         ('nc', 'no-change'),
@@ -546,25 +529,19 @@ class IVEndpointGroup(ConfidenceIntervalsMixin, models.Model):
     def difference_control_symbol(self):
         return self.DIFFERENCE_CONTROL_SYMBOLS[self.difference_control]
 
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects.filter(endpoint__assessment=assessment_id)
-
     class Meta:
         ordering = ('endpoint', 'dose_group_id')
 
 
 class IVBenchmark(models.Model):
+    objects = managers.IVBenchmarkManager()
+
     endpoint = models.ForeignKey(
         IVEndpoint,
         related_name="benchmarks")
     benchmark = models.CharField(
         max_length=32)
     value = models.FloatField()
-
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects.filter(endpoint__assessment=assessment_id)
 
 
 reversion.register(IVChemical)

--- a/project/invitro/models.py
+++ b/project/invitro/models.py
@@ -434,8 +434,8 @@ class IVEndpoint(BaseEndpoint):
     def delete_caches(cls, ids):
         SerializerHelper.delete_caches(cls, ids)
 
-    @classmethod
-    def max_dose_count(cls, queryset):
+    @staticmethod
+    def max_dose_count(queryset):
         max_val = 0
         qs = queryset\
             .annotate(max_egs=models.Count('groups'))\
@@ -444,8 +444,8 @@ class IVEndpoint(BaseEndpoint):
             max_val = max(qs)
         return max_val
 
-    @classmethod
-    def max_benchmark_count(cls, queryset):
+    @staticmethod
+    def max_benchmark_count(queryset):
         max_val = 0
         qs = queryset\
             .annotate(max_benchmarks=models.Count('benchmarks'))\
@@ -454,8 +454,8 @@ class IVEndpoint(BaseEndpoint):
             max_val = max(qs)
         return max_val
 
-    @classmethod
-    def get_docx_template_context(cls, queryset):
+    @staticmethod
+    def get_docx_template_context(queryset):
         return {
             "field1": "a",
             "field2": "b",

--- a/project/invitro/views.py
+++ b/project/invitro/views.py
@@ -204,10 +204,9 @@ class EndpointFullExport(BaseList):
 
     def get_queryset(self):
         perms = self.get_obj_perms()
-        filters = Q(assessment=self.assessment)
         if not perms['edit']:
-            filters &= Q(experiment__study__published=True)
-        return self.model.objects.filter(filters)
+            return self.model.objects.published(self.assessment)
+        return self.model.objects.get_qs(self.assessment)
 
     def get(self, request, *args, **kwargs):
         self.object_list = self.get_queryset()
@@ -225,11 +224,10 @@ class EndpointReport(GenerateReport):
     report_type = 5
 
     def get_queryset(self):
-        filters = Q(assessment=self.assessment)
         perms = self.get_obj_perms()
         if not perms['edit'] or self.onlyPublished:
-            filters &= Q(experiment__study__published=True)
-        return self.model.objects.filter(filters)
+            return self.model.objects.published(self.assessment)
+        return self.model.objects.get_qs(self.assessment)
 
     def get_filename(self):
         return "in-vitro.docx"

--- a/project/lit/constants.py
+++ b/project/lit/constants.py
@@ -1,0 +1,18 @@
+EXTERNAL_LINK = 0
+PUBMED = 1
+HERO = 2
+RIS = 3
+DOI = 4
+WOS = 5
+SCOPUS = 6
+EMBASE = 7
+REFERENCE_DATABASES = (
+    (EXTERNAL_LINK, 'External link'),
+    (PUBMED, 'PubMed'),
+    (HERO, 'HERO'),
+    (RIS, 'RIS (EndNote/Reference Manager)'),
+    (DOI, 'DOI'),
+    (WOS, 'Web of Science'),
+    (SCOPUS, 'Scopus'),
+    (EMBASE, 'Embase')
+)

--- a/project/lit/forms.py
+++ b/project/lit/forms.py
@@ -210,7 +210,7 @@ class SearchSelectorForm(forms.Form):
         for fld in self.fields.keys():
             self.fields[fld].widget.attrs['class'] = 'span11'
 
-        assessment_pks = Assessment.get_viewable_assessments(user)\
+        assessment_pks = Assessment.objects.get_viewable_assessments(user)\
                                    .values_list('pk', flat=True)
 
         self.fields['searches'].queryset = self.fields['searches'].queryset\
@@ -317,7 +317,7 @@ class TagsCopyForm(forms.Form):
         self.assessment = kwargs.pop('assessment', None)
         super(TagsCopyForm, self).__init__(*args, **kwargs)
         self.fields['assessment'].widget.attrs['class'] = 'span12'
-        self.fields['assessment'].queryset = Assessment.get_viewable_assessments(
+        self.fields['assessment'].queryset = Assessment.objects.get_viewable_assessments(
             user, exclusion_id=self.assessment.id)
 
     def copy_tags(self):

--- a/project/lit/managers.py
+++ b/project/lit/managers.py
@@ -56,9 +56,9 @@ class SearchManager(BaseManager):
     def get_manually_added(self, assessment):
         try:
             return self.get(assessment=assessment,
-                                      source=constants.EXTERNAL_LINK,
-                                      title="Manual import",
-                                      slug=self.model.MANUAL_IMPORT_SLUG)
+                            source=constants.EXTERNAL_LINK,
+                            title="Manual import",
+                            slug=self.model.MANUAL_IMPORT_SLUG)
         except Exception:
             return None
 
@@ -222,7 +222,7 @@ class ReferenceManager(BaseManager):
             if pmid:
                 ref = self.get_qs(search.assessment)\
                     .filter(identifiers__unique_id=pmid,
-                        identifiers__database=constants.PUBMED)
+                            identifiers__database=constants.PUBMED)
             else:
                 ref = self.none()
 
@@ -244,9 +244,10 @@ class ReferenceManager(BaseManager):
         # Get an overview of tagging progress for an assessment
         refs = self.get_qs(assessment)
         total = refs.count()
-        total_tagged = refs.annotate(tag_count=models.Count('tags'))\
-                            .filter(tag_count__gt=0)\
-                            .count()
+        total_tagged = refs\
+            .annotate(tag_count=models.Count('tags'))\
+            .filter(tag_count__gt=0)\
+            .count()
         total_untagged = total - total_tagged
         total_searched = refs.filter(searches__search_type='s').distinct().count()
         total_imported = total - total_searched
@@ -286,8 +287,8 @@ class ReferenceManager(BaseManager):
 
     def get_untagged_references(self, assessment):
         return self.get_qs(assessment)\
-                .annotate(tag_count=models.Count('tags'))\
-                .filter(tag_count=0)
+            .annotate(tag_count=models.Count('tags'))\
+            .filter(tag_count=0)
 
     def process_excel(self, df, assessment_id):
         """

--- a/project/lit/models.py
+++ b/project/lit/models.py
@@ -480,8 +480,8 @@ class Identifiers(models.Model):
             "url": self.get_url()
         }
 
-    @classmethod
-    def update_pubmed_content(cls, idents):
+    @staticmethod
+    def update_pubmed_content(idents):
         tasks.update_pubmed_content.delay([d.unique_id for d in idents])
 
 

--- a/project/lit/views.py
+++ b/project/lit/views.py
@@ -30,10 +30,10 @@ class LitOverview(BaseList):
 
     def get_context_data(self, **kwargs):
         context = super(LitOverview, self).get_context_data(**kwargs)
-        context['overview'] = models.Reference.get_overview_details(self.assessment)
-        context['manual_import'] = models.Search.get_manually_added(self.assessment)
+        context['overview'] = models.Reference.objects.get_overview_details(self.assessment)
+        context['manual_import'] = models.Search.objects.get_manually_added(self.assessment)
         if context['obj_perms']['edit']: # expensive, only calculate if needed
-            qryset = models.Reference.get_references_ready_for_import(self.assessment)
+            qryset = models.Reference.objects.get_references_ready_for_import(self.assessment)
             context['need_import_count'] = qryset.count()
         context['tags'] = models.ReferenceFilterTag.get_all_tags(self.assessment.id)
         return context
@@ -104,9 +104,9 @@ class RefDownloadExcel(BaseList):
 
     def get_queryset(self):
         if self.tag:
-            return self.model.get_references_with_tag(self.tag, descendants=True)
+            return self.model.objects.get_references_with_tag(self.tag, descendants=True)
         else:
-            return self.model.objects.filter(assessment=self.assessment)
+            return self.model.objects.assessment_qs(self.assessment)
 
     def render_to_response(self, context, **response_kwargs):
         exporter = exports.ReferenceFlatComplete(
@@ -370,7 +370,7 @@ class TagByUntagged(TagReferences):
 
     def get_context_data(self, **kwargs):
         context = super(TagByUntagged, self).get_context_data(**kwargs)
-        context['references'] = models.Reference.get_untagged_references(self.assessment)
+        context['references'] = models.Reference.objects.get_untagged_references(self.assessment)
         context['tags'] = models.ReferenceFilterTag.get_all_tags(self.assessment.id)
         return context
 
@@ -422,7 +422,7 @@ class RefList(BaseList):
         context['object_type'] = 'reference'
         context['ref_objs'] = models.Reference.get_full_assessment_json(self.assessment)
         context['tags'] = models.ReferenceFilterTag.get_all_tags(self.assessment.id)
-        context['untagged'] = models.Reference.get_untagged_references(self.assessment)
+        context['untagged'] = models.Reference.objects.get_untagged_references(self.assessment)
         return context
 
 
@@ -549,11 +549,11 @@ class RefsByTagJSON(BaseDetail):
                 .get_references_with_tag(tag=tag, descendants=True)\
                 .prefetch_related('searches', 'identifiers')
         elif tag:
-            refs = models.Reference\
+            refs = models.Reference.objects\
                 .get_references_with_tag(tag, descendants=True)\
                 .prefetch_related('searches', 'identifiers')
         else:
-            refs = models.Reference\
+            refs = models.Reference.objects\
                 .get_untagged_references(self.assessment)\
                 .prefetch_related('searches', 'identifiers')
 
@@ -574,7 +574,7 @@ class RefVisualization(BaseDetail):
     def get_context_data(self, **kwargs):
         context = super(RefVisualization, self).get_context_data(**kwargs)
         context['object_type'] = 'reference'
-        context['ref_objs'] = models.Reference.get_full_assessment_json(self.assessment)
+        context['ref_objs'] = models.Reference.objects.get_full_assessment_json(self.assessment)
         context['tags'] = models.ReferenceFilterTag.get_all_tags(self.assessment.id)
         context['objectType'] = self.model.__name__
         return context

--- a/project/lit/views.py
+++ b/project/lit/views.py
@@ -141,7 +141,7 @@ class SearchNew(BaseCreate):
 
         if pk > 0:
             obj = self.model.objects.filter(pk=pk).first()
-            permitted_assesments = Assessment.get_viewable_assessments(
+            permitted_assesments = Assessment.objects.get_viewable_assessments(
                 self.request.user, exclusion_id=self.assessment.pk)
             if obj and obj.assessment in permitted_assesments:
                 kwargs['initial'] = model_to_dict(obj)

--- a/project/lit/views.py
+++ b/project/lit/views.py
@@ -44,7 +44,7 @@ class SearchList(BaseList):
     model = models.Search
 
     def get_queryset(self):
-        return self.model.objects.filter(assessment=self.assessment)
+        return self.model.objects.get_qs(self.assessment)
 
 
 class SearchCopyAsNewSelector(AssessmentPermissionsMixin, FormView):
@@ -106,7 +106,7 @@ class RefDownloadExcel(BaseList):
         if self.tag:
             return self.model.objects.get_references_with_tag(self.tag, descendants=True)
         else:
-            return self.model.objects.assessment_qs(self.assessment)
+            return self.model.objects.get_qs(self.assessment)
 
     def render_to_response(self, context, **response_kwargs):
         exporter = exports.ReferenceFlatComplete(
@@ -466,7 +466,7 @@ class RefReport(GenerateReport):
     report_type = 0
 
     def get_queryset(self):
-        return self.model.objects.filter(assessment=self.assessment)
+        return self.model.objects.get_qs(self.assessment)
 
     def get_filename(self):
         return "literature.docx"

--- a/project/myuser/models.py
+++ b/project/myuser/models.py
@@ -117,7 +117,7 @@ class HAWCUser(AbstractBaseUser, PermissionsMixin):
 
     def get_assessments(self):
         Assessment = apps.get_model('assessment', 'Assessment')
-        return Assessment.get_viewable_assessments(self)
+        return Assessment.objects.get_viewable_assessments(self)
 
     def get_json(self, json_encode=True):
         return SerializerHelper.get_serialized(self, json=json_encode)

--- a/project/riskofbias/forms.py
+++ b/project/riskofbias/forms.py
@@ -249,7 +249,7 @@ class RiskOfBiasCopyForm(forms.Form):
         self.assessment = kwargs.pop('assessment', None)
         super(RiskOfBiasCopyForm, self).__init__(*args, **kwargs)
         self.fields['assessment'].widget.attrs['class'] = 'span12'
-        self.fields['assessment'].queryset = Assessment\
+        self.fields['assessment'].queryset = Assessment.objects\
             .get_viewable_assessments(user, exclusion_id=self.assessment.id)
         self.helper = self.setHelper()
 

--- a/project/riskofbias/managers.py
+++ b/project/riskofbias/managers.py
@@ -16,7 +16,6 @@ class RiskOfBiasMetricManager(BaseManager):
             requireds |= models.Q(required_animal=True)
         if study.epi or study.epi_meta:
             requireds |= models.Q(required_epi=True)
-
         return self.get_qs(assessment).filter(requireds)
 
     def get_metrics_for_visuals(self, assessment_id):

--- a/project/riskofbias/managers.py
+++ b/project/riskofbias/managers.py
@@ -17,16 +17,23 @@ class RiskOfBiasMetricManager(BaseManager):
         if study.epi or study.epi_meta:
             requireds |= models.Q(required_epi=True)
 
-        return self.filter(domain__assessment=assessment)\
-            .filter(requireds)
+        return self.get_qs(assessment).filter(requireds)
 
     def get_metrics_for_visuals(self, assessment_id):
-        return self.filter(domain__assessment_id=assessment_id)\
-            .values('id', 'metric')
+        return self.get_qs(assessment_id).values('id', 'metric')
 
 
 class RiskOfBiasManager(BaseManager):
     assessment_relation = 'study__assessment'
+
+    def all_active(self, assessment=None):
+        return self.get_qs(assessment).filter(active=True)
+
+    def active(self, assessment=None):
+        return self.get_qs(assessment).filter(active=True, final=False)
+
+    def final(self, assessment=None):
+        return self.get_qs(assessment).filter(final=True)
 
 
 class RiskOfBiasScoreManager(BaseManager):

--- a/project/riskofbias/managers.py
+++ b/project/riskofbias/managers.py
@@ -1,0 +1,37 @@
+from django.db import models
+
+from utils.models import BaseManager
+
+
+class RiskOfBiasDomainManager(BaseManager):
+    assessment_relation = 'assessment'
+
+
+class RiskOfBiasMetricManager(BaseManager):
+    assessment_relation = 'domain__assessment'
+
+    def get_required_metrics(self, assessment, study):
+        requireds = models.Q()
+        if study.bioassay:
+            requireds |= models.Q(required_animal=True)
+        if study.epi or study.epi_meta:
+            requireds |= models.Q(required_epi=True)
+
+        return self.filter(domain__assessment=assessment)\
+            .filter(requireds)
+
+    def get_metrics_for_visuals(self, assessment_id):
+        return self.filter(domain__assessment_id=assessment_id)\
+            .values('id', 'metric')
+
+
+class RiskOfBiasManager(BaseManager):
+    assessment_relation = 'study__assessment'
+
+
+class RiskOfBiasScoreManager(BaseManager):
+    assessment_relation = 'riskofbias__study__assessment'
+
+
+class RiskOfBiasAssessmentManager(BaseManager):
+    assessment_relation = 'assessment'

--- a/project/riskofbias/models.py
+++ b/project/riskofbias/models.py
@@ -165,7 +165,7 @@ class RiskOfBias(models.Model):
         scores = [
             RiskOfBiasScore(riskofbias=self, metric=metric)
             for metric in
-            RiskOfBiasMetric.get_required_metrics(assessment, study)
+            RiskOfBiasMetric.objects.get_required_metrics(assessment, study)
         ]
         RiskOfBiasScore.objects.bulk_create(scores)
 

--- a/project/study/api.py
+++ b/project/study/api.py
@@ -46,7 +46,7 @@ class Study(viewsets.ReadOnlyModelViewSet):
     @list_route()
     def rob_scores(self, request):
         assessment_id = tryParseInt(self.request.query_params.get('assessment_id'), -1)
-        scores = self.model.rob_scores(assessment_id)
+        scores = self.model.objects.rob_scores(assessment_id)
         return Response(scores)
 
     @list_route()

--- a/project/study/api.py
+++ b/project/study/api.py
@@ -28,20 +28,15 @@ class Study(viewsets.ReadOnlyModelViewSet):
         return cls
 
     def get_queryset(self):
-        filters = {}
-        prefetch = ()
-
         if self.action == "list":
             if not self.assessment.user_can_edit_object(self.request.user):
-                filters["published"] = True
+                return self.model.objects.published(self.assessment)
+            return self.model.objects.get_qs(self.assessment)
         else:
-            prefetch = (
+            return self.model.objects.prefetch_related(
                 'identifiers',
                 'riskofbiases__scores__metric__domain',
             )
-
-        return self.model.objects.filter(**filters)\
-                   .prefetch_related(*prefetch)
 
     @list_route()
     def rob_scores(self, request):

--- a/project/study/forms.py
+++ b/project/study/forms.py
@@ -138,7 +138,7 @@ class StudiesCopy(forms.Form):
         assessment = kwargs.pop('assessment')
         super(StudiesCopy, self).__init__(*args, **kwargs)
         self.fields['assessment'].queryset = self.fields['assessment']\
-            .queryset.model.get_editable_assessments(user, assessment.id)
+            .queryset.model.objects.get_editable_assessments(user, assessment.id)
         self.fields['studies'].queryset = self.fields['studies']\
             .queryset.filter(assessment_id=assessment.id, epi=True)
         self.helper = self.setHelper(assessment)

--- a/project/study/managers.py
+++ b/project/study/managers.py
@@ -1,0 +1,25 @@
+from django.db import models
+
+from utils.models import BaseManager
+
+
+class StudyManager(BaseManager):
+    assessment_relation = 'assessment'
+
+    def get_choices(self, assessment_id):
+        return self.filter(assessment_id=assessment_id)\
+                  .values_list('id', 'short_citation')
+
+    def rob_scores(self, assessment_id):
+        return self.filter(assessment_id=assessment_id)\
+                .annotate(final_score=models.Sum(
+                    models.Case(
+                        models.When(riskofbiases__active=True,
+                                riskofbiases__final=True,
+                                then='riskofbiases__scores__score'),
+                        default=0)))\
+                .values('id', 'short_citation', 'final_score')
+
+
+class AttachmentManager(BaseManager):
+    assessment_relation = 'study__assessment'

--- a/project/study/managers.py
+++ b/project/study/managers.py
@@ -6,12 +6,15 @@ from utils.models import BaseManager
 class StudyManager(BaseManager):
     assessment_relation = 'assessment'
 
-    def get_choices(self, assessment_id):
-        return self.filter(assessment_id=assessment_id)\
+    def published(self, assessment_id=None):
+        return self.get_qs(assessment_id).filter(published=True)
+
+    def get_choices(self, assessment_id=None):
+        return self.get_qs(assessment_id)\
                   .values_list('id', 'short_citation')
 
-    def rob_scores(self, assessment_id):
-        return self.filter(assessment_id=assessment_id)\
+    def rob_scores(self, assessment_id=None):
+        return self.get_qs(assessment_id)\
                 .annotate(final_score=models.Sum(
                     models.Case(
                         models.When(riskofbiases__active=True,

--- a/project/study/models.py
+++ b/project/study/models.py
@@ -223,8 +223,8 @@ class Study(Reference):
                 types.append(field)
         return types
 
-    @classmethod
-    def flat_complete_header_row(cls):
+    @staticmethod
+    def flat_complete_header_row():
         return (
             'study-id',
             'study-url',
@@ -244,8 +244,8 @@ class Study(Reference):
             'study-published'
         )
 
-    @classmethod
-    def flat_complete_data_row(cls, ser):
+    @staticmethod
+    def flat_complete_data_row(ser):
         return (
             ser['id'],
             ser['url'],
@@ -265,8 +265,8 @@ class Study(Reference):
             ser['published']
         )
 
-    @classmethod
-    def get_docx_template_context(cls, assessment, queryset):
+    @staticmethod
+    def get_docx_template_context(assessment, queryset):
         studies = [SerializerHelper.get_serialized(study, json=False) for study in queryset]
         return {
             "assessment": AssessmentSerializer().to_representation(assessment),

--- a/project/study/views.py
+++ b/project/study/views.py
@@ -19,7 +19,7 @@ class StudyList(BaseList):
     model = models.Study
 
     def get_queryset(self):
-        return self.model.objects.filter(assessment=self.assessment)
+        return self.model.objects.get_qs(self.assessment.id)
 
 
 class StudyReport(GenerateReport):
@@ -28,11 +28,10 @@ class StudyReport(GenerateReport):
     report_type = 1
 
     def get_queryset(self):
-        filters = {"assessment": self.assessment}
         perms = super(StudyReport, self).get_obj_perms()
         if not perms['edit'] or self.onlyPublished:
-            filters["published"] = True
-        return self.model.objects.filter(**filters)
+            return self.model.objects.published(self.assessment.id)
+        return self.model.objects.get_qs(self.assessment.id)
 
     def get_filename(self):
         return "study.docx"

--- a/project/summary/forms.py
+++ b/project/summary/forms.py
@@ -235,23 +235,23 @@ class PrefilterMixin(object):
         choices = None
 
         if field_name == "systems":
-            choices = Endpoint.get_system_choices(assessment_id)
+            choices = Endpoint.objects.get_system_choices(assessment_id)
         elif field_name == "organs":
-            choices = Endpoint.get_organ_choices(assessment_id)
+            choices = Endpoint.objects.get_organ_choices(assessment_id)
         elif field_name == "effects":
-            choices = Endpoint.get_effect_choices(assessment_id)
+            choices = Endpoint.objects.get_effect_choices(assessment_id)
         elif field_name == "iv_categories":
             choices = IVEndpointCategory.get_choices(assessment_id)
         elif field_name == "iv_chemicals":
-            choices = IVChemical.get_choices(assessment_id)
+            choices = IVChemical.objects.get_choices(assessment_id)
         elif field_name == "effect_tags":
-            choices = EffectTag.get_choices(assessment_id)
+            choices = EffectTag.objects.get_choices(assessment_id)
         elif field_name == "studies":
-            choices = Study.get_choices(assessment_id)
+            choices = Study.objects.get_choices(assessment_id)
         elif field_name == "episystems":
-            choices = Outcome.get_system_choices(assessment_id)
+            choices = Outcome.objects.get_system_choices(assessment_id)
         elif field_name == "epieffects":
-            choices = Outcome.get_effect_choices(assessment_id)
+            choices = Outcome.objects.get_effect_choices(assessment_id)
         else:
             raise ValueError("Unknown field name: {}".format(field_name))
 

--- a/project/summary/forms.py
+++ b/project/summary/forms.py
@@ -637,7 +637,7 @@ class DataPivotSelectorForm(forms.Form):
         for fld in self.fields.keys():
             self.fields[fld].widget.attrs['class'] = 'span12'
 
-        self.fields['dp'].queryset = models.DataPivot\
+        self.fields['dp'].queryset = models.DataPivot.objects\
             .clonable_queryset(user)
 
 

--- a/project/summary/managers.py
+++ b/project/summary/managers.py
@@ -1,0 +1,36 @@
+from django.apps import apps
+from utils.models import BaseManager
+
+
+BIOASSAY = 0
+EPI = 1
+EPI_META = 4
+IN_VITRO = 2
+OTHER = 3
+
+STUDY_TYPE_CHOICES = (
+    (BIOASSAY, 'Animal Bioassay'),
+    (EPI, 'Epidemiology'),
+    (EPI_META, 'Epidemiology meta-analysis/pooled analysis'),
+    (IN_VITRO, 'In vitro'),
+    (OTHER, 'Other'))
+
+
+class VisualManager(BaseManager):
+    assessment_relation = 'assessment'
+
+
+class DataPivotManager(BaseManager):
+    assessment_relation = 'assessment'
+
+    def clonable_queryset(self, user):
+        """
+        Return data-pivots which can cloned by a specific user
+        """
+        Assessment = apps.get_model('assessment', 'Assessment')
+        assessment_ids = Assessment.objects\
+            .get_viewable_assessments(user, public=True)\
+            .values_list('id', flat=True)
+        return self.filter(assessment__in=assessment_ids)\
+            .select_related('assessment')\
+            .order_by('assessment__name', 'title')

--- a/project/summary/managers.py
+++ b/project/summary/managers.py
@@ -2,20 +2,6 @@ from django.apps import apps
 from utils.models import BaseManager
 
 
-BIOASSAY = 0
-EPI = 1
-EPI_META = 4
-IN_VITRO = 2
-OTHER = 3
-
-STUDY_TYPE_CHOICES = (
-    (BIOASSAY, 'Animal Bioassay'),
-    (EPI, 'Epidemiology'),
-    (EPI_META, 'Epidemiology meta-analysis/pooled analysis'),
-    (IN_VITRO, 'In vitro'),
-    (OTHER, 'Other'))
-
-
 class VisualManager(BaseManager):
     assessment_relation = 'assessment'
 

--- a/project/summary/models.py
+++ b/project/summary/models.py
@@ -222,8 +222,8 @@ class Visual(models.Model):
     def __unicode__(self):
         return self.title
 
-    @classmethod
-    def get_list_url(cls, assessment_id):
+    @staticmethod
+    def get_list_url(assessment_id):
         return reverse('summary:visualization_list', args=[str(assessment_id)])
 
     def get_absolute_url(self):
@@ -367,8 +367,8 @@ class DataPivot(models.Model):
     def __unicode__(self):
         return self.title
 
-    @classmethod
-    def get_list_url(cls, assessment_id):
+    @staticmethod
+    def get_list_url(assessment_id):
         return reverse('summary:visualization_list', args=[str(assessment_id)])
 
     def get_absolute_url(self):
@@ -406,8 +406,8 @@ class DataPivot(models.Model):
             return None
 
 
-    @classmethod
-    def reset_row_overrides(cls, settings):
+    @staticmethod
+    def reset_row_overrides(settings):
         settings_as_json = json.loads(settings)
         settings_as_json['row_overrides'] = []
         return json.dumps(settings_as_json)
@@ -610,8 +610,8 @@ class Prefilter(object):
     """
     Helper-object to deal with DataPivot and Visual prefilters fields.
     """
-    @classmethod
-    def setFiltersFromForm(cls, filters, d, visual_type):
+    @staticmethod
+    def setFiltersFromForm(filters, d, visual_type):
         evidence_type = d.get('evidence_type')
 
         if visual_type == Visual.BIOASSAY_CROSSVIEW:
@@ -660,8 +660,8 @@ class Prefilter(object):
             else:
                 raise ValueError("Unknown evidence type")
 
-    @classmethod
-    def setFiltersFromObj(cls, filters, prefilters):
+    @staticmethod
+    def setFiltersFromObj(filters, prefilters):
         filters.update(json.loads(prefilters))
 
 

--- a/project/summary/models.py
+++ b/project/summary/models.py
@@ -25,6 +25,7 @@ from treebeard.mp_tree import MP_Node
 from utils.helper import HAWCtoDateString, HAWCDjangoJSONEncoder, \
     SerializerHelper, tryParseInt
 
+from . import managers
 
 BIOASSAY = 0
 EPI = 1
@@ -167,6 +168,7 @@ class SummaryText(MP_Node):
 
 
 class Visual(models.Model):
+    objects = managers.VisualManager()
 
     BIOASSAY_AGGREGATION = 0
     BIOASSAY_CROSSVIEW = 1
@@ -219,10 +221,6 @@ class Visual(models.Model):
 
     def __unicode__(self):
         return self.title
-
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects.filter(assessment=assessment_id)
 
     @classmethod
     def get_list_url(cls, assessment_id):
@@ -340,6 +338,8 @@ class Visual(models.Model):
 
 
 class DataPivot(models.Model):
+    objects = managers.DataPivotManager()
+
     assessment = models.ForeignKey(
         Assessment)
     title = models.CharField(
@@ -366,10 +366,6 @@ class DataPivot(models.Model):
 
     def __unicode__(self):
         return self.title
-
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects.filter(assessment=assessment_id)
 
     @classmethod
     def get_list_url(cls, assessment_id):
@@ -409,17 +405,6 @@ class DataPivot(models.Model):
         except ValueError:
             return None
 
-    @classmethod
-    def clonable_queryset(cls, user):
-        """
-        Return data-pivots which can cloned by a specific user
-        """
-        assessment_ids = Assessment\
-            .get_viewable_assessments(user, public=True)\
-            .values_list('id', flat=True)
-        return cls.objects.filter(assessment__in=assessment_ids)\
-            .select_related('assessment')\
-            .order_by('assessment__name', 'title')
 
     @classmethod
     def reset_row_overrides(cls, settings):

--- a/project/summary/views.py
+++ b/project/summary/views.py
@@ -150,7 +150,7 @@ class VisualizationCreate(BaseCreate):
         context['visual_type'] = int(self.kwargs.get('visual_type'))
         context['smart_tag_form'] = forms.SmartTagForm(assessment_id=self.assessment.id)
         context['rob_metrics'] = json.dumps(list(
-            RiskOfBiasMetric.get_metrics_for_visuals(self.assessment.id)))
+            RiskOfBiasMetric.objects.get_metrics_for_visuals(self.assessment.id)))
         return context
 
 
@@ -181,7 +181,7 @@ class VisualizationUpdate(BaseUpdate):
         context['visual_type'] = self.object.visual_type
         context['smart_tag_form'] = forms.SmartTagForm(assessment_id=self.assessment.id)
         context['rob_metrics'] = json.dumps(list(
-            RiskOfBiasMetric.get_metrics_for_visuals(self.assessment.id)))
+            RiskOfBiasMetric.objects.get_metrics_for_visuals(self.assessment.id)))
         return context
 
 

--- a/project/summary/views.py
+++ b/project/summary/views.py
@@ -115,7 +115,7 @@ class VisualizationList(BaseList):
     model = models.Visual
 
     def get_queryset(self):
-        return self.model.objects.filter(assessment=self.assessment)
+        return self.model.objects.get_qs(self.assessment)
 
 
 class VisualizationDetail(BaseDetail):

--- a/project/utils/models.py
+++ b/project/utils/models.py
@@ -5,7 +5,7 @@ import django
 
 from django.apps import apps
 from django.db import models, IntegrityError, transaction, connection
-from django.db.models import URLField
+from django.db.models import URLField, Q
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist, SuspiciousOperation
 from django.template.defaultfilters import slugify as default_slugify
@@ -17,6 +17,18 @@ from utils.helper import HAWCDjangoJSONEncoder
 
 from . import forms, validators
 
+
+class BaseManager(models.Manager):
+    assessment_relation = None
+
+    def get_qs(self, assessment_id):
+        if assessment_id:
+            return self.assessment_qs(assessment_id)
+        return self.get_queryset()
+
+
+    def assessment_qs(self, assessment_id):
+        return self.get_queryset().filter(Q(**{self.assessment_relation: assessment_id}))
 
 @property
 def NotImplementedAttribute(self):

--- a/project/utils/models.py
+++ b/project/utils/models.py
@@ -285,8 +285,7 @@ class CustomURLField(URLField):
 
 
 def get_distinct_charfield(Cls, assessment_id, field):
-    return Cls.objects\
-              .filter(assessment_id=assessment_id)\
+    return Cls.filter(assessment_id=assessment_id)\
               .distinct(field)\
               .order_by(field)\
               .values_list(field, flat=True)

--- a/project/utils/models.py
+++ b/project/utils/models.py
@@ -21,14 +21,18 @@ from . import forms, validators
 class BaseManager(models.Manager):
     assessment_relation = None
 
-    def get_qs(self, assessment_id):
+    def get_qs(self, assessment_id=None):
+        '''
+        Allows for queryset to be filtered on assessment if assessment_id is passed as argument.
+        If assessment_id is not passed, then functions identically to .all()
+        '''
         if assessment_id:
             return self.assessment_qs(assessment_id)
         return self.get_queryset()
 
-
     def assessment_qs(self, assessment_id):
         return self.get_queryset().filter(Q(**{self.assessment_relation: assessment_id}))
+
 
 @property
 def NotImplementedAttribute(self):

--- a/project/utils/views.py
+++ b/project/utils/views.py
@@ -317,7 +317,7 @@ class BaseCreate(AssessmentPermissionsMixin, MessageMixin, CreateView):
         if pk > 0:
             initial = self.model.objects.filter(pk=pk).first()
             if initial and initial.get_assessment() in \
-                    Assessment.get_viewable_assessments(self.request.user, public=True):
+                    Assessment.objects.get_viewable_assessments(self.request.user, public=True):
                 kwargs['initial'] = model_to_dict(initial)
 
         return kwargs

--- a/project/utils/views.py
+++ b/project/utils/views.py
@@ -564,7 +564,7 @@ class GenerateReport(BaseList):
         ReportTemplate = apps.get_model("assessment", "ReportTemplate")
         try:
             template_id = tryParseInt(self.request.GET.get('template_id'), -1)
-            return ReportTemplate.get_template(template_id, self.assessment.id, self.report_type)
+            return ReportTemplate.objects.get_template(template_id, self.assessment.id, self.report_type)
         except ObjectDoesNotExist:
             raise Http404
 


### PR DESCRIPTION
https://trello.com/c/X3a9Lmay/505-add-new-manager-py-files-and-move-manager-queries-4

Added managers for most models (skipped taggit and treebeard based models).
Most class methods are either moved to the model manager or changed to static methods.
Frequently used queryset filters were refactored as manager methods.