### PR TITLE
hotfix- fix bug preventing tag creation

### DIFF
--- a/frontend/assets/nestedTagEditor/actions.js
+++ b/frontend/assets/nestedTagEditor/actions.js
@@ -50,7 +50,7 @@ var addDepth = function(node, depth) {
     createTag = function(newNode) {
         return (dispatch, getState) => {
             let state = getState(),
-                url = `${state.config.base_url}`,
+                url = `${state.config.list_url}`,
                 csrf = state.config.csrf,
                 obj = {
                     assessment_id: state.config.assessment_id,


### PR DESCRIPTION
Bug reported that a user can no longer create tags; this was fixed be replacing the URL and using the correct one.