### PR TITLE
update django to 1.11, django-selectable to most recent commit

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,12 +1,12 @@
 # web application
-Django==1.10.7
+Django==1.11.4
 django-crispy-forms==1.6.1
 django-filter==1.0.4
 django-redis==4.8.0
 django-markdown-deux==1.0.5
 django-pagedown==0.1.3
 django-reversion==2.0.8
-django-selectable==1.0.0
+-e git://github.com/mlavin/django-selectable.git@66ed38326cbd8ffa611c9648f58343a899cc1e41#egg=django-selectable
 django-taggit==0.22.1
 django-treebeard==4.1.1
 django-webpack-loader==0.5.0


### PR DESCRIPTION
### Updates
 - Django to 1.11.4
 - django-selectable to the latest commit: https://github.com/mlavin/django-selectable/commit/66ed38326cbd8ffa611c9648f58343a899cc1e41. I checked the different selectable widgets we're using, and they all work with Django 1.11.4. Based on discussion in https://github.com/mlavin/django-selectable/issues/187, more work is needed before a new release with proper support is finished, so we'll need to check on progress periodically.