### PR TITLE
Hotfix: reference search permissions

### DIFF
--- a/hawc/apps/assessment/api.py
+++ b/hawc/apps/assessment/api.py
@@ -115,6 +115,13 @@ class AssessmentLevelPermissions(permissions.BasePermission):
         return True
 
 
+class AssessmentReadPermissions(AssessmentLevelPermissions):
+    def has_object_permission(self, request, view, obj):
+        if not hasattr(view, "assessment"):
+            view.assessment = obj.get_assessment()
+        return view.assessment.user_can_view_object(request.user)
+
+
 class InAssessmentFilter(filters.BaseFilterBackend):
     """
     Filter objects which are in a particular assessment.

--- a/hawc/apps/lit/api.py
+++ b/hawc/apps/lit/api.py
@@ -8,7 +8,11 @@ from rest_framework import exceptions, mixins, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from ..assessment.api import AssessmentLevelPermissions, AssessmentRootedTagTreeViewset
+from ..assessment.api import (
+    AssessmentLevelPermissions,
+    AssessmentReadPermissions,
+    AssessmentRootedTagTreeViewset,
+)
 from ..assessment.models import Assessment
 from ..common.api import (
     CleanupFieldsBaseViewSet,
@@ -208,7 +212,12 @@ class LiteratureAssessmentViewset(LegacyAssessmentAdapterMixin, viewsets.Generic
         models.Reference.update_hero_metadata(assessment.id)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
-    @action(detail=True, methods=("post",), url_path="reference-search", permission_classes=[])
+    @action(
+        detail=True,
+        methods=("post",),
+        url_path="reference-search",
+        permission_classes=(AssessmentReadPermissions,),
+    )
     def reference_search(self, request, pk):
         assessment = self.get_object()
         if not assessment.user_can_view_object(request.user):

--- a/hawc/apps/lit/api.py
+++ b/hawc/apps/lit/api.py
@@ -208,7 +208,7 @@ class LiteratureAssessmentViewset(LegacyAssessmentAdapterMixin, viewsets.Generic
         models.Reference.update_hero_metadata(assessment.id)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
-    @action(detail=True, methods=("post",), url_path="reference-search")
+    @action(detail=True, methods=("post",), url_path="reference-search", permission_classes=[])
     def reference_search(self, request, pk):
         assessment = self.get_object()
         if not assessment.user_can_view_object(request.user):


### PR DESCRIPTION
`AssessmentLevelPermissions` required edit permissions on the reference search API when it should have been read permissions; the subclassed permissions were removed and instead checked locally.