### PR TITLE
added makefile and command for auto-building documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+.PHONY: clean docs help
+.DEFAULT_GOAL := help
+define BROWSER_PYSCRIPT
+import os, webbrowser, sys
+try:
+	from urllib import pathname2url
+except:
+	from urllib.request import pathname2url
+
+webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
+endef
+export BROWSER_PYSCRIPT
+
+define PRINT_HELP_PYSCRIPT
+import re, sys
+
+for line in sys.stdin:
+	match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)
+	if match:
+		target, help = match.groups()
+		print("%-20s %s" % (target, help))
+endef
+export PRINT_HELP_PYSCRIPT
+BROWSER := python -c "$$BROWSER_PYSCRIPT"
+
+help:
+	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+
+docs: ## generate Sphinx HTML documentation, including API docs
+	$(MAKE) -C docs clean
+	$(MAKE) -C docs html
+	$(BROWSER) docs/_build/html/index.html
+
+servedocs: docs ## compile the docs watching for changes
+	watchmedo shell-command -p '*.rst' -c '$(MAKE) -C docs html' -R -D .

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,7 +5,7 @@
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
-BUILDDIR      = build
+BUILDDIR      = _build
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)

--- a/docs/source/dev_setup.rst
+++ b/docs/source/dev_setup.rst
@@ -16,13 +16,13 @@ following applications installed on your local development system:
 - git >= 1.7
 
 
-.. note::
+.. warning::
     HAWC can be developed in Windows, however, in versions older than Windows 10,
     it may not be possible due to file-system restrictions. The maximum
     path length in some Windows environments is 260; the Node.js packaging
     system may often exceed this length, and does in the current HAWC environment.
 
-    There's nothing we can do to fix this :( that we're aware of.
+    There's nothing we can do to fix this that we're aware of.
 
 
 HAWC setup: Part I (OS-specific)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,6 +14,7 @@ identification and potentially derive quantitative levels of concern.
 The development team consists of:
 
 * Andy Shapiro
+* Josh Addington
 
 The Principal Investigator (PI) is:
 

--- a/docs/source/server_setup.rst
+++ b/docs/source/server_setup.rst
@@ -1,4 +1,4 @@
-Server Setup
+Server setup
 ============
 
 Minimum hardware requirements:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,6 +8,10 @@ django-extensions==1.6.1
 # for better-shell (optional; doesn't work on windows)
 bpython==0.15
 
+# for docs
+watchdog==0.8.3
+Sphinx==1.4.6
+
 # for django_extensions.graph_models
 pyparsing==2.0.3
 pydot==1.0.2


### PR DESCRIPTION
Added new command `make servedocs` which allows the documentation to be rebuilt and automatically regenerated while source-files change. This should make it easier to write documentation and test that formatting is appropriate.

Also added @JoshAddington to the list of HAWC developers.