### PR TITLE
Hotfix: 'clean-extracted-data' hanging

### DIFF
--- a/frontend/assets/textCleanup/components/Items/BulkForm.js
+++ b/frontend/assets/textCleanup/components/Items/BulkForm.js
@@ -136,7 +136,7 @@ BulkForm.propTypes = {
     handleDetailSubmit: PropTypes.func.isRequired,
     params: PropTypes.object.isRequired,
     items: PropTypes.array.isRequired,
-    modalClass: PropTypes.object,
+    modalClass: PropTypes.string,
 };
 
 export default BulkForm;

--- a/frontend/assets/textCleanup/components/Items/Header.js
+++ b/frontend/assets/textCleanup/components/Items/Header.js
@@ -12,7 +12,7 @@ class Header extends Component {
 
 Header.propTypes = {
     params: PropTypes.shape({
-        field: PropTypes.object,
+        field: PropTypes.string,
     }),
 };
 

--- a/frontend/assets/textCleanup/containers/FieldSelection.js
+++ b/frontend/assets/textCleanup/containers/FieldSelection.js
@@ -43,17 +43,17 @@ function mapStateToProps(state) {
 }
 
 FieldSelection.propTypes = {
-    types: PropTypes.object,
+    types: PropTypes.array,
     dispatch: PropTypes.func,
     match: PropTypes.shape({
         params: PropTypes.shape({
-            type: PropTypes.object,
+            type: PropTypes.string,
         }),
     }),
     location: PropTypes.shape({
-        pathname: PropTypes.object,
+        pathname: PropTypes.string,
     }),
-    objects: PropTypes.object,
+    objects: PropTypes.array,
 };
 
 export default connect(mapStateToProps)(FieldSelection);

--- a/frontend/assets/textCleanup/containers/Items/App.js
+++ b/frontend/assets/textCleanup/containers/Items/App.js
@@ -30,7 +30,7 @@ Items.propTypes = {
     match: PropTypes.shape({
         params: PropTypes.object,
     }),
-    items: PropTypes.object,
+    items: PropTypes.array,
 };
 
 export default connect(mapStateToProps)(Items);

--- a/frontend/assets/textCleanup/containers/Items/BulkForm.js
+++ b/frontend/assets/textCleanup/containers/Items/BulkForm.js
@@ -83,15 +83,15 @@ function mapDispatchToProps(dispatch) {
 BulkForm.propTypes = {
     dispatch: PropTypes.func,
     params: PropTypes.shape({
-        field: PropTypes.object,
-        type: PropTypes.object,
+        field: PropTypes.string,
+        type: PropTypes.string,
     }),
     model: PropTypes.shape({
         editObject: PropTypes.object,
         editObjectErrors: PropTypes.object,
-        itemsLoaded: PropTypes.object,
+        itemsLoaded: PropTypes.bool,
     }),
-    items: PropTypes.object,
+    items: PropTypes.array,
     config: PropTypes.object,
 };
 

--- a/frontend/assets/textCleanup/containers/Root.js
+++ b/frontend/assets/textCleanup/containers/Root.js
@@ -11,7 +11,8 @@ import FieldSelection from "textCleanup/containers/FieldSelection";
 import Items from "textCleanup/containers/Items/App";
 
 class Root extends Component {
-    componentDidMount() {
+    constructor(props) {
+        super(props);
         this.props.store.dispatch(loadConfig());
     }
 


### PR DESCRIPTION
Problem from when we were removing instances of deprecated `componentWillMount`. It was changed to `componentDidMount` within `textCleanup/containers/Root.js`, which made it wait until after render to set `config` in store, when it was expected to be set before the child React components were mounted. Changed it to happen within the constructor so that actions based on this variable are no longer broken.

Also cleaned up PropType errors once it was working.