### PR TITLE
remove BMD options until BMD is operational again

### DIFF
--- a/project/animal/templates/animal/endpoint_detail.html
+++ b/project/animal/templates/animal/endpoint_detail.html
@@ -23,6 +23,8 @@
             <li class="divider"></li>
             {% endif %}
 
+            {% comment %}
+            <!-- DISABLED UNTIL BMDS SERVER ONLINE (hopefully temporarily) -->
             {% if assessment.enable_bmd and object.bmd_modeling_possible %}
               {% if bmd_session %}
                 <li class="disabled"><a tabindex="-1" href="#">BMD Modeling</a></li>
@@ -35,6 +37,7 @@
                 {% endif %}
               {% endif %}
             {% endif %}
+            {% endcomment %}
         </ul>
       </div>
     {% endif %}

--- a/project/assessment/forms.py
+++ b/project/assessment/forms.py
@@ -81,7 +81,7 @@ class AssessmentModulesForm(forms.ModelForm):
                   'enable_data_extraction',
                   'enable_project_management',
                   'enable_risk_of_bias',
-                  'enable_bmd',
+                  # 'enable_bmd',  # DISABLED UNTIL BMDS SERVER ONLINE (hopefully temporarily)
                   'enable_summary_text')
         model = models.Assessment
 

--- a/project/assessment/templates/assessment/assessment_detail.html
+++ b/project/assessment/templates/assessment/assessment_detail.html
@@ -40,9 +40,12 @@
           <li><a href="{% url 'riskofbias:arob_detail' pk=object.pk %}">Risk of bias settings</a></li>
           {% endif %}
 
+          {% comment %}
+          <!-- DISABLED UNTIL BMDS SERVER ONLINE (hopefully temporarily) -->
           {% if assessment.enable_bmd %}
           <li><a href="{% url 'bmd:assess_settings_detail' pk=object.pk %}">Benchmark dose settings</a></li>
           {% endif %}
+          {% endcomment %}
 
           {% if assessment.enable_data_extraction and obj_perms.edit_assessment %}
           <li><a href="{% url 'invitro:endpointcategory_update' object.pk %}">Update IV endpoint categories</a></li>


### PR DESCRIPTION
Implements #97.  

Remove BMD links until BMD online again; added comment to search for in the
future to add back in (3 matches):
`DISABLED UNTIL BMDS SERVER ONLINE (hopefully temporarily)`