### PR TITLE
Remove old required environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ project/hawc/settings/local.py
 project/static/css/hawc_d3_aggregated.css
 docs/build/*
 project/celerybeat*
+venv/
 
 public/static/
 public/media/

--- a/docs/source/dev_setup.rst
+++ b/docs/source/dev_setup.rst
@@ -5,15 +5,18 @@ Below you will find basic setup and deployment instructions for the Health
 Assessment Workspace Collaborative project.  To begin you should have the
 following applications installed on your local development system:
 
-- Python 2.7
-- `Node.js >= 4.0 <https://nodejs.org/>`_
-- `Npm.js >= 3.0 <https://npmjs.org/>`_
-- `pip >= 8.1 <http://www.pip-installer.org/>`_
-- `virtualenv >= 1.9 <http://www.virtualenv.org/>`_
-- `virtualenvwrapper >= 3.5 <http://pypi.python.org/pypi/virtualenvwrapper>`_ (mac/linux)
-- `virtualenvwrapper-win >= 1.2.1 <https://pypi.python.org/pypi/virtualenvwrapper-win>`_. (windows)
-- Postgres >= 9.3
-- git >= 1.7
+- `Git`_
+- `Node.js`_
+- `Yarn`_
+- `PostgreSQL`_ ≥ 9.4 (uses `JSONB`_)
+- `Python`_ 2.7 (not Python 3... yet)
+
+.. _`Git`: https://git-scm.com/
+.. _`Python`: https://www.python.org/
+.. _`Node.js`: https://nodejs.org
+.. _`Yarn`: https://yarnpkg.com/
+.. _`PostgreSQL`: https://www.postgresql.org/
+.. _`JSONB`: https://www.postgresql.org/docs/current/static/datatype-json.html
 
 
 .. warning::
@@ -35,81 +38,98 @@ own adventure below.
 Mac/Linux
 ~~~~~~~~~
 
-To setup your local environment you should create a virtualenv and install the
-necessary requirements::
+.. code-block:: bash
 
-    mkvirtualenv hawc
+    # clone repository; we'll put in ~/dev but you can put anywhere
+    mkdir -p ~/dev
+    cd ~/dev
     git clone https://github.com/shapiromatron/hawc.git
-    cd hawc
+
+    # create virtual environment and install requirements
+    cd ~/dev/hawc
+    python -m venv venv
+    source ./venv/bin/activate
     $VIRTUAL_ENV/bin/pip install -r ./requirements/dev.txt
 
-Create a local settings file and update the necessary fields within the settings::
-
+    # create a local settings file
     cp ./project/hawc/settings/local.example.py ./project/hawc/settings/local.py
 
+Update the settings file with any changes you'd like to make for your local
+development environment.
 
 Windows
-~~~~~~~~~
+~~~~~~~
 
 To setup your local environment you should create a virtualenv and install the
-necessary requirements::
+necessary requirements:
 
-    mkvirtualenv hawc
+.. code-block:: batch
+
+    :: clone repository; we'll put in ~/dev but you can put anywhere
+    mkdir ~/dev
+    cd ~/dev
     git clone https://github.com/shapiromatron/hawc.git
 
-To install python packages, ensure you have the Python C++ compiler, available
-from `Microsoft <https://www.microsoft.com/en-us/download/details.aspx?id=44266>`_. Also
-ensure that your version of pip allows for installation of wheels (v8 or higher).
-Install numpy and scipy using precompiled binaries, available for download from
-`Christoph Gohlke <http://www.lfd.uci.edu/~gohlke/pythonlibs/>`_ (they're difficult to build on Windows),
-by using these commands (adapted to the filename/location on your computer)::
+    :: create virtual environment and install requirements
+    cd ~/dev/hawc
+    python -m venv venv
+    call ./venv/bin/activate.bat
+    $VIRTUAL_ENV/bin/pip install -r ./requirements/dev.txt
+
+    :: create a local settings file
+    copy ./project/hawc/settings/local.example.py ./project/hawc/settings/local.py
+
+The ``pip install`` call may fail with some packages on Windows if you don't have
+the `Python Microsoft C++ compiler`_ available. You can use prepackaged
+binaries available from `Christoph Gohlke`_ using these commands after
+downloading the wheels from the website:
+
+.. _`Python Microsoft C++ compiler`: https://www.microsoft.com/en-us/download/details.aspx?id=44266
+.. _`Christoph Gohlke`: http://www.lfd.uci.edu/~gohlke/pythonlibs/
+
+.. code-block:: batch
 
     pip install "C:\Users\username\Desktop\numpy-version.whl"
     pip install "C:\Users\username\Desktop\scipy-version.whl"
 
-Then, you should be able to install remaining packages via pip::
-
-    cd hawc
-    pip install -r requirements/windows/dev.txt
-
-Create a local settings file and update the necessary fields within the settings::
-
-    copy project\hawc\settings\local.example.py project\hawc\settings\local.py
-
+Update the settings file with any changes you'd like to make for your local
+development environment.
 
 HAWC setup: Part II
 -------------------
 
-start the virtual environment::
+You'll need to run both the python webserver and the node webserver to develop
+HAWC; here are instructions how how to do both.
 
-    deactivate
-    workon hawc
+To run the python webserver:
 
-Create a PostgreSQL database and run the initial syncdb/migrate::
+.. code-block:: bash
 
+    # create a PostgreSQL database
     createdb -E UTF-8 hawc
 
-Next, we'll run a few management command and apply migrations::
-
-    cd project
+    # active python virtual environment and sync database schema with code
+    cd ~/dev/hawc/project
+    source ../venv/bin/activate
     python manage.py build_d3_styles
     python manage.py migrate
     python manage.py createcachetable
 
-You should now be able to run the python backend development server::
+    # run development webserver
+    python manage.py runserver
 
-    cd ./project && python manage.py runserver
+In a new terminal, run the node development webserver for javascript:
 
-Next, you'll need to setup the front-end web bundler. Make sure the ``npm``
-command is accessible from your virtual environment. In the ``/project`` path,
-run the following command, which will install all javascript packages for our
-development environment::
+.. code-block:: bash
 
-    cd ./project && npm install --save-dev
+    # navigate to project folder
+    cd ~/dev/hawc/project
 
-After installing dependencies, run the javascript bundler in a second terminal::
+    # install javascript dependencies
+    yarn install
 
-    cd ./project && npm start
+    # start node hot-reloading server
+    npm start
 
 If you navigate to `localhost`_ and see a website, you're ready to begin coding!
 
@@ -128,11 +148,12 @@ You can modify the tmux environment by creating a local copy::
 
     cp bin/dev.sh bin/dev.local.sh
 
+.. _`tmux`: https://tmux.github.io/
 
 Importing a database export:
 ----------------------------
 
-To load a database export from the `assessment_db_dump` management command,
+To load a database export from the ``assessment_db_dump`` management command,
 use the following arguments, if Postgres is available from the command-line::
 
     dropdb hawc         # if database already exists

--- a/docs/source/dev_setup.rst
+++ b/docs/source/dev_setup.rst
@@ -47,18 +47,6 @@ Create a local settings file and update the necessary fields within the settings
 
     cp ./project/hawc/settings/local.example.py ./project/hawc/settings/local.py
 
-Next, update your virtual-environment settings in ``$VIRTUAL_ENV/bin/postactivate``::
-
-    #!/bin/sh
-    # This hook is sourced after this virtualenv is activated.
-
-    # django environment-variable settings
-    export "DJANGO_SETTINGS_MODULE=hawc.settings.local"
-    export "DJANGO_STATIC_ROOT=$HOME/dev/temp/hawc/static"
-    export "DJANGO_MEDIA_ROOT=$HOME/dev/temp/hawc/media"
-
-    # move to root HAWC path (wherever that is one your computer)
-    cd $HOME/dev/hawc
 
 Windows
 ~~~~~~~~~
@@ -88,16 +76,6 @@ Create a local settings file and update the necessary fields within the settings
 
     copy project\hawc\settings\local.example.py project\hawc\settings\local.py
 
-Next, add these values to the bottom of the ``activate.bat`` file, which should be
-located in ``%VIRTUAL_ENV%\Scripts\activate.bat``::
-
-    :: django environment-variable settings
-    set "DJANGO_SETTINGS_MODULE=hawc.settings.local"
-    set "DJANGO_STATIC_ROOT=%USERPROFILE%\dev\temp\hawc\static"
-    set "DJANGO_MEDIA_ROOT=$HOME\dev\temp\hawc\media"
-
-    :: move to project path (change to correct path)
-    cd %USERPROFILE%\dev\hawc\project"
 
 HAWC setup: Part II
 -------------------

--- a/docs/source/server_setup.rst
+++ b/docs/source/server_setup.rst
@@ -33,10 +33,9 @@ Required environment variables
 ------------------------------
 
 The following environment variables will need to be set when running HAWC in
-production;
-For linux, you can update your virtual-environment settings in ``$VIRTUAL_ENV/bin/postactivate``::
-For Windows, you can update these values in ``activate.bat`` file, which should be
-located in ``%VIRTUAL_ENV%\Scripts\activate.bat``::
+production.
+ - For linux, you can set these values in ``$VIRTUAL_ENV/bin/postactivate``.
+ - For Windows, you can set these values in ``activate.bat``, which should be located at ``%VIRTUAL_ENV%\Scripts\activate.bat``.
 
 
 Example values are shown for each:

--- a/docs/source/server_setup.rst
+++ b/docs/source/server_setup.rst
@@ -33,14 +33,19 @@ Required environment variables
 ------------------------------
 
 The following environment variables will need to be set when running HAWC in
-production; example values are shown for each:
+production;
+For linux, you can update your virtual-environment settings in ``$VIRTUAL_ENV/bin/postactivate``::
+For Windows, you can update these values in ``activate.bat`` file, which should be
+located in ``%VIRTUAL_ENV%\Scripts\activate.bat``::
+
+
+Example values are shown for each:
 
 .. code-block:: bash
 
     #!/bin/bash
 
     # hawc settings
-    export "DJANGO_SETTINGS_MODULE=hawc.settings.production"
     export "DJANGO_ADMIN_NAMES=Johnny Appleseed|Tommy Appleseed"
     export "DJANGO_ADMIN_EMAILS=johnny@appleseed.com|tommy@appleseed.com"
     export "DJANGO_ALLOWED_HOSTS=hawc.mydomain.org|hawc.mydomain.com"
@@ -61,8 +66,6 @@ production; example values are shown for each:
     export "DJANGO_CACHE_SOCK=127.0.0.1:6379:1"
 
     # filesystem settings
-    export "DJANGO_MEDIA_ROOT=/path/to/public/media"
-    export "DJANGO_STATIC_ROOT=/path/to/public/static"
     export "DJANGO_STATIC_DIRS=/path/to/hawc/project/static|/path/to/venv/lib/python2.7/site-packages/django/contrib/admin/static"
     export "LOGS_PATH=/path/to/logs/hawc"
     export "PHANTOMJS_PATH=/path/to/phantomjs"

--- a/docs/source/server_setup.rst
+++ b/docs/source/server_setup.rst
@@ -34,7 +34,7 @@ Required environment variables
 
 The following environment variables will need to be set when running HAWC in
 production.
- - For linux, you can set these values in ``$VIRTUAL_ENV/bin/postactivate``.
+ - For linux, you can set these values in ``$VIRTUAL_ENV/bin/activate``.
  - For Windows, you can set these values in ``activate.bat``, which should be located at ``%VIRTUAL_ENV%\Scripts\activate.bat``.
 
 

--- a/project/hawc/celery.py
+++ b/project/hawc/celery.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import
 
+import os
 from celery import Celery
 from celery.utils.log import get_task_logger
 
 from django.conf import settings
 
 
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'hawc.settings.local')
 logger = get_task_logger(__name__)
 app = Celery('hawc')
 

--- a/project/hawc/settings/base.py
+++ b/project/hawc/settings/base.py
@@ -163,7 +163,7 @@ LOGIN_REDIRECT_URL = reverse_lazy('portal')
 
 # Static files
 STATIC_URL = '/static/'
-STATIC_ROOT = os.getenv('DJANGO_STATIC_ROOT')
+STATIC_ROOT = os.path.join(PROJECT_ROOT, 'public', 'static')
 STATICFILES_DIRS = os.getenv('DJANGO_STATIC_DIRS', '').split('|')
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
@@ -172,7 +172,7 @@ STATICFILES_FINDERS = (
 
 # Media files
 MEDIA_URL = '/media/'
-MEDIA_ROOT = os.getenv('DJANGO_MEDIA_ROOT')
+MEDIA_ROOT = os.path.join(PROJECT_ROOT, 'public', 'media')
 
 
 # Filesystem settings

--- a/project/hawc/wsgi.py
+++ b/project/hawc/wsgi.py
@@ -1,6 +1,6 @@
 import os
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'hawc.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'hawc.settings.local')
 os.environ['LC_ALL'] = 'en_US.UTF-8'
 
 from django.core.wsgi import get_wsgi_application  # noqa

--- a/project/manage.py
+++ b/project/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "hawc.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "hawc.settings.local")
 
     from django.core.management import execute_from_command_line
 


### PR DESCRIPTION
Closes https://trello.com/c/rMXB0PuT/575-remove-old-required-environment-variables-for-hawc
I cloned this to a new folder and setup a new virtualenv to test out.

Removes old environment variables from hawc/settings/  and docs, and moves notes about adding env vars from dev_setup to server_setup in docs.