### PR TITLE
Copy as new for animal models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ node_modules
 bundles/
 webpack-stats.json
 .happypack/
+
+bin/*local.sh

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,13 @@ endef
 export PRINT_HELP_PYSCRIPT
 BROWSER := python -c "$$BROWSER_PYSCRIPT"
 
+dev: ## Start development environment
+	if [ -a ./bin/dev.local.sh ]; then \
+		./bin/dev.local.sh; \
+	else \
+		./bin/dev.sh; \
+	fi;
+
 help:
 	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ export PRINT_HELP_PYSCRIPT
 BROWSER := python -c "$$BROWSER_PYSCRIPT"
 
 dev: ## Start development environment
-	if [ -a ./bin/dev.local.sh ]; then \
+	@if [ -a ./bin/dev.local.sh ]; then \
 		./bin/dev.local.sh; \
 	else \
 		./bin/dev.sh; \

--- a/bin/dev.sh
+++ b/bin/dev.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Create the session to be used
+tmux new-session -d -s hawc
+
+# split the window
+tmux split-window -v
+tmux split-window -h
+tmux select-pane -t 0
+tmux split-window -h
+
+# Run commands
+tmux send-keys -t 0 "workon hawc && cd project" enter
+tmux send-keys -t 1 "workon hawc && cd project && python manage.py shell" enter
+tmux send-keys -t 2 "workon hawc && cd project && python manage.py runserver 8000" enter
+tmux send-keys -t 3 "workon hawc && cd project && npm start" enter
+
+# attach to shell
+tmux select-pane -t 0
+tmux attach-session

--- a/docs/source/dev_setup.rst
+++ b/docs/source/dev_setup.rst
@@ -41,27 +41,24 @@ necessary requirements::
     mkvirtualenv hawc
     git clone https://github.com/shapiromatron/hawc.git
     cd hawc
-    $VIRTUAL_ENV/bin/pip install -r $PWD/requirements/dev.txt
+    $VIRTUAL_ENV/bin/pip install -r ./requirements/dev.txt
 
 Create a local settings file and update the necessary fields within the settings::
 
-    cp hawc/settings/local.example.py hawc/settings/local.py
+    cp ./project/hawc/settings/local.example.py ./project/hawc/settings/local.py
 
 Next, update your virtual-environment settings in ``$VIRTUAL_ENV/bin/postactivate``::
 
     #!/bin/sh
     # This hook is sourced after this virtualenv is activated.
 
-    # required to install psycopg2 on Mac
-    export "PATH=/Library/PostgreSQL/9.4/bin:${PATH}"
-
     # django environment-variable settings
     export "DJANGO_SETTINGS_MODULE=hawc.settings.local"
     export "DJANGO_STATIC_ROOT=$HOME/dev/temp/hawc/static"
     export "DJANGO_MEDIA_ROOT=$HOME/dev/temp/hawc/media"
 
-    # move to project path
-    cd $HOME/dev/hawc/project
+    # move to root HAWC path (wherever that is one your computer)
+    cd $HOME/dev/hawc
 
 Windows
 ~~~~~~~~~
@@ -116,28 +113,42 @@ Create a PostgreSQL database and run the initial syncdb/migrate::
 
 Next, we'll run a few management command and apply migrations::
 
+    cd project
     python manage.py build_d3_styles
     python manage.py migrate
     python manage.py createcachetable
 
 You should now be able to run the python backend development server::
 
-    python manage.py runserver
+    cd ./project && python manage.py runserver
 
 Next, you'll need to setup the front-end web bundler. Make sure the ``npm``
 command is accessible from your virtual environment. In the ``/project`` path,
 run the following command, which will install all javascript packages for our
 development environment::
 
-    npm install --save-dev
+    cd ./project && npm install --save-dev
 
 After installing dependencies, run the javascript bundler in a second terminal::
 
-    npm start
+    cd ./project && npm start
 
 If you navigate to `localhost`_ and see a website, you're ready to begin coding!
 
 .. _`localhost`: http://127.0.0.1:8000/
+
+
+Using the bundled development environment
+-----------------------------------------
+
+For quicker development, HAWC includes a Makefile command which creates a `tmux`_
+terminal for opening all required tabs for development. To execute, use the command::
+
+    make dev
+
+You can modify the tmux environment by creating a local copy::
+
+    cp bin/dev.sh bin/dev.local.sh
 
 
 Importing a database export:

--- a/project/animal/forms.py
+++ b/project/animal/forms.py
@@ -13,7 +13,7 @@ from selectable import forms as selectable
 from assessment.models import DoseUnits
 from assessment.lookups import EffectTagLookup, SpeciesLookup, StrainLookup
 from study.lookups import AnimalStudyLookup
-from utils.forms import BaseFormHelper
+from utils.forms import BaseFormHelper, CopyAsNewSelectorForm
 
 from . import models, lookups
 
@@ -137,6 +137,11 @@ class ExperimentForm(ModelForm):
         return self.cleaned_data.get("purity_qualifier", "")
 
 
+class ExperimentSelectorForm(CopyAsNewSelectorForm):
+    label = 'Experiment'
+    lookup_class = lookups.ExperimentByStudyLookup
+
+
 class AnimalGroupForm(ModelForm):
 
     class Meta:
@@ -222,6 +227,11 @@ class AnimalGroupForm(ModelForm):
             self.add_error('strain', err)
 
         return cleaned_data
+
+
+class AnimalGroupSelectorForm(CopyAsNewSelectorForm):
+    label = 'Animal group'
+    lookup_class = lookups.AnimalGroupByExperimentLookup
 
 
 class GenerationalAnimalGroupForm(AnimalGroupForm):

--- a/project/animal/forms.py
+++ b/project/animal/forms.py
@@ -564,21 +564,9 @@ EndpointGroupFormSet = modelformset_factory(
     extra=0)
 
 
-class EndpointSelectorForm(forms.Form):
-    model = models.Endpoint
-    selector = selectable.AutoCompleteSelectField(
-        lookup_class=lookups.EndpointByStudyLookup,
-        label='Endpoint',
-        help_text="Type keywords in search-box to filter endpoints by name",
-        widget=selectable.AutoComboboxSelectWidget)
-
-    def __init__(self, *args, **kwargs):
-        study_id = kwargs.pop("study_id")
-        super(EndpointSelectorForm, self).__init__(*args, **kwargs)
-        for fld in self.fields.keys():
-            self.fields[fld].widget.attrs['class'] = 'span11'
-        self.fields['selector'].widget.update_query_parameters(
-            {'related': study_id})
+class EndpointSelectorForm(CopyAsNewSelectorForm):
+    label = 'Endpoint'
+    lookup_class = lookups.EndpointByStudyLookup
 
 
 class UploadFileForm(forms.Form):

--- a/project/animal/lookups.py
+++ b/project/animal/lookups.py
@@ -10,6 +10,18 @@ class RelatedExperimentCASLookup(RelatedDistinctStringLookup):
     related_filter = 'study__assessment_id'
 
 
+class ExperimentByStudyLookup(RelatedLookup):
+    model = models.Experiment
+    search_fields = ('name__icontains', )
+    related_filter = 'study_id'
+
+
+class AnimalGroupByExperimentLookup(RelatedLookup):
+    model = models.AnimalGroup
+    search_fields = ('name__icontains', )
+    related_filter = 'experiment_id'
+
+
 class RelatedAnimalGroupLifestageExposedLookup(RelatedDistinctStringLookup):
     model = models.AnimalGroup
     distinct_field = "lifestage_exposed"
@@ -149,6 +161,8 @@ class EndpointByAssessmentLookupHtml(EndpointByAssessmentLookup):
         )
 
 
+registry.register(ExperimentByStudyLookup)
+registry.register(AnimalGroupByExperimentLookup)
 registry.register(RelatedExperimentCASLookup)
 registry.register(RelatedAnimalGroupLifestageExposedLookup)
 registry.register(RelatedAnimalGroupLifestageAssessedLookup)

--- a/project/animal/urls.py
+++ b/project/animal/urls.py
@@ -6,47 +6,105 @@ from . import views, api
 
 
 router = DefaultRouter()
-router.register(r'endpoint', api.Endpoint, base_name="endpoint")
-router.register(r'experiment', api.Experiment, base_name="experiment")
-router.register(r'animal-group', api.AnimalGroup, base_name="animal_group")
-router.register(r'experiment-cleanup', api.ExperimentCleanupFieldsView, base_name="experiment-cleanup")
-router.register(r'animal_group-cleanup', api.AnimalGroupCleanupFieldsView, base_name="animal_group-cleanup")
-router.register(r'endpoint-cleanup', api.EndpointCleanupFieldsView, base_name="endpoint-cleanup")
-router.register(r'dose-units', api.DoseUnits, base_name="dose_units")
+router.register(r'endpoint',
+                api.Endpoint,
+                base_name="endpoint")
+router.register(r'experiment',
+                api.Experiment,
+                base_name="experiment")
+router.register(r'animal-group',
+                api.AnimalGroup,
+                base_name="animal_group")
+router.register(r'experiment-cleanup',
+                api.ExperimentCleanupFieldsView,
+                base_name="experiment-cleanup")
+router.register(r'animal_group-cleanup',
+                api.AnimalGroupCleanupFieldsView,
+                base_name="animal_group-cleanup")
+router.register(r'endpoint-cleanup',
+                api.EndpointCleanupFieldsView,
+                base_name="endpoint-cleanup")
+router.register(r'dose-units',
+                api.DoseUnits,
+                base_name="dose_units")
 
 
 urlpatterns = [
+    url(r'^api/', include(router.urls, namespace='api')),
+
     # Overall views
-    url(r'^assessment/(?P<pk>\d+)/full-export/$', views.FullExport.as_view(), name='export'),
-    url(r'^assessment/(?P<pk>\d+)/endpoint-export/$', views.EndpointExport.as_view(), name='endpoint_export'),
-    url(r'^assessment/(?P<pk>\d+)/report/$', views.EndpointsReport.as_view(), name='endpoints_report'),
-    url(r'^assessment/(?P<pk>\d+)/fixed-report/$', views.EndpointsFixedReport.as_view(), name='endpoints_fixedreport'),
+    url(r'^assessment/(?P<pk>\d+)/full-export/$',
+        views.FullExport.as_view(),
+        name='export'),
+    url(r'^assessment/(?P<pk>\d+)/endpoint-export/$',
+        views.EndpointExport.as_view(),
+        name='endpoint_export'),
+    url(r'^assessment/(?P<pk>\d+)/report/$',
+        views.EndpointsReport.as_view(),
+        name='endpoints_report'),
+    url(r'^assessment/(?P<pk>\d+)/fixed-report/$',
+        views.EndpointsFixedReport.as_view(),
+        name='endpoints_fixedreport'),
 
     # Experiment
-    url(r'^study/(?P<pk>\d+)/experiment/new/$', views.ExperimentCreate.as_view(), name='experiment_new'),
-    url(r'^study/(?P<pk>\d+)/experiment/copy-as-new-selector/$', views.ExperimentCopyAsNewSelector.as_view(), name='experiment_copy_selector'),
-    url(r'^experiment/(?P<pk>\d+)/$', views.ExperimentRead.as_view(), name='experiment_detail'),
-    url(r'^experiment/(?P<pk>\d+)/edit/$', views.ExperimentUpdate.as_view(), name='experiment_update'),
-    url(r'^experiment/(?P<pk>\d+)/delete/$', views.ExperimentDelete.as_view(), name='experiment_delete'),
+    url(r'^study/(?P<pk>\d+)/experiment/new/$',
+        views.ExperimentCreate.as_view(),
+        name='experiment_new'),
+    url(r'^study/(?P<pk>\d+)/experiment/copy-as-new-selector/$',
+        views.ExperimentCopyAsNewSelector.as_view(),
+        name='experiment_copy_selector'),
+    url(r'^experiment/(?P<pk>\d+)/$',
+        views.ExperimentRead.as_view(),
+        name='experiment_detail'),
+    url(r'^experiment/(?P<pk>\d+)/edit/$',
+        views.ExperimentUpdate.as_view(),
+        name='experiment_update'),
+    url(r'^experiment/(?P<pk>\d+)/delete/$',
+        views.ExperimentDelete.as_view(),
+        name='experiment_delete'),
 
     # AnimalGroup
-    url(r'^experiment/(?P<pk>\d+)/animal-group/new/$', views.AnimalGroupCreate.as_view(), name='animal_group_new'),
-    url(r'^experiment/(?P<pk>\d+)/animal-group/copy-as-new-selector/$', views.AnimalGroupCopyAsNewSelector.as_view(), name='animal_group_copy_selector'),
-    url(r'^animal-group/(?P<pk>\d+)/$', views.AnimalGroupRead.as_view(), name='animal_group_detail'),
-    url(r'^animal-group/(?P<pk>\d+)/edit/$', views.AnimalGroupUpdate.as_view(), name='animal_group_update'),
-    url(r'^animal-group/(?P<pk>\d+)/delete/$', views.AnimalGroupDelete.as_view(), name='animal_group_delete'),
-    url(r'^animal-group/(?P<pk>\d+)/endpoint/copy-as-new-selector/$', views.EndpointCopyAsNewSelector.as_view(), name='endpoint_copy_selector'),
+    url(r'^experiment/(?P<pk>\d+)/animal-group/new/$',
+        views.AnimalGroupCreate.as_view(),
+        name='animal_group_new'),
+    url(r'^experiment/(?P<pk>\d+)/animal-group/copy-as-new-selector/$',
+        views.AnimalGroupCopyAsNewSelector.as_view(),
+        name='animal_group_copy_selector'),
+    url(r'^animal-group/(?P<pk>\d+)/$',
+        views.AnimalGroupRead.as_view(),
+        name='animal_group_detail'),
+    url(r'^animal-group/(?P<pk>\d+)/edit/$',
+        views.AnimalGroupUpdate.as_view(),
+        name='animal_group_update'),
+    url(r'^animal-group/(?P<pk>\d+)/delete/$',
+        views.AnimalGroupDelete.as_view(),
+        name='animal_group_delete'),
+    url(r'^animal-group/(?P<pk>\d+)/endpoint/copy-as-new-selector/$',
+        views.EndpointCopyAsNewSelector.as_view(),
+        name='endpoint_copy_selector'),
 
     # Dosing Regime
-    url(r'^dosing-regime/(?P<pk>\d+)/edit/$', views.DosingRegimeUpdate.as_view(), name='dosing_regime_update'),
+    url(r'^dosing-regime/(?P<pk>\d+)/edit/$',
+        views.DosingRegimeUpdate.as_view(),
+        name='dosing_regime_update'),
 
     # Endpoint
-    url(r'^assessment/(?P<pk>\d+)/endpoints/$', views.EndpointList.as_view(), name='endpoint_list'),
-    url(r'^assessment/(?P<pk>\d+)/endpoints/tags/(?P<tag_slug>[-\w]+)/$', views.EndpointTags.as_view(), name='assessment_endpoint_taglist'),
-    url(r'^animal-group/(?P<pk>\d+)/endpoint/new/$', views.EndpointCreate.as_view(), name='endpoint_new'),
-    url(r'^endpoint/(?P<pk>\d+)/$', views.EndpointRead.as_view(), name='endpoint_detail'),
-    url(r'^endpoint/(?P<pk>\d+)/edit/$', views.EndpointUpdate.as_view(), name='endpoint_update'),
-    url(r'^endpoint/(?P<pk>\d+)/delete/$', views.EndpointDelete.as_view(), name='endpoint_delete'),
-
-    url(r'^api/', include(router.urls, namespace='api'))
+    url(r'^assessment/(?P<pk>\d+)/endpoints/$',
+        views.EndpointList.as_view(),
+        name='endpoint_list'),
+    url(r'^assessment/(?P<pk>\d+)/endpoints/tags/(?P<tag_slug>[-\w]+)/$',
+        views.EndpointTags.as_view(),
+        name='assessment_endpoint_taglist'),
+    url(r'^animal-group/(?P<pk>\d+)/endpoint/new/$',
+        views.EndpointCreate.as_view(),
+        name='endpoint_new'),
+    url(r'^endpoint/(?P<pk>\d+)/$',
+        views.EndpointRead.as_view(),
+        name='endpoint_detail'),
+    url(r'^endpoint/(?P<pk>\d+)/edit/$',
+        views.EndpointUpdate.as_view(),
+        name='endpoint_update'),
+    url(r'^endpoint/(?P<pk>\d+)/delete/$',
+        views.EndpointDelete.as_view(),
+        name='endpoint_delete'),
 ]

--- a/project/animal/urls.py
+++ b/project/animal/urls.py
@@ -24,12 +24,14 @@ urlpatterns = [
 
     # Experiment
     url(r'^study/(?P<pk>\d+)/experiment/new/$', views.ExperimentCreate.as_view(), name='experiment_new'),
+    url(r'^study/(?P<pk>\d+)/experiment/copy-as-new-selector/$', views.ExperimentCopyAsNewSelector.as_view(), name='experiment_copy_selector'),
     url(r'^experiment/(?P<pk>\d+)/$', views.ExperimentRead.as_view(), name='experiment_detail'),
     url(r'^experiment/(?P<pk>\d+)/edit/$', views.ExperimentUpdate.as_view(), name='experiment_update'),
     url(r'^experiment/(?P<pk>\d+)/delete/$', views.ExperimentDelete.as_view(), name='experiment_delete'),
 
     # AnimalGroup
     url(r'^experiment/(?P<pk>\d+)/animal-group/new/$', views.AnimalGroupCreate.as_view(), name='animal_group_new'),
+    url(r'^experiment/(?P<pk>\d+)/animal-group/copy-as-new-selector/$', views.AnimalGroupCopyAsNewSelector.as_view(), name='animal_group_copy_selector'),
     url(r'^animal-group/(?P<pk>\d+)/$', views.AnimalGroupRead.as_view(), name='animal_group_detail'),
     url(r'^animal-group/(?P<pk>\d+)/edit/$', views.AnimalGroupUpdate.as_view(), name='animal_group_update'),
     url(r'^animal-group/(?P<pk>\d+)/delete/$', views.AnimalGroupDelete.as_view(), name='animal_group_delete'),

--- a/project/animal/views.py
+++ b/project/animal/views.py
@@ -8,6 +8,7 @@ from django.views.generic.edit import CreateView, UpdateView
 
 from assessment.models import Assessment, DoseUnits
 from study.models import Study
+from study.views import StudyRead
 from utils.forms import form_error_list_to_lis, form_error_lis_to_ul
 from mgmt.views import EnsureExtractionStartedMixin
 from utils.views import (AssessmentPermissionsMixin, BaseCreate,
@@ -30,6 +31,15 @@ class ExperimentCreate(EnsureExtractionStartedMixin, BaseCreate):
 
 class ExperimentRead(BaseDetail):
     model = models.Experiment
+
+
+class ExperimentCopyAsNewSelector(StudyRead):
+    template_name = 'animal/experiment_copy_selector.html'
+
+    def get_context_data(self, **kwargs):
+        context = super(ExperimentCopyAsNewSelector, self).get_context_data(**kwargs)
+        context['form'] = forms.ExperimentSelectorForm(parent_id=self.object.id)
+        return context
 
 
 class ExperimentUpdate(BaseUpdate):
@@ -134,6 +144,15 @@ class AnimalGroupCreate(BaseCreate):
 
 class AnimalGroupRead(BaseDetail):
     model = models.AnimalGroup
+
+
+class AnimalGroupCopyAsNewSelector(ExperimentRead):
+    template_name = 'animal/animalgroup_copy_selector.html'
+
+    def get_context_data(self, **kwargs):
+        context = super(AnimalGroupCopyAsNewSelector, self).get_context_data(**kwargs)
+        context['form'] = forms.AnimalGroupSelectorForm(parent_id=self.object.id)
+        return context
 
 
 class AnimalGroupUpdate(AssessmentPermissionsMixin, MessageMixin, UpdateView):

--- a/project/animal/views.py
+++ b/project/animal/views.py
@@ -15,7 +15,7 @@ from utils.views import (AssessmentPermissionsMixin, BaseCreate,
                          BaseCreateWithFormset, BaseDelete, BaseDetail,
                          BaseEndpointFilterList, BaseList, BaseUpdate,
                          BaseUpdateWithFormset, GenerateReport,
-                         GenerateFixedReport, MessageMixin)
+                         GenerateFixedReport, MessageMixin, CopyAsNewSelectorMixin)
 
 from . import forms, models, exports, reports
 
@@ -33,13 +33,9 @@ class ExperimentRead(BaseDetail):
     model = models.Experiment
 
 
-class ExperimentCopyAsNewSelector(StudyRead):
-    template_name = 'animal/experiment_copy_selector.html'
-
-    def get_context_data(self, **kwargs):
-        context = super(ExperimentCopyAsNewSelector, self).get_context_data(**kwargs)
-        context['form'] = forms.ExperimentSelectorForm(parent_id=self.object.id)
-        return context
+class ExperimentCopyAsNewSelector(CopyAsNewSelectorMixin, StudyRead):
+    copy_model = models.Experiment
+    form_class = forms.ExperimentSelectorForm
 
 
 class ExperimentUpdate(BaseUpdate):
@@ -146,13 +142,9 @@ class AnimalGroupRead(BaseDetail):
     model = models.AnimalGroup
 
 
-class AnimalGroupCopyAsNewSelector(ExperimentRead):
-    template_name = 'animal/animalgroup_copy_selector.html'
-
-    def get_context_data(self, **kwargs):
-        context = super(AnimalGroupCopyAsNewSelector, self).get_context_data(**kwargs)
-        context['form'] = forms.AnimalGroupSelectorForm(parent_id=self.object.id)
-        return context
+class AnimalGroupCopyAsNewSelector(CopyAsNewSelectorMixin, ExperimentRead):
+    copy_model = models.AnimalGroup
+    form_class = forms.AnimalGroupSelectorForm
 
 
 class AnimalGroupUpdate(AssessmentPermissionsMixin, MessageMixin, UpdateView):
@@ -188,14 +180,12 @@ class AnimalGroupDelete(BaseDelete):
         return self.object.experiment.get_absolute_url()
 
 
-class EndpointCopyAsNewSelector(AnimalGroupRead):
-    # Select an existing assessed outcome as a template for a new one
-    template_name = 'animal/endpoint_copy_selector.html'
+class EndpointCopyAsNewSelector(CopyAsNewSelectorMixin, AnimalGroupRead):
+    copy_model = models.Endpoint
+    form_class = forms.EndpointSelectorForm
 
-    def get_context_data(self, **kwargs):
-        context = super(EndpointCopyAsNewSelector, self).get_context_data(**kwargs)
-        context['form'] = forms.EndpointSelectorForm(study_id=self.object.experiment.study_id)
-        return context
+    def get_related_id(self):
+        return self.object.experiment.study_id
 
 
 # Dosing Regime Views

--- a/project/epi/views.py
+++ b/project/epi/views.py
@@ -6,7 +6,8 @@ from study.models import Study
 from study.views import StudyRead
 from utils.views import (BaseCreate, BaseCreateWithFormset, BaseDetail,
                          BaseDelete, BaseEndpointFilterList, BaseUpdate,
-                         BaseList, BaseUpdateWithFormset, CloseIfSuccessMixin)
+                         BaseList, BaseUpdateWithFormset, CloseIfSuccessMixin,
+                         CopyAsNewSelectorMixin)
 
 from . import forms, exports, models
 
@@ -44,13 +45,9 @@ class StudyPopulationCreate(EnsureExtractionStartedMixin, BaseCreate):
         return kwargs
 
 
-class StudyPopulationCopyAsNewSelector(StudyRead):
-    template_name = 'epi/studypopulation_copy_selector.html'
-
-    def get_context_data(self, **kwargs):
-        context = super(StudyPopulationCopyAsNewSelector, self).get_context_data(**kwargs)
-        context['form'] = forms.StudyPopulationSelectorForm(parent_id=self.object.id)
-        return context
+class StudyPopulationCopyAsNewSelector(CopyAsNewSelectorMixin, StudyRead):
+    copy_model = models.StudyPopulation
+    form_class = forms.StudyPopulationSelectorForm
 
 
 class StudyPopulationDetail(BaseDetail):
@@ -89,13 +86,9 @@ class ExposureCreate(BaseCreate):
     form_class = forms.ExposureForm
 
 
-class ExposureCopyAsNewSelector(StudyPopulationDetail):
-    template_name = 'epi/exposure_copy_selector.html'
-
-    def get_context_data(self, **kwargs):
-        context = super(ExposureCopyAsNewSelector, self).get_context_data(**kwargs)
-        context['form'] = forms.ExposureSelectorForm(parent_id=self.object.id)
-        return context
+class ExposureCopyAsNewSelector(CopyAsNewSelectorMixin, StudyPopulationDetail):
+    copy_model = models.Exposure
+    form_class = forms.ExposureSelectorForm
 
 
 class ExposureDetail(BaseDetail):
@@ -162,13 +155,9 @@ class OutcomeCreate(BaseCreate):
         return kwargs
 
 
-class OutcomeCopyAsNewSelector(StudyPopulationDetail):
-    template_name = 'epi/outcome_copy_selector.html'
-
-    def get_context_data(self, **kwargs):
-        context = super(OutcomeCopyAsNewSelector, self).get_context_data(**kwargs)
-        context['form'] = forms.OutcomeSelectorForm(parent_id=self.object.id)
-        return context
+class OutcomeCopyAsNewSelector(CopyAsNewSelectorMixin, StudyPopulationDetail):
+    copy_model = models.Outcome
+    form_class = forms.OutcomeSelectorForm
 
 
 class OutcomeDetail(BaseDetail):
@@ -227,13 +216,9 @@ class ResultCreate(BaseCreateWithFormset):
             **self.get_formset_kwargs())
 
 
-class ResultCopyAsNewSelector(OutcomeDetail):
-    template_name = 'epi/result_copy_selector.html'
-
-    def get_context_data(self, **kwargs):
-        context = super(ResultCopyAsNewSelector, self).get_context_data(**kwargs)
-        context['form'] = forms.ResultSelectorForm(parent_id=self.object.id)
-        return context
+class ResultCopyAsNewSelector(CopyAsNewSelectorMixin, OutcomeDetail):
+    copy_model = models.Result
+    form_class = forms.ResultSelectorForm
 
 
 class ResultDetail(BaseDetail):
@@ -303,22 +288,16 @@ class ComparisonSetOutcomeCreate(ComparisonSetCreate):
     parent_template_name = 'outcome'
 
 
-class ComparisonSetStudyPopCopySelector(StudyPopulationDetail):
+class ComparisonSetStudyPopCopySelector(CopyAsNewSelectorMixin, StudyPopulationDetail):
+    copy_model = models.ComparisonSet
+    form_class = forms.ComparisonSetByStudyPopulationSelectorForm
     template_name = 'epi/comparisonset_sp_copy_selector.html'
 
-    def get_context_data(self, **kwargs):
-        context = super(ComparisonSetStudyPopCopySelector, self).get_context_data(**kwargs)
-        context['form'] = forms.ComparisonSetByStudyPopulationSelectorForm(parent_id=self.object.id)
-        return context
 
-
-class ComparisonSetOutcomeCopySelector(OutcomeDetail):
+class ComparisonSetOutcomeCopySelector(CopyAsNewSelectorMixin, OutcomeDetail):
+    copy_model = models.ComparisonSet
+    form_class = forms.ComparisonSetByOutcomeSelectorForm
     template_name = 'epi/comparisonset_outcome_copy_selector.html'
-
-    def get_context_data(self, **kwargs):
-        context = super(ComparisonSetOutcomeCopySelector, self).get_context_data(**kwargs)
-        context['form'] = forms.ComparisonSetByOutcomeSelectorForm(parent_id=self.object.id)
-        return context
 
 
 class ComparisonSetDetail(BaseDetail):

--- a/project/templates/animal/animalgroup_copy_selector.html
+++ b/project/templates/animal/animalgroup_copy_selector.html
@@ -1,0 +1,39 @@
+{% extends 'animal/experiment_detail.html' %}
+
+
+{% load add_class %}
+{% load selectable_tags %}
+
+{% block title %}
+  {{block.super}} | Copy animal group
+{% endblock title %}
+
+{% block extrastyle %}
+  {% include_ui_theme %}
+{% endblock %}
+
+{% block breadcrumbs_self %}
+    <li><a href="{{object.get_absolute_url}}">{{object}}</a><span class="divider">/</span></li>
+    <li class="active">Copy animal group<span class="divider">/</span></li>
+{% endblock breadcrumbs_self %}
+
+{% block content %}
+
+  {% include "hawc/_copy_as_new.html" with name="animal group" notes="Select an existing animal group as a template to create a new one." %}
+
+{% endblock content %}
+
+{% block extrajs %}
+  {{ form.media }}
+  <script type="text/javascript">
+    $(document).ready(function(){
+
+      new window.app.utils.HAWCUtils.InitialForm({
+        "form": $('form'),
+        "base_url": "{% url 'animal:animal_group_new' object.pk %}",
+      });
+
+    });
+  </script>
+{% endblock extrajs %}
+

--- a/project/templates/animal/experiment_copy_selector.html
+++ b/project/templates/animal/experiment_copy_selector.html
@@ -1,0 +1,39 @@
+{% extends 'study/study_detail.html' %}
+
+
+{% load add_class %}
+{% load selectable_tags %}
+
+{% block title %}
+  {{block.super}} | Copy experiment
+{% endblock title %}
+
+{% block extrastyle %}
+  {% include_ui_theme %}
+{% endblock %}
+
+{% block breadcrumbs_self %}
+    <li><a href="{{object.get_absolute_url}}">{{object}}</a><span class="divider">/</span></li>
+    <li class="active">Copy experiment<span class="divider">/</span></li>
+{% endblock breadcrumbs_self %}
+
+{% block content %}
+
+  {% include "hawc/_copy_as_new.html" with name="experiment" notes="Select an existing experiment as a template to create a new one." %}
+
+{% endblock content %}
+
+{% block extrajs %}
+  {{ form.media }}
+  <script type="text/javascript">
+    $(document).ready(function(){
+
+      new window.app.utils.HAWCUtils.InitialForm({
+        "form": $('form'),
+        "base_url": "{% url 'animal:experiment_new' object.pk %}",
+      });
+
+    });
+  </script>
+{% endblock extrajs %}
+

--- a/project/templates/animal/experiment_detail.html
+++ b/project/templates/animal/experiment_detail.html
@@ -24,6 +24,7 @@
               <li class="divider"></li>
               <li class="disabled"><a tabindex="-1" href="#">Animal Group Editing</a></li>
               <li><a href="{% url 'animal:animal_group_new' object.pk %}">Create new</a></li>
+              <li><a href="{% url 'animal:animal_group_copy_selector' object.pk %}">Copy from existing</a></li>
           </ul>
         </div>
       {% endif %}

--- a/project/templates/animal/experiment_detail.html
+++ b/project/templates/animal/experiment_detail.html
@@ -20,7 +20,6 @@
               <li class="disabled"><a tabindex="-1" href="#">Experiment Editing</a></li>
               <li><a href="{% url 'animal:experiment_update' object.pk %}">Update</a></li>
               <li><a href="{% url 'animal:experiment_delete' object.pk %}">Delete</a></li>
-              {% comment %} <!-- <li><a href="{% url 'animal:experiment_versions' object.pk %}">View prior versions</a></li> --> {% endcomment %}
               <li class="divider"></li>
               <li class="disabled"><a tabindex="-1" href="#">Animal Group Editing</a></li>
               <li><a href="{% url 'animal:animal_group_new' object.pk %}">Create new</a></li>

--- a/project/templates/study/study_detail.html
+++ b/project/templates/study/study_detail.html
@@ -30,6 +30,7 @@
               <li class="divider"></li>
               <li class="disabled"><a tabindex="-1" href="#">Animal bioassay editing</a></li>
               <li><a href="{% url 'animal:experiment_new' object.pk %}">Create new experiment</a></li>
+              <li><a href="{% url 'animal:experiment_copy_selector' object.pk %}">Copy from existing</a></li>
             {% endif %}
 
             {% if object.in_vitro %}

--- a/project/utils/views.py
+++ b/project/utils/views.py
@@ -243,6 +243,32 @@ class CanCreateMixin(object):
             raise PermissionDenied
 
 
+class CopyAsNewSelectorMixin(object):
+    form_class = None  # required
+    copy_model = None  # required
+    template_name_suffix = '_copy_selector'
+
+    def get_related_id(self):
+        return self.object.id
+
+    def get_context_data(self, **kwargs):
+        context = super(CopyAsNewSelectorMixin, self).get_context_data(**kwargs)
+        related_id = self.get_related_id()
+        context['form'] = self.form_class(parent_id=related_id)
+        return context
+
+    def get_template_names(self):
+        if hasattr(self, 'template_name'):
+            name = self.template_name
+        else:
+            name = '%s/%s%s.html' % (
+                self.copy_model._meta.app_label,
+                self.copy_model._meta.object_name.lower(),
+                self.template_name_suffix
+            )
+        return [name]
+
+
 # Base HAWC views
 class BaseDetail(AssessmentPermissionsMixin, DetailView):
     crud = 'Read'

--- a/project/utils/views.py
+++ b/project/utils/views.py
@@ -258,7 +258,7 @@ class CopyAsNewSelectorMixin(object):
         return context
 
     def get_template_names(self):
-        if hasattr(self, 'template_name'):
+        if self.template_name is not None:
             name = self.template_name
         else:
             name = '%s/%s%s.html' % (


### PR DESCRIPTION
Added copy as new for animal experiment and animal-group models, per trello card: https://trello.com/c/S4jXMPVY/540-copy-as-new-animal-experiment-and-animal-groups.

Also created a view mixin and applied for all standard copy as new models; investigated implementing for data-pivot and search but determined that they have custom implementations that are too different for this generic mixin.