### PR TITLE
use 'ISO-8859-1' encoding to parse svg for download

### DIFF
--- a/project/utils/svg.py
+++ b/project/utils/svg.py
@@ -88,7 +88,7 @@ class SVGConverter(object):
             .replace('%u', '\\u')\
             .encode()\
             .decode('unicode-escape')
-        self.svg = parse.unquote(svg)
+        self.svg = parse.unquote(svg, encoding='ISO-8859-1')
 
     def to_svg(self):
         svg = self.svg


### PR DESCRIPTION
Closes https://trello.com/c/TLPHRJJf/631-investigate-visualization-download-character-encoding

The urllib parser isn't intended to decode characters not used in a URL, so it can't handle utf-8 encoded characters that aren't basic ASCII characters. Using ISO-8859-1 encoding lets the parser handle more characters.