### PR TITLE
HAWC flavors

### DIFF
--- a/docs/source/dev_setup.rst
+++ b/docs/source/dev_setup.rst
@@ -57,6 +57,13 @@ Mac/Linux
 Update the settings file with any changes you'd like to make for your local
 development environment.
 
+Current HAWC as two possible application "flavors", where the application is slightly
+different depending on which flavor is selected. To change, modify the ``HAWC_FLAVOR``
+environment variable in the local settings. Possible values include:
+
+- PRIME (default application)
+- EPA (EPA application)
+
 Windows
 ~~~~~~~
 

--- a/docs/source/server_setup.rst
+++ b/docs/source/server_setup.rst
@@ -54,6 +54,9 @@ please specify in the docker-compose `.env` file (example secrets below):
     PHANTOMJS_PATH=/usr/local/bin/phantomjs
     PUBMED_EMAIL=myEmail@email.com
 
+    # Enum; one of {"PRIME", "EPA"}
+    HAWC_FLAVOR=PRIME
+
     # email (use these settings if using SMTP)
     DJANGO_EMAIL_BACKEND=SMTP
     EMAIL_HOST=smtpHost

--- a/project/assessment/views.py
+++ b/project/assessment/views.py
@@ -152,6 +152,7 @@ class About(TemplateView):
         context = super().get_context_data(**kwargs)
         context['GIT_COMMIT'] = settings.GIT_COMMIT
         context['COMMIT_URL'] = settings.COMMIT_URL
+        context['HAWC_FLAVOR'] = settings.HAWC_FLAVOR
         context['counts'] = self.get_object_counts()
         return context
 

--- a/project/hawc/settings/base.py
+++ b/project/hawc/settings/base.py
@@ -25,6 +25,7 @@ if (len(_admin_names) > 0 and len(_admin_emails) > 0):
     ADMINS = list(zip(_admin_names.split('|'), _admin_emails.split('|')))
 MANAGERS = ADMINS
 
+HAWC_FLAVOR = os.getenv("HAWC_FLAVOR", "PRIME")
 
 # Template processors
 TEMPLATES = [

--- a/project/hawc/settings/local.example.py
+++ b/project/hawc/settings/local.example.py
@@ -21,3 +21,6 @@ PHANTOMJS_PATH = r'/path/to/phantomjs'
 
 # API keys
 CHEMSPIDER_TOKEN = r'get-chemspider-token-online'
+
+# SET HAWC FLAVOR (see docs)
+HAWC_FLAVOR = "PRIME"

--- a/project/templates/hawc/about.html
+++ b/project/templates/hawc/about.html
@@ -84,8 +84,12 @@
 
           <div class="tab-content">
               <div id="started" class="videoTab tab-pane active">
+                {% if HAWC_FLAVOR == "EPA" %}
+                  <iframe width="560" height="315" src="https://www.youtube.com/embed/LWtZWttBhkA" frameborder="0" allowfullscreen></iframe>
+                {% else %}
                   <iframe width="560" height="315" src="https://www.youtube.com/embed/DSXFTtylrQU" frameborder="0" allowfullscreen></iframe>
-                  <iframe width="560" height="315" src="https://www.youtube.com/embed/-XsmG38lvps" frameborder="0" allowfullscreen></iframe>
+                {% endif %}
+                <iframe width="560" height="315" src="https://www.youtube.com/embed/-XsmG38lvps" frameborder="0" allowfullscreen></iframe>
               </div>
               <div id="importing" class="videoTab tab-pane">
                   <iframe width="560" height="315" src="https://www.youtube.com/embed/VIgstH82cL0" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
Create a new application setting, HAWC_FLAVOR, which allows slight changes in behavior based on deployment environment.

Has two possible values: PRIME (default), or EPA. 

Currently, training videos vary slightly depending on which HAWC flavor is being used.