### PR TITLE
logscale axes

### DIFF
--- a/frontend/animal/Barplot.js
+++ b/frontend/animal/Barplot.js
@@ -2,6 +2,7 @@ import $ from "$";
 import _ from "lodash";
 import * as d3 from "d3";
 
+import h from "shared/utils/helpers";
 import D3Plot from "utils/D3Plot";
 
 class Barplot extends D3Plot {
@@ -82,8 +83,7 @@ class Barplot extends D3Plot {
             if (this.y_axis_settings.scale_type == "linear") {
                 this.y_axis_settings.scale_type = "log";
                 this.y_axis_settings.number_ticks = 1;
-                var formatNumber = d3.format(",");
-                this.y_axis_settings.label_format = formatNumber;
+                this.y_axis_settings.label_format = h.numericAxisFormat;
             } else {
                 this.y_axis_settings.scale_type = "linear";
                 this.y_axis_settings.number_ticks = 10;

--- a/frontend/animal/Barplot.js
+++ b/frontend/animal/Barplot.js
@@ -82,7 +82,7 @@ class Barplot extends D3Plot {
         if (this.endpoint.data.data_type == "C") {
             if (this.y_axis_settings.scale_type == "linear") {
                 this.y_axis_settings.scale_type = "log";
-                this.y_axis_settings.number_ticks = 1;
+                this.y_axis_settings.number_ticks = h.numLogTicks(this.y_axis_settings.domain);
                 this.y_axis_settings.label_format = h.numericAxisFormat;
             } else {
                 this.y_axis_settings.scale_type = "linear";

--- a/frontend/animal/Barplot.js
+++ b/frontend/animal/Barplot.js
@@ -1,6 +1,5 @@
 import $ from "$";
 import _ from "lodash";
-import * as d3 from "d3";
 
 import h from "shared/utils/helpers";
 import D3Plot from "utils/D3Plot";

--- a/frontend/animal/DRPlot.js
+++ b/frontend/animal/DRPlot.js
@@ -137,7 +137,7 @@ class DRPlot extends D3Plot {
         if (this.endpoint.data.data_type == "C") {
             if (this.y_axis_settings.scale_type == "linear") {
                 this.y_axis_settings.scale_type = "log";
-                this.y_axis_settings.number_ticks = 1;
+                this.y_axis_settings.number_ticks = h.numLogTicks(this.y_axis_settings.domain);
                 this.y_axis_settings.label_format = h.numericAxisFormat;
             } else {
                 this.y_axis_settings.scale_type = "linear";
@@ -162,7 +162,7 @@ class DRPlot extends D3Plot {
         if (window.event && window.event.stopPropagation) event.stopPropagation();
         if (this.x_axis_settings.scale_type == "linear") {
             this.x_axis_settings.scale_type = "log";
-            this.x_axis_settings.number_ticks = 1;
+            this.x_axis_settings.number_ticks = h.numLogTicks(this.x_axis_settings.domain);
             this.x_axis_settings.label_format = h.numericAxisFormat;
         } else {
             this.x_axis_settings.scale_type = "linear";
@@ -252,12 +252,15 @@ class DRPlot extends D3Plot {
         // Assuming the plot has already been constructed once,
         // rebuild plot with updated x-scale.
 
-        var x = this.x_scale;
+        var x = this.x_scale,
+            settings = this.x_axis_settings,
+            numTicks =
+                settings.scale_type === "log"
+                    ? h.numLogTicks(settings.domain)
+                    : settings.number_ticks;
 
         //rebuild x-axis
-        this.xAxis
-            .scale(x)
-            .ticks(this.x_axis_settings.number_ticks, this.x_axis_settings.label_format);
+        this.xAxis.scale(x).ticks(numTicks, this.x_axis_settings.label_format);
 
         this.vis
             .selectAll(".x_axis")
@@ -278,7 +281,6 @@ class DRPlot extends D3Plot {
             });
 
         this.rebuild_x_gridlines({animate: true});
-
         this.add_dr_error_bars(true);
         this.add_dose_response(true);
         this.render_bmd_lines();

--- a/frontend/animal/DRPlot.js
+++ b/frontend/animal/DRPlot.js
@@ -2,6 +2,7 @@ import $ from "$";
 import _ from "lodash";
 import * as d3 from "d3";
 
+import h from "shared/utils/helpers";
 import D3Plot from "utils/D3Plot";
 
 class DRPlot extends D3Plot {
@@ -137,8 +138,7 @@ class DRPlot extends D3Plot {
             if (this.y_axis_settings.scale_type == "linear") {
                 this.y_axis_settings.scale_type = "log";
                 this.y_axis_settings.number_ticks = 1;
-                var formatNumber = d3.format(",");
-                this.y_axis_settings.label_format = formatNumber;
+                this.y_axis_settings.label_format = h.numericAxisFormat;
             } else {
                 this.y_axis_settings.scale_type = "linear";
                 this.y_axis_settings.number_ticks = 10;
@@ -163,7 +163,7 @@ class DRPlot extends D3Plot {
         if (this.x_axis_settings.scale_type == "linear") {
             this.x_axis_settings.scale_type = "log";
             this.x_axis_settings.number_ticks = 1;
-            this.x_axis_settings.label_format = d3.format(",");
+            this.x_axis_settings.label_format = h.numericAxisFormat;
         } else {
             this.x_axis_settings.scale_type = "linear";
             this.x_axis_settings.number_ticks = 5;

--- a/frontend/assets/shared/utils/helpers.js
+++ b/frontend/assets/shared/utils/helpers.js
@@ -207,6 +207,7 @@ const helpers = {
         const _cartesian = (a, b, ...c) => (b ? _cartesian(f(a, b), ...c) : a);
         return _cartesian(...arrs);
     },
+    numericAxisFormat: d3.format(",~g"),
     COLORS: {
         WHITE: "#ffffff",
         BLUE: "#003d7b",

--- a/frontend/assets/shared/utils/helpers.js
+++ b/frontend/assets/shared/utils/helpers.js
@@ -212,7 +212,7 @@ const helpers = {
         // domain should be output of d3.extent, eg., [1, 100]
         return Math.max(
             2,
-            Math.min(Math.ceil(Math.log10(domain[1])) - Math.floor(Math.log10(domain[0])) + 1, 10)
+            Math.min(Math.ceil(Math.log10(domain[1])) - Math.floor(Math.log10(domain[0])), 10)
         );
     },
     numericAxisFormat: d3.format(",~g"),

--- a/frontend/assets/shared/utils/helpers.js
+++ b/frontend/assets/shared/utils/helpers.js
@@ -207,6 +207,14 @@ const helpers = {
         const _cartesian = (a, b, ...c) => (b ? _cartesian(f(a, b), ...c) : a);
         return _cartesian(...arrs);
     },
+    numLogTicks(domain) {
+        // number of ticks to be used for a given dataset.
+        // domain should be output of d3.extent, eg., [1, 100]
+        return Math.max(
+            2,
+            Math.min(Math.ceil(Math.log10(domain[1])) - Math.floor(Math.log10(domain[0])) + 1, 10)
+        );
+    },
     numericAxisFormat: d3.format(",~g"),
     COLORS: {
         WHITE: "#ffffff",

--- a/frontend/summary/dataPivot/DataPivotVisualization.js
+++ b/frontend/summary/dataPivot/DataPivotVisualization.js
@@ -2,6 +2,7 @@ import $ from "$";
 import _ from "lodash";
 import * as d3 from "d3";
 
+import h from "shared/utils/helpers";
 import D3Plot from "utils/D3Plot";
 import HAWCUtils from "utils/HAWCUtils";
 
@@ -194,8 +195,7 @@ class DataPivotVisualization extends D3Plot {
         this.h = this.w; // temporary; depends on rendered text-size
         this.textPadding = 5; // text padding on all sides of text
 
-        var scale_type = this.dp_settings.plot_settings.logscale ? "log" : "linear",
-            formatNumber = d3.format(",");
+        var scale_type = this.dp_settings.plot_settings.logscale ? "log" : "linear";
 
         this.text_spacing_offset = 10;
         this.x_axis_settings = {
@@ -206,7 +206,7 @@ class DataPivotVisualization extends D3Plot {
             number_ticks: 10,
             axis_labels: true,
             x_translate: 0,
-            label_format: formatNumber,
+            label_format: h.numericAxisFormat,
         };
 
         this.y_axis_settings = {

--- a/frontend/summary/summary/CrossviewPlot.js
+++ b/frontend/summary/summary/CrossviewPlot.js
@@ -2,6 +2,7 @@ import $ from "$";
 import _ from "lodash";
 import * as d3 from "d3";
 
+import h from "shared/utils/helpers";
 import HAWCUtils from "utils/HAWCUtils";
 
 import D3Visualization from "./D3Visualization";
@@ -43,7 +44,7 @@ class CrossviewPlot extends D3Visualization {
                 gridline_class: "primary_gridlines x_gridlines",
                 number_ticks: 10,
                 axis_labels: true,
-                label_format: d3.format(","),
+                label_format: h.numericAxisFormat,
             },
             y_axis_settings: {
                 scale_type: "linear",

--- a/frontend/summary/summary/CrossviewPlot.js
+++ b/frontend/summary/summary/CrossviewPlot.js
@@ -305,15 +305,11 @@ class CrossviewPlot extends D3Visualization {
                 var vals = _.chain(f.values);
                 if (f.allValues) {
                     vals = _.chain(dataset)
-                        .map(function(d) {
-                            return d.filters[f.name];
-                        })
+                        .map(d => d.filters[f.name])
                         .flattenDeep()
                         .sort()
                         .uniq()
-                        .filter(function(d) {
-                            return d != "";
-                        });
+                        .filter(d => d !== "");
                 }
                 return vals
                     .map(function(d) {
@@ -363,23 +359,15 @@ class CrossviewPlot extends D3Visualization {
 
         if (!dose_range) {
             dose_range = [
-                d3.min(this.dataset, function(v) {
-                    return v.dose_extent[0];
-                }),
-                d3.max(this.dataset, function(v) {
-                    return v.dose_extent[1];
-                }),
+                d3.min(this.dataset, v => v.dose_extent[0]),
+                d3.max(this.dataset, v => v.dose_extent[1]),
             ];
         }
 
         if (!resp_range) {
             resp_range = [
-                d3.min(this.dataset, function(d) {
-                    return d.resp_extent[0];
-                }),
-                d3.max(this.dataset, function(d) {
-                    return d.resp_extent[1];
-                }),
+                d3.min(this.dataset, d => d.resp_extent[0]),
+                d3.max(this.dataset, d => d.resp_extent[1]),
             ];
         }
 
@@ -415,10 +403,8 @@ class CrossviewPlot extends D3Visualization {
             y = this.y_scale,
             hrng,
             vrng,
-            filter_rng = function(d) {
-                return $.isNumeric(d.lower) && $.isNumeric(d.upper);
-            },
-            make_hrng = function(d) {
+            filter_rng = d => $.isNumeric(d.lower) && $.isNumeric(d.upper),
+            make_hrng = d => {
                 return {
                     x: x.range()[0],
                     width: Math.abs(x.range()[1] - x.range()[0]),
@@ -430,7 +416,7 @@ class CrossviewPlot extends D3Visualization {
                     }),
                 };
             },
-            make_vrng = function(d) {
+            make_vrng = d => {
                 return {
                     x: x(d.lower),
                     width: Math.abs(x(d.upper) - x(d.lower)),
@@ -441,6 +427,10 @@ class CrossviewPlot extends D3Visualization {
                         name: d.style,
                     }),
                 };
+            },
+            apply_styles = function(d) {
+                var obj = d3.select(this);
+                _.each(d.styles, (value, key) => obj.style(key, value));
             };
 
         hrng = _.chain(this.plot_settings.refranges_response)
@@ -453,37 +443,26 @@ class CrossviewPlot extends D3Visualization {
             .map(make_vrng)
             .value();
 
-        hrng.push.apply(hrng, vrng);
-        if (hrng.length === 0) return;
+        const ranges = [...hrng, ...vrng];
+        if (ranges.length === 0) return;
 
-        this.g_reference_ranges = this.vis.append("g");
-        this.g_reference_ranges
+        let g_reference_ranges = this.vis.append("g");
+
+        g_reference_ranges
             .selectAll("rect")
-            .data(hrng)
+            .data(ranges)
             .enter()
             .append("svg:rect")
-            .attr("x", function(d) {
-                return d.x;
-            })
-            .attr("y", function(d) {
-                return d.y;
-            })
-            .attr("width", function(d) {
-                return d.width;
-            })
-            .attr("height", function(d) {
-                return d.height;
-            })
-            .each(function(d) {
-                d3.select(this).attr(d.styles);
-            });
+            .attr("x", d => d.x)
+            .attr("y", d => d.y)
+            .attr("width", d => d.width)
+            .attr("height", d => d.height)
+            .each(apply_styles);
 
-        this.g_reference_ranges
+        g_reference_ranges
             .selectAll("rect")
             .append("svg:title")
-            .text(function(d) {
-                return d.title;
-            });
+            .text(d => d.title);
     }
 
     _draw_ref_lines() {

--- a/frontend/summary/summary/EndpointAggregationExposureResponsePlot.js
+++ b/frontend/summary/summary/EndpointAggregationExposureResponsePlot.js
@@ -2,6 +2,7 @@ import $ from "$";
 import _ from "lodash";
 import * as d3 from "d3";
 
+import h from "shared/utils/helpers";
 import D3Visualization from "./D3Visualization";
 
 class EndpointAggregationExposureResponsePlot extends D3Visualization {
@@ -11,8 +12,7 @@ class EndpointAggregationExposureResponsePlot extends D3Visualization {
     }
 
     setDefaults() {
-        var left = 25,
-            formatNumber = d3.format(",");
+        var left = 25;
 
         _.extend(this, {
             default_x_scale: "log",
@@ -32,7 +32,7 @@ class EndpointAggregationExposureResponsePlot extends D3Visualization {
                 gridline_class: "primary_gridlines x_gridlines",
                 number_ticks: 10,
                 axis_labels: true,
-                label_format: formatNumber,
+                label_format: h.numericAxisFormat,
             },
             y_axis_settings: {
                 scale_type: "ordinal",
@@ -195,8 +195,7 @@ class EndpointAggregationExposureResponsePlot extends D3Visualization {
         if (this.x_axis_settings.scale_type == "linear") {
             this.x_axis_settings.scale_type = "log";
             this.x_axis_settings.number_ticks = 1;
-            var formatNumber = d3.format(",");
-            this.x_axis_settings.label_format = formatNumber;
+            this.x_axis_settings.label_format = h.numericAxisFormat;
         } else {
             this.x_axis_settings.scale_type = "linear";
             this.x_axis_settings.number_ticks = 10;

--- a/frontend/summary/summary/EndpointAggregationExposureResponsePlot.js
+++ b/frontend/summary/summary/EndpointAggregationExposureResponsePlot.js
@@ -211,7 +211,17 @@ class EndpointAggregationExposureResponsePlot extends D3Visualization {
         // rebuild plot with updated x-scale.
         var x = this.x_scale;
 
-        this.rebuild_x_axis();
+        //rebuild x-axis
+        this.xAxis
+            .scale(this.x_scale)
+            .ticks(this.x_axis_settings.number_ticks, this.x_axis_settings.label_format);
+
+        this.vis
+            .selectAll(".x_axis")
+            .transition()
+            .duration(1000)
+            .call(this.xAxis);
+
         this.rebuild_x_gridlines({animate: true});
 
         //rebuild dosing lines

--- a/frontend/utils/D3Plot.js
+++ b/frontend/utils/D3Plot.js
@@ -1,6 +1,8 @@
 import $ from "$";
 import * as d3 from "d3";
 
+import h from "shared/utils/helpers";
+
 // Generic parent for all d3.js visualizations
 class D3Plot {
     add_title(x, y) {
@@ -242,10 +244,11 @@ class D3Plot {
     }
 
     _print_axis(axisFunc, scale, settings) {
-        var axis = axisFunc(scale);
+        const axis = axisFunc(scale);
+
         switch (settings.scale_type) {
             case "log":
-                axis.ticks(1, settings.label_format);
+                axis.ticks(h.numLogTicks(settings.domain), settings.label_format);
                 break;
             case "linear":
                 axis.ticks(settings.number_ticks);
@@ -297,19 +300,6 @@ class D3Plot {
         return gridlines;
     }
 
-    rebuild_y_axis() {
-        //rebuild y-axis
-        this.yAxis
-            .scale(this.y_scale)
-            .ticks(this.y_axis_settings.number_ticks, this.y_axis_settings.label_format);
-
-        this.vis
-            .selectAll(".y_axis")
-            .transition()
-            .duration(1000)
-            .call(this.yAxis);
-    }
-
     rebuild_y_gridlines(options) {
         // rebuild y-gridlines
 
@@ -346,19 +336,6 @@ class D3Plot {
             .duration(duration / 2)
             .attr("x2", 0)
             .remove();
-    }
-
-    rebuild_x_axis() {
-        //rebuild x-axis
-        this.xAxis
-            .scale(this.x_scale)
-            .ticks(this.x_axis_settings.number_ticks, this.x_axis_settings.label_format);
-
-        this.vis
-            .selectAll(".x_axis")
-            .transition()
-            .duration(1000)
-            .call(this.xAxis);
     }
 
     rebuild_x_gridlines(options) {

--- a/hawc/apps/animal/forms.py
+++ b/hawc/apps/animal/forms.py
@@ -538,7 +538,7 @@ class EndpointForm(ModelForm):
     CONF_INT_REQ = "Confidence-interval is required for" "percent-difference data"
     VAR_TYPE_REQ = "If entering continuous data, the variance type must be SD (standard-deviation) or SE (standard error)"
     RESP_UNITS_REQ = "If data is extracted, response-units are required"
-    NAME_REQ = "Name is required"
+    NAME_REQ = "Endpoint/Adverse outcome is required"
 
     @classmethod
     def clean_endpoint(cls, instance: models.Endpoint, data: Dict) -> Dict:


### PR DESCRIPTION
Regression w/ d3 v5 migration, logscale tick behavior changed:

---

### Error 

![Screen Shot 2020-10-07 at 5 52 09 PM](https://user-images.githubusercontent.com/999952/95391978-fcee7e80-08c5-11eb-8557-d87d5966b2cc.png)

---

### Fix 

![Screen Shot 2020-10-07 at 5 52 17 PM](https://user-images.githubusercontent.com/999952/95391988-01b33280-08c6-11eb-8d0a-3e7bf3366e04.png)

---

In addition, the following changes were made:

- standardized d3.format for numerical formatting data
- removed unused methods
- fixed bug in crossview plot where range styles were not applied (another d3 v5 issue)