### PR TITLE
Refactor assessment_db_dump for multiple assessments

### DIFF
--- a/project/assessment/management/commands/assessment_db_dump.py
+++ b/project/assessment/management/commands/assessment_db_dump.py
@@ -135,10 +135,12 @@ class Command(UnicodeCommand):
 
             self.stdout.write("\n--- TABLE {}\n".format(db_table))
             qs = None
-            if hasattr(model, 'assessment_qs'):
-                qs = model.assessment_qs(assessment_id)
+            if hasattr(model.objects, 'assessment_qs'):
+                qs = model.objects.assessment_qs(assessment_id)
             elif external_exports.lookup(db_table):
                 qs = external_exports.lookup(db_table)(model, assessment_id)
+            else:
+                print(f'--- {model} not exported\n')
 
             if qs is not None:
 

--- a/project/assessment/management/commands/assessment_db_dump.py
+++ b/project/assessment/management/commands/assessment_db_dump.py
@@ -106,6 +106,7 @@ class BaseHawcDataExports(ExternalLibraryExports):
     def myuser_userprofile(self, cls, ids):
         return self.join_querysets_distinct(cls, ids)
 
+
 class Command(UnicodeCommand):
     help = HELP_TEXT
 
@@ -205,6 +206,8 @@ class Command(UnicodeCommand):
             qs = None
             if hasattr(model.objects, 'assessment_qs'):
                 qs = model.objects.assessment_qs(assessment_id)
+            elif hasattr(model, 'assessment_qs'):
+                qs = model.assessment_qs(assessment_id)
             else:
                 print(f'--- {model} not exported\n')
 

--- a/project/assessment/management/commands/assessment_db_dump.py
+++ b/project/assessment/management/commands/assessment_db_dump.py
@@ -166,9 +166,9 @@ class Command(UnicodeCommand):
             self.write_m2m_data(m2m, qs)
 
     def write_base_data(self):
-        '''
-            Exports data that would be duplicated when exporting multiple assessments
-        '''
+        """
+        Exports data that would be duplicated when exporting multiple assessments
+        """
         models = apps.get_models()
         base_exports = BaseHawcDataExports()
         self.stdout.write('--- HAWC BASE DATA\n')

--- a/project/assessment/managers.py
+++ b/project/assessment/managers.py
@@ -112,3 +112,7 @@ class EffectTagManager(BaseManager):
 
 class BaseEndpointManager(BaseManager):
     assessment_relation = 'assessment'
+
+
+class TimeSpentEditingManager(BaseManager):
+    assessment_relation = 'assessment'

--- a/project/assessment/models.py
+++ b/project/assessment/models.py
@@ -385,6 +385,8 @@ class BaseEndpoint(models.Model):
 
 
 class TimeSpentEditing(models.Model):
+    objects = managers.TimeSpentEditingManager()
+    
     seconds = models.FloatField(
         validators=(MinValueValidator, ))
     assessment = models.ForeignKey(

--- a/project/bmd/managers.py
+++ b/project/bmd/managers.py
@@ -1,0 +1,20 @@
+from utils.models import BaseManager
+
+
+class AssessmentSettingsManager(BaseManager):
+    assessment_relation = 'assessment'
+
+
+class LogicFieldManager(BaseManager):
+    assessment_relation = 'assessment'
+
+
+class SessionManager(BaseManager):
+    assessment_relation = 'endpoint__assessment'
+
+
+class ModelManager(BaseManager):
+    assessment_relation = 'session__endpoint__assessment'
+
+class SelectedModelManager(BaseManager):
+    assessment_relation = 'endpoint__assessment'

--- a/project/bmd/models.py
+++ b/project/bmd/models.py
@@ -10,6 +10,7 @@ from django.core.urlresolvers import reverse_lazy
 from django.utils.timezone import now
 
 from utils.models import get_crumbs
+from . import managers
 
 import bmds
 
@@ -24,6 +25,8 @@ BMDS_CHOICES = (
 
 
 class AssessmentSettings(models.Model):
+    objects = managers.AssessmentSettingsManager()
+
     assessment = models.OneToOneField(
         'assessment.Assessment',
         related_name='bmd_settings')
@@ -55,6 +58,7 @@ class AssessmentSettings(models.Model):
 
 
 class LogicField(models.Model):
+    objects = managers.LogicFieldManager()
 
     LOGIC_BIN_CHOICES = (
         (0, 'Warning (no change)'),
@@ -130,6 +134,8 @@ class LogicField(models.Model):
 
 
 class Session(models.Model):
+    objects = managers.SessionManager()
+
     endpoint = models.ForeignKey(
         'animal.Endpoint',
         related_name='bmd_sessions')
@@ -282,6 +288,7 @@ class Session(models.Model):
 
 
 class Model(models.Model):
+    objects = managers.ModelManager()
 
     IMAGE_UPLOAD_TO = 'bmds_plot'
 
@@ -339,6 +346,8 @@ class Model(models.Model):
 
 
 class SelectedModel(models.Model):
+    objects = managers.SelectedModelManager()
+
     endpoint = models.OneToOneField(
         'animal.Endpoint',
         related_name='bmd_model')

--- a/project/epi/managers.py
+++ b/project/epi/managers.py
@@ -92,4 +92,4 @@ class ResultManager(BaseManager):
 
 
 class GroupResultManager(BaseManager):
-    assessment_relation = 'results__outcome__assessment'
+    assessment_relation = 'result__outcome__assessment'

--- a/project/epi/models.py
+++ b/project/epi/models.py
@@ -67,6 +67,8 @@ class Country(models.Model):
 
 
 class AdjustmentFactor(models.Model):
+    objects = managers.AdjustmentFactorManager()
+    
     assessment = models.ForeignKey(
         'assessment.Assessment')
     description = models.TextField()

--- a/project/lit/managers.py
+++ b/project/lit/managers.py
@@ -421,3 +421,7 @@ class ReferenceManager(BaseManager):
             # add all identifiers and searches
             ref.identifiers.add(*idents)
             ref.searches.add(search)
+
+
+class ReferenceTagsManager(BaseManager):
+    assessment_relation = 'content_object__assessment'

--- a/project/lit/models.py
+++ b/project/lit/models.py
@@ -558,6 +558,7 @@ class ReferenceFilterTag(NonUniqueTagBase, AssessmentRootMixin, MP_Node):
 
 
 class ReferenceTags(ItemBase):
+    objects = managers.ReferenceTagsManager()
     # required to be copied when overridden tag object. See GitHub bug report:
     # https://github.com/alex/django-taggit/issues/101
     # copied directly and unchanged from "TaggedItemBase"
@@ -573,10 +574,6 @@ class ReferenceTags(ItemBase):
         return cls.tag_model().objects.filter(**{
             '%s__content_object__isnull' % cls.tag_relname(): False
         }).distinct()
-
-    @classmethod
-    def assessment_qs(cls, assessment_id):
-        return cls.objects.filter(content_object__assessment=assessment_id)
 
 
 class Reference(models.Model):

--- a/project/myuser/managers.py
+++ b/project/myuser/managers.py
@@ -1,0 +1,82 @@
+from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin, BaseUserManager
+from django.db import models
+from django.utils import timezone
+
+from utils.models import BaseManager
+
+
+class UserProfileManager(BaseManager):
+
+    def assessment_qs(self, assessment_id):
+        return self.filter(
+                models.Q(user__assessment_pms=assessment_id) |
+                models.Q(user__assessment_teams=assessment_id) |
+                models.Q(user__assessment_reviewers=assessment_id)
+            ).distinct()
+
+class HAWCMgr(BaseUserManager):
+    # from https://docs.djangoproject.com/en/1.5/topics/auth/customizing/
+    # also from UserManager(BaseUserManager)
+
+    def create_user(self, email, password=None, **extra_fields):
+        if not email:
+            raise ValueError('Users must have an email address')
+        if not password:
+            raise ValueError('Users must have an password')
+
+        now = timezone.now()
+        user = self.model(email=self.normalize_email(email),
+                          is_staff=False, is_active=True, is_superuser=False,
+                          last_login=now, date_joined=now, **extra_fields)
+
+        user.set_password(password)
+        user.save()
+        return user
+
+    def create_superuser(self, email, password=None, **extra_fields):
+        u = self.create_user(email, password, **extra_fields)
+        u.is_staff = True
+        u.is_active = True
+        u.is_superuser = True
+        u.save()
+        return u
+
+    def create_user_batch(self, email, first_name, last_name,
+                         pms=False, tms=False, rvs=False,
+                         welcome_email=False):
+        """
+        Create a HAWC user, assign to assessments, and optionally send a welcome-email.
+        Used for batch-creation of multiple users by administrators.
+
+        Assessment-are a list of assessment-ids or False if none are added.
+
+        Example method call:
+
+            create_hawc_user("hikingfan@gmail.com", "George", "Washington",
+                             pms=[1,2,3] tms=False, rvs=False,
+                             welcome_email=True)
+        """
+        user = self.create_user(
+            email=email,
+            password=self.make_random_password(),
+            first_name=first_name,
+            last_name=last_name)
+
+        if pms:
+            user.assessment_pms.add(*pms)
+
+        if tms:
+            user.assessment_teams.add(*tms)
+
+        if rvs:
+            user.assessment_reviewers.add(*rvs)
+
+        if welcome_email:
+            user.send_welcome_email()
+
+    def assessment_qs(self, assessment_id):
+        return self.filter(
+                models.Q(assessment_pms=assessment_id) |
+                models.Q(assessment_teams=assessment_id) |
+                models.Q(assessment_reviewers=assessment_id)
+            ).distinct()

--- a/project/riskofbias/models.py
+++ b/project/riskofbias/models.py
@@ -462,7 +462,7 @@ class RiskOfBiasScore(models.Model):
 
 
 class RiskOfBiasAssessment(models.Model):
-    objects = managers.RiskOfBiasScoreManager()
+    objects = managers.RiskOfBiasAssessmentManager()
 
     assessment = models.OneToOneField(
         Assessment,

--- a/project/study/models.py
+++ b/project/study/models.py
@@ -349,6 +349,8 @@ class Study(Reference):
 
 
 class Attachment(models.Model):
+    objects = managers.AttachmentManager()
+    
     study = models.ForeignKey(Study, related_name="attachments")
     attachment = models.FileField(upload_to="study-attachment")
 

--- a/project/summary/managers.py
+++ b/project/summary/managers.py
@@ -1,5 +1,16 @@
 from django.apps import apps
+from treebeard.mp_tree import MP_NodeQuerySet
 from utils.models import BaseManager
+
+
+class SummaryTextManager(BaseManager):
+    assessment_relation = 'assessment'
+
+    """Custom manager for nodes in a Materialized Path tree."""
+
+    def get_queryset(self):
+        """Sets the custom queryset as the default."""
+        return MP_NodeQuerySet(self.model).order_by('path')
 
 
 class VisualManager(BaseManager):

--- a/project/summary/managers.py
+++ b/project/summary/managers.py
@@ -20,3 +20,11 @@ class DataPivotManager(BaseManager):
         return self.filter(assessment__in=assessment_ids)\
             .select_related('assessment')\
             .order_by('assessment__name', 'title')
+
+
+class DataPivotUploadManager(BaseManager):
+    assessment_relation = 'assessment'
+
+
+class DataPivotQueryManager(BaseManager):
+    assessment_relation = 'assessment'

--- a/project/summary/models.py
+++ b/project/summary/models.py
@@ -42,6 +42,8 @@ STUDY_TYPE_CHOICES = (
 
 
 class SummaryText(MP_Node):
+    objects = managers.SummaryTextManager()
+
     assessment = models.ForeignKey(Assessment)
     title = models.CharField(max_length=128)
     slug = models.SlugField(verbose_name="URL Name",

--- a/project/summary/models.py
+++ b/project/summary/models.py
@@ -419,6 +419,8 @@ class DataPivot(models.Model):
 
 
 class DataPivotUpload(DataPivot):
+    objects = managers.DataPivotUploadManager()
+
     file = models.FileField(
         upload_to='data_pivot',
         help_text="The data should be in unicode-text format, tab delimited "
@@ -436,6 +438,7 @@ class DataPivotUpload(DataPivot):
 
 
 class DataPivotQuery(DataPivot):
+    objects = managers.DataPivotQueryManager()
 
     MAXIMUM_QUERYSET_COUNT = 500
 

--- a/project/utils/models.py
+++ b/project/utils/models.py
@@ -113,13 +113,18 @@ class AssessmentRootMixin(object):
             return cls.create_root(assessment_id)
 
     @classmethod
-    def get_assessment_qs(cls, assessment_id):
-        # return queryset, excluding root
-        return cls.get_assessment_root(assessment_id).get_descendants()
+    def get_assessment_qs(cls, assessment_id, include_root=False):
+        root = cls.get_assessment_root(assessment_id)
+        if include_root:
+            return cls.get_tree(root)
+        return root.get_descendants()
 
     @classmethod
     def assessment_qs(cls, assessment_id):
-        ids = cls.get_assessment_qs(assessment_id).values_list('id', flat=True)
+        include_root = False
+        if issubclass(cls, AssessmentRootMixin):
+            include_root = True
+        ids = cls.get_assessment_qs(assessment_id, include_root).order_by('depth').values_list('id', flat=True)
         ids = list(ids)  # force evaluation
         return cls.objects.filter(id__in=ids)
 


### PR DESCRIPTION
Enables https://trello.com/c/wpoRQefX/612-hawc-data-import-and-export

### Refactors
 - `assessment_db_dump` to allow multiple assessment ids for export https://github.com/shapiromatron/hawc/pull/70/commits/d5853a64cead898da1fd32969b82612795dc80d3#diff-b05ec24c7255d4c7f62e435d7c5b41bfR269
### Adds
 - BaseHawcDataExports class https://github.com/shapiromatron/hawc/pull/70/commits/d5853a64cead898da1fd32969b82612795dc80d3#diff-b05ec24c7255d4c7f62e435d7c5b41bfR82 and write_base_data() https://github.com/shapiromatron/hawc/pull/70/commits/d5853a64cead898da1fd32969b82612795dc80d3#diff-b05ec24c7255d4c7f62e435d7c5b41bfR167 for exporting data that would be duplicated across assessments
 - multiple model managers
 - `include_root` option in AssessmentRootMixin.get_assessment_qs for including the root node in treebeard exports https://github.com/shapiromatron/hawc/pull/70/files#diff-89ae389dd2800c9bfb96666cba1b52e7
