### PR TITLE
controlled vocabulary - extraction cleanup exclusion

### DIFF
--- a/frontend/assets/textCleanup/GroupedObjectList.js
+++ b/frontend/assets/textCleanup/GroupedObjectList.js
@@ -13,6 +13,15 @@ class GroupedObjectList extends Component {
         let {store} = this.props;
         return (
             <div className="container-fluid">
+                {store.hasTermMapping ? (
+                    <div className="row">
+                        <p className="alert alert-info">
+                            <i className="fa fa-exclamation-triangle"></i> Controlled vocabulary may
+                            exist for this assessment. This list is filtered to only display terms
+                            which are not being used with controlled vocabulary.
+                        </p>
+                    </div>
+                ) : null}
                 <div className="row">
                     <span className="bulk-header span4">{h.caseToWords(store.selectedField)}</span>
                     <span className="bulk-header span5">

--- a/hawc/apps/animal/models.py
+++ b/hawc/apps/animal/models.py
@@ -714,6 +714,13 @@ class Endpoint(BaseEndpoint):
         "endpoint_notes",
         "litter_effect_notes",
     )
+    TERM_FIELD_MAPPING = {
+        "name": "name_term_id",
+        "system": "system_term_id",
+        "organ": "organ_term_id",
+        "effect": "effect_term_id",
+        "effect_subtype": "effect_subtype_term_id",
+    }
 
     DATA_TYPE_CONTINUOUS = "C"
     DATA_TYPE_DICHOTOMOUS = "D"

--- a/hawc/apps/animal/serializers.py
+++ b/hawc/apps/animal/serializers.py
@@ -384,7 +384,7 @@ class EndpointCleanupFieldsSerializer(DynamicFieldsMixin, serializers.ModelSeria
     class Meta:
         model = models.Endpoint
         cleanup_fields = ("study_short_citation",) + model.TEXT_CLEANUP_FIELDS
-        fields = cleanup_fields + ("id",)
+        fields = cleanup_fields + ("id",) + tuple(model.TERM_FIELD_MAPPING.values())
 
     def get_study_short_citation(self, obj):
         return obj.animal_group.experiment.study.short_citation

--- a/hawc/apps/common/api.py
+++ b/hawc/apps/common/api.py
@@ -93,7 +93,10 @@ class CleanupFieldsBaseViewSet(
         Return field names available for cleanup.
         """
         cleanup_fields = self.model.TEXT_CLEANUP_FIELDS
-        return Response({"text_cleanup_fields": cleanup_fields})
+        TERM_FIELD_MAPPING = getattr(self.model, "TERM_FIELD_MAPPING", {})
+        return Response(
+            {"text_cleanup_fields": cleanup_fields, "term_field_mapping": TERM_FIELD_MAPPING}
+        )
 
     def post_save_bulk(self, queryset, update_bulk_dict):
         ids = list(queryset.values_list("id", flat=True))


### PR DESCRIPTION
If we're using controlled vocabulary we don't want those fields present when cleaning up endpoints. This PR adds an additional filter to filter items which can be cleaned up to only show those which aren't using a term.

---
#### this endpoint has name, system, controlled
![Screen Shot 2020-10-06 at 3 33 05 PM](https://user-images.githubusercontent.com/999952/95251551-b7f51a00-07e9-11eb-9271-837e210cdba5.png)

---
#### `Cholesterol, Total` is not shown b/c it's controlled and we get a warning
![Screen Shot 2020-10-06 at 3 33 20 PM](https://user-images.githubusercontent.com/999952/95251471-9d22a580-07e9-11eb-8e96-26019e28383a.png)

---
#### `Liver` is not controlled, so we do see it
![Screen Shot 2020-10-06 at 3 33 52 PM](https://user-images.githubusercontent.com/999952/95251475-9e53d280-07e9-11eb-9732-c11d472b94f1.png)

---
#### This term doesn't have controlled vocab, so we don't see the blue warning
![Screen Shot 2020-10-06 at 3 34 06 PM](https://user-images.githubusercontent.com/999952/95251478-9f84ff80-07e9-11eb-8bc9-05991c9e9827.png)

