### PR TITLE
Anymail

### DIFF
--- a/docs/source/server_setup.rst
+++ b/docs/source/server_setup.rst
@@ -54,15 +54,15 @@ please specify in the docker-compose `.env` file (example secrets below):
     PHANTOMJS_PATH=/usr/local/bin/phantomjs
     PUBMED_EMAIL=myEmail@email.com
 
-    # email - to use SMTP
+    # email (use these settings if using SMTP)
     DJANGO_EMAIL_BACKEND=SMTP
-    EMAIL_HOST = smtpHost
-    EMAIL_HOST_USER = smtpHostUsername
-    EMAIL_HOST_PASSWORD = smtpHostPassword
-    EMAIL_PORT = smtpPortNumber
-    EMAIL_USE_SSL = [True or False]
+    EMAIL_HOST=smtpHost
+    EMAIL_HOST_USER=smtpHostUsername
+    EMAIL_HOST_PASSWORD=smtpHostPassword
+    EMAIL_PORT=smtpPortNumber
+    EMAIL_USE_SSL=[True or False]
 
-    # email - to use mailgun
+    # email (use these settings if using mailgun)
     DJANGO_EMAIL_BACKEND=MAILGUN
     MAILGUN_ACCESS_KEY=myMailgunAccessKey
     MAILGUN_SERVER_NAME=myMailgunServerName

--- a/docs/source/server_setup.rst
+++ b/docs/source/server_setup.rst
@@ -50,17 +50,22 @@ please specify in the docker-compose `.env` file (example secrets below):
     DJANGO_CACHE_LOCATION=redis://redis:6379/0
     DJANGO_BROKER_URL=redis://redis:6379/1
     DJANGO_CELERY_RESULT_BACKEND=redis://redis:6379/2
-    DJANGO_EMAIL_BACKEND=[SMTP or MAILGUN]
+    CHEMSPIDER_TOKEN=myChemspiderToken
+    PHANTOMJS_PATH=/usr/local/bin/phantomjs
+    PUBMED_EMAIL=myEmail@email.com
+
+    # email - to use SMTP
+    DJANGO_EMAIL_BACKEND=SMTP
     EMAIL_HOST = smtpHost
     EMAIL_HOST_USER = smtpHostUsername
     EMAIL_HOST_PASSWORD = smtpHostPassword
     EMAIL_PORT = smtpPortNumber
     EMAIL_USE_SSL = [True or False]
+
+    # email - to use mailgun
+    DJANGO_EMAIL_BACKEND=MAILGUN
     MAILGUN_ACCESS_KEY=myMailgunAccessKey
     MAILGUN_SERVER_NAME=myMailgunServerName
-    CHEMSPIDER_TOKEN=myChemspiderToken
-    PHANTOMJS_PATH=/usr/local/bin/phantomjs
-    PUBMED_EMAIL=myEmail@email.com
 
     # required if using BMDS
     BMDS_HOST=http://bmdhost.com

--- a/docs/source/server_setup.rst
+++ b/docs/source/server_setup.rst
@@ -50,6 +50,12 @@ please specify in the docker-compose `.env` file (example secrets below):
     DJANGO_CACHE_LOCATION=redis://redis:6379/0
     DJANGO_BROKER_URL=redis://redis:6379/1
     DJANGO_CELERY_RESULT_BACKEND=redis://redis:6379/2
+    DJANGO_EMAIL_BACKEND=[SMTP or MAILGUN]
+    EMAIL_HOST = smtpHost
+    EMAIL_HOST_USER = smtpHostUsername
+    EMAIL_HOST_PASSWORD = smtpHostPassword
+    EMAIL_PORT = smtpPortNumber
+    EMAIL_USE_SSL = [True or False]
     MAILGUN_ACCESS_KEY=myMailgunAccessKey
     MAILGUN_SERVER_NAME=myMailgunServerName
     CHEMSPIDER_TOKEN=myChemspiderToken

--- a/project/hawc/settings/base.py
+++ b/project/hawc/settings/base.py
@@ -302,3 +302,9 @@ WEBPACK_LOADER = {
         'IGNORE': ['.+/.map']
     }
 }
+
+EMAIL_HOST = os.environ.get('DJANGO_EMAIL_HOST', None)
+EMAIL_HOST_USER = os.environ.get('DJANGO_EMAIL_USER', None)
+EMAIL_HOST_PASSWORD = os.environ.get('DJANGO_EMAIL_PASSWORD', None)
+EMAIL_PORT = int(os.environ.get('DJANGO_EMAIL_PORT', 25))
+EMAIL_USE_SSL = bool(os.environ.get('DJANGO_EMAIL_USE_SSL') == 'True')

--- a/project/hawc/settings/base.py
+++ b/project/hawc/settings/base.py
@@ -302,9 +302,3 @@ WEBPACK_LOADER = {
         'IGNORE': ['.+/.map']
     }
 }
-
-EMAIL_HOST = os.environ.get('DJANGO_EMAIL_HOST', None)
-EMAIL_HOST_USER = os.environ.get('DJANGO_EMAIL_USER', None)
-EMAIL_HOST_PASSWORD = os.environ.get('DJANGO_EMAIL_PASSWORD', None)
-EMAIL_PORT = int(os.environ.get('DJANGO_EMAIL_PORT', 25))
-EMAIL_USE_SSL = bool(os.environ.get('DJANGO_EMAIL_USE_SSL') == 'True')

--- a/project/hawc/settings/staging.py
+++ b/project/hawc/settings/staging.py
@@ -8,9 +8,15 @@ CSRF_COOKIE_SECURE = True
 
 ALLOWED_HOSTS = os.getenv('DJANGO_ALLOWED_HOSTS', '').split('|')
 
-EMAIL_BACKEND = 'django_mailgun.MailgunBackend'
-MAILGUN_ACCESS_KEY = os.environ.get('MAILGUN_ACCESS_KEY')
-MAILGUN_SERVER_NAME = os.environ.get('MAILGUN_SERVER_NAME')
+if os.environ.get('DJANGO_EMAIL_BACKEND') == 'SMTP':
+    EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+elif os.environ.get('DJANGO_EMAIL_BACKEND') == 'MAILGUN':
+    INSTALLED_APPS += 'anymail'
+    EMAIL_BACKEND = 'anymail.backends.mailgun.EmailBackend'
+    ANYMAIL = {
+        'MAILGUN_API_KEY': os.environ.get('MAILGUN_ACCESS_KEY'),
+        'MAILGUN_SENDER_DOMAIN': os.environ.get('MAILGUN_SERVER_NAME'),
+    }
 
 SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
 

--- a/project/hawc/settings/staging.py
+++ b/project/hawc/settings/staging.py
@@ -1,3 +1,4 @@
+import os
 from .base import *  # noqa
 
 SERVER_ROLE = 'staging'
@@ -8,17 +9,24 @@ CSRF_COOKIE_SECURE = True
 
 ALLOWED_HOSTS = os.getenv('DJANGO_ALLOWED_HOSTS', '').split('|')
 
+SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
+
 if os.environ.get('DJANGO_EMAIL_BACKEND') == 'SMTP':
     EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+    EMAIL_HOST = os.environ.get('DJANGO_EMAIL_HOST', None)
+    EMAIL_HOST_USER = os.environ.get('DJANGO_EMAIL_USER', None)
+    EMAIL_HOST_PASSWORD = os.environ.get('DJANGO_EMAIL_PASSWORD', None)
+    EMAIL_PORT = int(os.environ.get('DJANGO_EMAIL_PORT', 25))
+    EMAIL_USE_SSL = bool(os.environ.get('DJANGO_EMAIL_USE_SSL') == 'True')
 elif os.environ.get('DJANGO_EMAIL_BACKEND') == 'MAILGUN':
-    INSTALLED_APPS += 'anymail'
+    INSTALLED_APPS += ('anymail', )
     EMAIL_BACKEND = 'anymail.backends.mailgun.EmailBackend'
-    ANYMAIL = {
-        'MAILGUN_API_KEY': os.environ.get('MAILGUN_ACCESS_KEY'),
-        'MAILGUN_SENDER_DOMAIN': os.environ.get('MAILGUN_SERVER_NAME'),
-    }
-
-SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
+    ANYMAIL = dict(
+        MAILGUN_API_KEY=os.environ.get('MAILGUN_ACCESS_KEY'),
+        MAILGUN_SENDER_DOMAIN=os.environ.get('MAILGUN_SERVER_NAME'),
+    )
+else:
+    raise ValueError('Unknown email backend')
 
 LOGGING['handlers']['file']['filename'] = \
     os.path.join(os.getenv('LOGS_PATH'), 'hawc.log')

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,4 +4,4 @@
 gunicorn==19.7.1
 
 # email
-django-mailgun==0.9.1
+django-anymail==1.2


### PR DESCRIPTION
Closes https://trello.com/c/Kboytpmi/580-revise-email-settings-to-be-more-flexible

Replaces django-mailgun library with django-anymail for using Mailgun to send emails.
Adds settings and documentation for SMTP emailing.