### PR TITLE
Hotfix: extra quotes on animal group table

### DIFF
--- a/frontend/animal/Endpoint.js
+++ b/frontend/animal/Endpoint.js
@@ -320,7 +320,7 @@ class Endpoint extends Observee {
                     txt = "";
                     if (i > 0 && _.isNumber(v.response) && dr_control.response > 0) {
                         txt = self._continuous_percent_difference_from_control(v, dr_control);
-                        txt = txt === "NR" ? "" : `" (${txt}%)"`;
+                        txt = txt === "NR" ? "" : ` (${txt}%)`;
                     }
                     td.html(`${response}${txt}${footnotes}`);
                 } else if (data_type === "P") {


### PR DESCRIPTION
### Before
![image](https://user-images.githubusercontent.com/46504563/94752948-b8f5f980-035a-11eb-9e6c-3cf5e236d505.png)

### After
![image](https://user-images.githubusercontent.com/46504563/94752979-d2974100-035a-11eb-86b7-7cfb00e7ea59.png)
