### PR TITLE
Migrations to set DTXSID on experiments / IV chemicals v2

### DIFF
--- a/hawc/apps/animal/migrations/0026_experiment_dtxsid.py
+++ b/hawc/apps/animal/migrations/0026_experiment_dtxsid.py
@@ -42,6 +42,8 @@ def casrn_to_dtxsid(apps, schema_editor):
 
             # add experiment entry
             experiment.dtxsid_id = dsstox.dtxsid
+            updated_experiments.append(experiment)
+
             print(
                 json.dumps(
                     dict(experiment=experiment.id, casrn=experiment.cas, dtxsid=dsstox.dtxsid)
@@ -52,7 +54,7 @@ def casrn_to_dtxsid(apps, schema_editor):
 
     # bulk create/update items
     DSSTox.objects.bulk_create(new_dsstox_entries)
-    Experiment.objects.bulk_update(updated_experiments, ["dtxsid"])
+    Experiment.objects.bulk_update(updated_experiments, ["dtxsid_id"])
 
 
 class Migration(migrations.Migration):

--- a/hawc/apps/invitro/migrations/0009_ivchemical_dtxsid.py
+++ b/hawc/apps/invitro/migrations/0009_ivchemical_dtxsid.py
@@ -43,6 +43,8 @@ def casrn_to_dtxsid(apps, schema_editor):
 
             # add ivchemical entry
             ivchemical.dtxsid_id = dsstox.dtxsid
+            updated_ivchemicals.append(ivchemical)
+
             print(
                 json.dumps(
                     dict(ivchemical=ivchemical.id, casrn=ivchemical.cas, dtxsid=dsstox.dtxsid)
@@ -52,7 +54,7 @@ def casrn_to_dtxsid(apps, schema_editor):
             print(json.dumps(dict(ivchemical=ivchemical.id, casrn=ivchemical.cas, dtxsid=None)))
 
     DSSTox.objects.bulk_create(new_dsstox_entries)
-    IVChemical.objects.bulk_update(updated_ivchemicals, ["dtxsid"])
+    IVChemical.objects.bulk_update(updated_ivchemicals, ["dtxsid_id"])
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
Old migrations did not set DTXSIDs on experiments and IV chemicals correctly. New migrations were created to accomplish this, and the old migrations were cleaned up to remove the broken implementation with functionality left unchanged.