### PR TITLE
Filter user management tasks

### DIFF
--- a/project/assets/mgmt/TaskAssignments/components/FinishedTaskFilter/index.js
+++ b/project/assets/mgmt/TaskAssignments/components/FinishedTaskFilter/index.js
@@ -1,0 +1,26 @@
+import React, { Component, PropTypes } from 'react';
+
+class FinishedTaskFilter extends Component {
+
+    render() {
+        return (
+            <div>
+                <label>
+                    <input type="checkbox"
+                        name='filter'
+                        style={{margin: '4px'}}
+                        checked={this.props.checked}
+                        onChange={this.props.onChange}/>
+                    Hide completed and abandoned tasks
+                </label>
+            </div>
+        );
+    }
+}
+
+FinishedTaskFilter.propTypes = {
+    checked: PropTypes.bool.isRequired,
+    onChange: PropTypes.func.isRequired,
+};
+
+export default FinishedTaskFilter;

--- a/project/assets/mgmt/TaskAssignments/constants.js
+++ b/project/assets/mgmt/TaskAssignments/constants.js
@@ -1,2 +1,3 @@
 export const REQUEST_TASKS = 'REQUEST_TASKS';
 export const RECEIVE_TASKS = 'RECEIVE_TASKS';
+export const PATCH_TASK = 'PATCH_TASK';

--- a/project/assets/mgmt/TaskAssignments/containers/Assignments/index.js
+++ b/project/assets/mgmt/TaskAssignments/containers/Assignments/index.js
@@ -3,11 +3,21 @@ import { connect } from 'react-redux';
 import _ from 'underscore';
 
 import AssessmentTasks from 'mgmt/TaskAssignments/components/AssessmentTasks';
+import FinishedTaskFilter from 'mgmt/TaskAssignments/components/FinishedTaskFilter';
 import Loading from 'shared/components/Loading';
 import { fetchTasks } from 'mgmt/TaskAssignments/actions';
 
 
 class Assignments extends Component {
+    constructor(props) {
+        super(props);
+        this.toggleFilter = this.toggleFilter.bind(this);
+        this.state = {
+            filterTasks: true,
+            taskFilter:  (task) => {return task.status !== 30 && task.status !== 40;},
+        };
+    }
+
 
     componentWillMount() {
         this.props.dispatch(fetchTasks());
@@ -15,9 +25,24 @@ class Assignments extends Component {
 
     formatTasks() {
         return _.chain(this.props.tasks.list)
+                .filter(this.state.taskFilter)
                 .filter((task) => task.owner.id == this.props.config.user)
                 .groupBy((task) => { return task.study.assessment.name; })
                 .value();
+    }
+
+    toggleFilter() {
+        if (this.state.filterTasks){
+            this.setState({
+                filterTasks: false,
+                taskFilter: () => true,
+            });
+        } else {
+            this.setState({
+                filterTasks: true,
+                taskFilter: (task) => {return task.status !== 30 && task.status !== 40;},
+            });
+        }
     }
 
     renderNoTasks() {
@@ -37,6 +62,7 @@ class Assignments extends Component {
 
         return (
             <div>
+                <FinishedTaskFilter checked={this.state.filterTasks} onChange={this.toggleFilter} />
                 {_.map(groupedTasks, (tasks, key) => {
                     return <AssessmentTasks key={key} name={key} tasks={tasks} showAssessment={showAssessment} />;
                 })}

--- a/project/assets/mgmt/TaskAssignments/containers/Assignments/index.js
+++ b/project/assets/mgmt/TaskAssignments/containers/Assignments/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import _ from 'underscore';
 
 import AssessmentTasks from 'mgmt/TaskAssignments/components/AssessmentTasks';
@@ -44,11 +45,12 @@ class Assignments extends Component {
     }
 }
 
-Assignments.propTypes = {
-    dispatch: PropTypes.func.isRequired,
-    tasks: PropTypes.shape({
-        list: PropTypes.array.isRequired,
-    }).isRequired,
-};
+function mapStateToProps(state){
+    const { config, tasks } = state;
+    return {
+        config,
+        tasks,
+    };
+}
 
-export default Assignments;
+export default connect(mapStateToProps)(Assignments);

--- a/project/assets/mgmt/TaskAssignments/containers/Root/index.js
+++ b/project/assets/mgmt/TaskAssignments/containers/Root/index.js
@@ -1,22 +1,26 @@
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import React, { Component, PropTypes } from 'react';
+import { Provider } from 'react-redux';
 
 import { loadConfig } from 'shared/actions/Config';
-import Assignments from 'mgmt/TaskAssignments/components/Assignments';
+import Assignments from 'mgmt/TaskAssignments/containers/Assignments';
 
 class Root extends Component {
 
     componentWillMount() {
-        this.props.dispatch(loadConfig());
+        this.props.store.dispatch(loadConfig());
     }
 
     render() {
-        return (<Assignments {...this.props}/>);
+        return (
+            <Provider store={this.props.store}>
+                <Assignments />
+            </Provider>
+        );
     }
 }
 
-function mapStateToProps(state){
-    return state;
+Root.propTypes = {
+    store: PropTypes.object.isRequired,
 }
 
-export default connect(mapStateToProps)(Root);
+export default Root;

--- a/project/assets/mgmt/TaskAssignments/index.js
+++ b/project/assets/mgmt/TaskAssignments/index.js
@@ -1,13 +1,11 @@
-import React from 'react';
-import { render } from 'react-dom';
-import { Provider } from 'react-redux';
-
-import Root from './containers/Root';
-import configureStore from './store/configureStore';
+import { splitStartupRedux } from 'utils/WebpackSplit';
 
 const startup = function(element){
-    const store = configureStore();
-    render(<Provider store={store}><Root /></Provider>, element);
+    import('mgmt/TaskAssignments/containers/Root').then((Component) => {
+        import('mgmt/TaskAssignments/store/configureStore').then((store) => {
+            splitStartupRedux(element, Component.default, store.default);
+        });
+    });
 };
 
 export default startup;

--- a/project/assets/mgmt/TaskAssignments/reducers/Tasks.js
+++ b/project/assets/mgmt/TaskAssignments/reducers/Tasks.js
@@ -1,4 +1,4 @@
-import * as types from 'mgmt/TaskTable/constants';
+import * as types from 'mgmt/TaskAssignments/constants';
 
 
 const defaultState = {

--- a/project/assets/mgmt/TaskAssignments/reducers/Tasks.js
+++ b/project/assets/mgmt/TaskAssignments/reducers/Tasks.js
@@ -1,3 +1,4 @@
+import _ from 'underscore';
 import * as types from 'mgmt/TaskAssignments/constants';
 
 
@@ -8,6 +9,7 @@ const defaultState = {
 };
 
 function tasks(state=defaultState, action) {
+    let index, list;
     switch (action.type) {
     case types.REQUEST_TASKS:
         return Object.assign({}, state, {
@@ -21,6 +23,19 @@ function tasks(state=defaultState, action) {
             isLoaded: true,
             list: action.tasks,
         });
+
+    case types.PATCH_TASK:
+        index = state.list.indexOf(
+            _.findWhere(state.list, {id: action.task.id})
+        );
+        if (index >= 0){
+            list = [
+                ...state.list.slice(0, index),
+                {...state.list[index], ..._.omit(action.task, 'csrfmiddlewaretoken')},
+                ...state.list.slice(index + 1),
+            ];
+        }
+        return Object.assign({}, state, {list});
 
     default:
         return state;

--- a/project/assets/mgmt/TaskAssignments/reducers/index.js
+++ b/project/assets/mgmt/TaskAssignments/reducers/index.js
@@ -1,7 +1,7 @@
 import { combineReducers } from 'redux';
 
 import config from 'shared/reducers/Config';
-import tasks from 'mgmt/TaskTable/reducers/Tasks';
+import tasks from 'mgmt/TaskAssignments/reducers/Tasks';
 
 
 const rootReducer = combineReducers({


### PR DESCRIPTION
Adds code-splitting for mgmt/TaskAssignments.

Completes checklist item 4 in https://trello.com/c/OzwVEqzf/521-project-management-next-steps
 - For both user-task view, add a checkbox filter at the top to show/hide completed (and abandoned) tasks. By default, hide these tasks.

