### PR TITLE
add epimeta copy_across_assessments

### DIFF
--- a/project/epimeta/models.py
+++ b/project/epimeta/models.py
@@ -475,12 +475,8 @@ class SingleResult(models.Model):
     def copy_across_assessments(self, cw):
         old_id = self.id
         self.id = None
-        # meta_result might not be in the study getting copied
-        try:
-            self.meta_result_id = cw[MetaResult.COPY_NAME][self.meta_result_id]
-        except KeyError:
-            pass
-        # instance might not be in study being copied.
+        self.meta_result_id = cw[MetaResult.COPY_NAME][self.meta_result_id]
+        # instance.study might not be in studies being copied.
         try:
             self.study_id = cw[Study.COPY_NAME][self.study_id]
         except KeyError:

--- a/project/epimeta/models.py
+++ b/project/epimeta/models.py
@@ -476,11 +476,7 @@ class SingleResult(models.Model):
         old_id = self.id
         self.id = None
         self.meta_result_id = cw[MetaResult.COPY_NAME][self.meta_result_id]
-        # instance.study might not be in studies being copied.
-        try:
-            self.study_id = cw[Study.COPY_NAME][self.study_id]
-        except KeyError:
-            pass
+        self.study_id = cw[Study.COPY_NAME][self.study_id]
         self.save()
         cw[self.COPY_NAME][old_id] = self.id
 

--- a/project/study/forms.py
+++ b/project/study/forms.py
@@ -135,7 +135,7 @@ class StudiesCopy(forms.Form):
         self.fields['assessment'].queryset = self.fields['assessment']\
             .queryset.model.objects.get_editable_assessments(user, assessment.id)
         self.fields['studies'].queryset = self.fields['studies']\
-            .queryset.filter(assessment_id=assessment.id, epi_meta=False)
+            .queryset.filter(assessment_id=assessment.id)
         self.helper = self.setHelper(assessment)
 
     def setHelper(self, assessment):

--- a/project/study/forms.py
+++ b/project/study/forms.py
@@ -113,8 +113,6 @@ class AttachmentForm(forms.ModelForm):
 
 
 class StudiesCopy(forms.Form):
-    # TODO: remove study-type restriction
-
     HELP_TEXT = """
     Clone multiple studies and move from one assessment to  another assessment.
     Clones are complete and include most nested data.  Cloned studies do not

--- a/project/study/models.py
+++ b/project/study/models.py
@@ -5,6 +5,7 @@ import collections
 import itertools
 
 from django.db import models, transaction
+from django.db.models import Q
 from django.apps import apps
 from django.core.exceptions import (ValidationError, ObjectDoesNotExist,
                                     MultipleObjectsReturned)
@@ -162,6 +163,20 @@ class Study(Reference):
 
             for child in children:
                 child.copy_across_assessments(cw)
+
+        # epi-meta single_results contain cross-study data, so we need to finish
+        # copying studies before copying single results.
+
+        # Not all meta_result.single_results belong to the same study as meta_results,
+        # so single_results belonging to both the study and the study's meta_results
+        # need to be copied
+        if studies[0].epi_meta:
+            logging.info('Copying epi results')
+            SingleResult = apps.get_model('epimeta', 'SingleResult')
+            results = SingleResult.objects.filter(Q(study__assessment=source_assessment) | Q(meta_result__protocol__study__assessment=source_assessment))
+            print(len(results))
+            for result in results:
+                result.copy_across_assessments(cw)
 
         return cw
 

--- a/project/study/models.py
+++ b/project/study/models.py
@@ -166,18 +166,12 @@ class Study(Reference):
 
         # epi-meta single_results contain cross-study data, so we need to finish
         # copying studies before copying single results.
-
-        # Not all meta_result.single_results belong to the same study as meta_results,
-        # so single_results belonging to both the study and the study's meta_results
-        # need to be copied
         if studies[0].epi_meta:
             logging.info('Copying epi results')
             SingleResult = apps.get_model('epimeta', 'SingleResult')
-            results = SingleResult.objects.filter(Q(study__assessment=source_assessment) | Q(meta_result__protocol__study__assessment=source_assessment))
-            print(len(results))
+            results = SingleResult.objects.filter(meta_result__protocol__study__in=studies)
             for result in results:
                 result.copy_across_assessments(cw)
-
         return cw
 
     def _copy_across_assessment(self, cw):


### PR DESCRIPTION
Closes https://trello.com/c/AZxPhUKD/572-complete-epi-meta-copy-across-assessments

Adds epimeta `copy_across_assessments` ability.

The meta-ness of the data makes the process different from the rest of the studies. The MetaResult has many SingleResults, which link to other studies. The SingleResult.study might not be in the current assessment, so we have to go through SingleResults of all the assessment's Study.MetaProtocol.MetaResults, as well as the SingleResults that link directly to the assessment's Studies.

 If the `single_result.study` is being copied over, then it's in the `cw` crosswalk dict and the new id is assigned, otherwise it's not in the crosswalk dict and stays the same. Same with the `single_result.meta_result`.