### PR TITLE
pip install hawc-client

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -1,0 +1,30 @@
+.PHONY: clean build upload-testpypi upload-pypi
+.DEFAULT_GOAL := help
+define PRINT_HELP_PYSCRIPT
+import re, sys
+
+for line in sys.stdin:
+	match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)
+	if match:
+		target, help = match.groups()
+		print("%-20s %s" % (target, help))
+endef
+export PRINT_HELP_PYSCRIPT
+
+help:
+	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+
+clean: ## Remove old artifacts
+	rm -rf dist build *.egg-info
+
+build: clean  ## Build python distribution
+	python setup.py build
+	python setup.py sdist bdist_wheel
+	twine check dist/*.tar.gz
+	twine check dist/*.whl
+
+upload-testpypi:  ## Upload packages to testpypi
+	twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+
+upload-pypi:  ## Upload packages to pypi
+	twine upload --repository-url https://upload.pypi.org/legacy/ dist/*

--- a/client/hawc_client/__init__.py
+++ b/client/hawc_client/__init__.py
@@ -8,6 +8,7 @@ from requests import Response, Session
 from tqdm import tqdm
 
 __all__ = ["HawcClient"]
+__version__ = "2020.5"
 
 
 class HawcClientException(Exception):

--- a/client/setup.cfg
+++ b/client/setup.cfg
@@ -1,18 +1,34 @@
 [metadata]
-name = hawc_client
-version = 0.1
-description = A python client for HAWC.
-author = Daniel Rabstejnek
-author_email = rabstejnek@gmail.com
+description = A client for the Health Assessment Workspace Collaborative (HAWC)
+long_description = Documentation available at https://hawc.readthedocs.io/.
+long_description_content_type = text/x-rst
 license = MIT
+maintainer = The HAWC development team
+maintainer_email = shapiromaron@gmail.com
+name = hawc-client
+version = 2020.5
 classifiers =
+    Operating System :: OS Independent
+    Intended Audience :: Science/Research
     Programming Language :: Python
     Programming Language :: Python :: 3.6
-
+    Topic :: Scientific/Engineering
+platform = any
+url = https://github.com/shapiromatron/hawc
+project_urls =
+    Bug Tracker = https://github.com/shapiromatron/hawc/issues
+    Documentation = https://hawc.readthedocs.io/
+    Source Code = https://github.com/shapiromatron/hawc
 
 [options]
 packages = hawc_client
+python_requires = >=3.6
 install_requires =
     requests
     pandas
     tqdm
+
+[check]
+metadata = true
+restructuredtext = true
+strict = true

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,5 +1,67 @@
-API
-===
+Clients and APIs
+================
+
+The development team maintains a number of clients and APIs that are used for development and for some user interfaces for the application. The same rules for authentication and authorization are in place to access data from HAWC assessments programmatically using the API or clients.  Access for assessments can only be modified using the HAWC website; they cannot be changed via the client or API at this time.
+
+Python HAWC client
+------------------
+
+A `HAWC client`_ has been developed and is the recommended approach to programmatically add or fetch content
+from a HAWC instance. To install the client (requires Python ≥ 3.6):
+
+.. _`HAWC client`: https://pypi.org/project/hawc-client/
+
+.. code-block:: bash
+
+    pip install hawc-client
+
+Using a notebook or python shell:
+
+.. code-block:: python
+
+    from hawc_client import HawcClient
+
+    client = HawcClient(root_url="https://hawcproject.org")
+    client.authenticate(username="username",password="password")
+
+    # get all references for an assessment
+    client.lit.references(assessment_id=123)
+
+    # import new references to an assessment
+    client.lit.import_hero(
+        assessment_id=123,
+        title="example title",
+        description="example description",
+        ids=[5000,5010]
+    )
+
+There are many more commands available in the HAWC client that aren't documented here. It is recommended to use an interactive terminal session using a notebook or ipython to browse the available methods and their docstrings for more details.
+
+R HAWC client
+-------------
+
+An R client is also available, though it is updated less frequently. To install and use:
+
+.. code-block:: R
+
+    devtools::install_github('shapiromatron/hawc', subdir='client/r/rhawc')
+    library(rhawc)
+
+    client = HawcClient("https://hawcproject.org")
+    client$authenticate("me@me.com", "keep-it-hidden")
+
+    hero_ids = list(500:520)
+    client$lit_import_hero(
+        assessment_id=123,
+        title="example title",
+        description="example description",
+        ids=hero_ids
+    )
+
+The API for the R-client is roughly a mirror of the Python client, but may be lagging in features.
+
+API access
+----------
 
 Authenticated users can access HAWC REST APIs; below is an example script for use:
 
@@ -19,43 +81,3 @@ Authenticated users can access HAWC REST APIs; below is an example script for us
         raise EnvironmentError("Authentication failed")
 
     session.get('https://hawcproject.org/ani/api/endpoint/?assessment_id=123').json()
-
-
-There's also a HAWC client available:
-
-.. code-block:: python
-
-    from hawc_client import HawcClient
-
-    client = HawcClient(root_url="https://hawcproject.org")
-    client.authenticate(username="username",password="password")
-
-    # as an example, get all references for an assessment
-    client.lit.references(assessment_id=123)
-
-    # as an example, import new references to an assessment
-    client.lit.import_hero(
-        assessment_id=123,
-        title="example title",
-        description="example description",
-        ids=[5000,5010]
-    )
-
-There's also a HAWC client available in R:
-
-.. code-block:: R
-
-    devtools::install_github('shapiromatron/hawc', subdir='client/r/rhawc')
-    library(rhawc)
-
-    client = HawcClient("https://hawcproject.org")
-    client$authenticate("me@me.com", "keep-it-hidden")
-
-    hero_ids = list(500:520)
-    client$lit_import_hero(
-        assessment_id=123,
-        title="example title",
-        description="example description",
-        ids=hero_ids
-    )
-

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -40,7 +40,7 @@ There are many more commands available in the HAWC client that aren't documented
 R HAWC client
 -------------
 
-An R client is also available, though it is updated less frequently. To install and use:
+An R client is also available. To install and use:
 
 .. code-block:: R
 
@@ -58,7 +58,7 @@ An R client is also available, though it is updated less frequently. To install 
         ids=hero_ids
     )
 
-The API for the R-client is roughly a mirror of the Python client, but may be lagging in features.
+Please note that the Python client is considered the reference implementation for a HAWC client and will include the latest features; the R client may be a little behind.
 
 API access
 ----------

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -377,10 +377,15 @@ The Python HAWC client can be packaged for easy distribution.
 
 .. code-block:: bash
 
-    # change to your client directory within the hawc project
+    # install dependencies
+    pip install twine wheel
+
+    # change to client path
     cd client
 
-    # make a sdist and wheel for your hawc-client
-    python setup.py sdist bdist_wheel
+    # build packages; these can be distributed directly
+    make build
 
-These distributions will be located in the ``dist`` folder within the aforementioned ``client`` directory.
+    # or can be uploaded to pypi
+    make upload-testpypi
+    make upload-pypi


### PR DESCRIPTION
- added new `Makefile` and commands for pushing hawc to pypi
- updated documentation to reflect installation process
- released first version of hawc-client