### PR TITLE
change topic-model URL route

### DIFF
--- a/hawc/apps/lit/templates/lit/overview.html
+++ b/hawc/apps/lit/templates/lit/overview.html
@@ -75,7 +75,7 @@
         <a class="btn btn-primary" href="{% url 'lit:ref_visual' assessment.pk %}">Visualization</a>
         {% if user.is_staff or request.user|has_user_group:"beta tester" %}
           {% if can_topic_model %}
-          <a class="btn btn-primary" href="{% url 'lit:topic_model' assessment.literature_settings.pk %}">Topic model</a>
+          <a class="btn btn-primary" href="{% url 'lit:topic_model' assessment.pk %}">Topic model</a>
           {% endif %}
         {% endif %}
         <a class="btn btn-primary" href="{% url 'lit:ref_search' assessment.pk %}">Find a reference</a>

--- a/hawc/apps/lit/views.py
+++ b/hawc/apps/lit/views.py
@@ -520,6 +520,12 @@ class RefTopicModel(BaseDetail):
     model = models.LiteratureAssessment
     template_name = "lit/topic_model.html"
 
+    def get_object(self, queryset=None):
+        # use the assessment_id as the primary key instead of the models.LiteratureAssessment
+        assessment_id = self.kwargs.get(self.pk_url_kwarg)
+        object_ = get_object_or_404(self.model, assessment_id=assessment_id)
+        return super().get_object(object=object_)
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["num_references"] = self.object.assessment.references.count()


### PR DESCRIPTION
- Use the `assessment_id` as the pk for the topic model instead of the literature assessment settings