### PR TITLE
Migrations to set DTXSID on experiments / IV chemicals

### DIFF
--- a/hawc/apps/animal/migrations/0026_experiment_dtxsid.py
+++ b/hawc/apps/animal/migrations/0026_experiment_dtxsid.py
@@ -1,4 +1,3 @@
-import json
 from typing import Optional, Set
 
 import django.db.models.deletion
@@ -19,40 +18,26 @@ def casrn_to_dtxsid(apps, schema_editor):
         except ValueError:
             return None
 
-    # lists to keep track of changed data for bulk creates/updates
-    existing_dtxsids: Set = set(DSSTox.objects.values_list("dtxsid", flat=True))
-    updated_experiments = []
+    # list to keep track of dsstox entries for bulk create
     new_dsstox_entries = []
-    api_cache = {}
 
-    for experiment in Experiment.objects.exclude(cas=""):
+    # existing dtxsids and Experiment casrns
+    existing_dtxsids: Set = set(DSSTox.objects.values_list("dtxsid", flat=True))
+    experiment_casrns: Set = set(Experiment.objects.values_list("cas", flat=True))
 
-        # try to find a DTXSID instance; hit API cache first; may return None
-        if experiment.cas not in api_cache:
-            dsstox = _create_dsstox(experiment.cas)
-            api_cache[experiment.cas] = dsstox
-        else:
-            dsstox = api_cache[experiment.cas]
-
-        if dsstox:
-            # add new dsstox entry
+    # for each casrn...
+    for casrn in experiment_casrns:
+        # create the corresponding DSSTox object
+        dsstox = _create_dsstox(casrn)
+        # if an error wasn't thrown during creation...
+        if dsstox is not None:
+            # and the DSSTox object doesn't exist...
             if dsstox.dtxsid not in existing_dtxsids:
+                # create the DSSTox object
                 new_dsstox_entries.append(dsstox)
                 existing_dtxsids.add(dsstox.dtxsid)
 
-            # add experiment entry
-            experiment.dtxsid_id = dsstox.dtxsid
-            print(
-                json.dumps(
-                    dict(experiment=experiment.id, casrn=experiment.cas, dtxsid=dsstox.dtxsid)
-                )
-            )
-        else:
-            print(json.dumps(dict(experiment=experiment.id, casrn=experiment.cas, dtxsid=None)))
-
-    # bulk create/update items
     DSSTox.objects.bulk_create(new_dsstox_entries)
-    Experiment.objects.bulk_update(updated_experiments, ["dtxsid"])
 
 
 class Migration(migrations.Migration):

--- a/hawc/apps/animal/migrations/0030_experiment_set_dtxsid.py
+++ b/hawc/apps/animal/migrations/0030_experiment_set_dtxsid.py
@@ -1,0 +1,42 @@
+import json
+from typing import Dict
+
+from django.db import migrations
+
+
+def set_dtxsid(apps, schema_editor):
+
+    Experiment = apps.get_model("animal", "experiment")
+    DSSTox = apps.get_model("assessment", "dsstox")
+
+    # list to keep track of changed data for bulk update
+    updated_experiments = []
+
+    # casrn to dtxsid in db
+    casrn_to_dtxsid: Dict = dict(list(DSSTox.objects.values_list("content__casrn", "dtxsid")))
+
+    # we're only looking at experiments with non-empty chemical identifiers
+    for experiment in Experiment.objects.exclude(cas=""):
+
+        dtxsid = casrn_to_dtxsid.get(experiment.cas)
+
+        if dtxsid is not None:
+            # add dtxsid to experiment entry
+            experiment.dtxsid_id = dtxsid
+            updated_experiments.append(experiment)
+            print(json.dumps(dict(experiment=experiment.id, casrn=experiment.cas, dtxsid=dtxsid)))
+        else:
+            print(json.dumps(dict(experiment=experiment.id, casrn=experiment.cas, dtxsid=None)))
+
+    Experiment.objects.bulk_update(updated_experiments, ["dtxsid"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("animal", "0029_strip_terms"),
+    ]
+
+    operations = [
+        migrations.RunPython(set_dtxsid, migrations.RunPython.noop),
+    ]

--- a/hawc/apps/invitro/migrations/0011_ivchemical_set_dtxsid.py
+++ b/hawc/apps/invitro/migrations/0011_ivchemical_set_dtxsid.py
@@ -1,0 +1,42 @@
+import json
+from typing import Dict
+
+from django.db import migrations
+
+
+def set_dtxsid(apps, schema_editor):
+
+    IVChemical = apps.get_model("invitro", "ivchemical")
+    DSSTox = apps.get_model("assessment", "dsstox")
+
+    # list to keep track of changed data for bulk update
+    updated_ivchemicals = []
+
+    # casrn to dtxsid in db
+    casrn_to_dtxsid: Dict = dict(list(DSSTox.objects.values_list("content__casrn", "dtxsid")))
+
+    # we're only looking at ivchemicals with non-empty chemical identifiers
+    for ivchemical in IVChemical.objects.exclude(cas=""):
+
+        dtxsid = casrn_to_dtxsid.get(ivchemical.cas)
+
+        if dtxsid is not None:
+            # add dtxsid to ivchemical entry
+            ivchemical.dtxsid_id = dtxsid
+            updated_ivchemicals.append(ivchemical)
+            print(json.dumps(dict(ivchemical=ivchemical.id, casrn=ivchemical.cas, dtxsid=dtxsid)))
+        else:
+            print(json.dumps(dict(ivchemical=ivchemical.id, casrn=ivchemical.cas, dtxsid=None)))
+
+    IVChemical.objects.bulk_update(updated_ivchemicals, ["dtxsid"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("invitro", "0010_endpoint_ordering"),
+    ]
+
+    operations = [
+        migrations.RunPython(set_dtxsid, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
Old migrations did not set DTXSIDs on experiments and IV chemicals correctly. New migrations were created to accomplish this, and the old migrations were cleaned up to remove the broken implementation with functionality left unchanged.