### PR TITLE
cache expensive part not entire page

### DIFF
--- a/hawc/apps/vocab/views.py
+++ b/hawc/apps/vocab/views.py
@@ -2,9 +2,9 @@ import json
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
+from django.core.cache import cache
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.views.decorators.cache import cache_page
 from django.views.generic import ListView, TemplateView
 from django.views.generic.edit import CreateView
 
@@ -12,14 +12,22 @@ from ..common.views import MessageMixin
 from . import forms, models
 
 
-@method_decorator(cache_page(settings.CACHE_10_MIN), name="dispatch")
 @method_decorator(login_required, name="dispatch")
 class EhvBrowse(TemplateView):
     template_name = "vocab/ehv_browse.html"
 
+    def _get_ehv_json(self) -> str:
+        # get EHV in json; use cache if possible
+        key = "ehv-dataframe-json"
+        data = cache.get(key)
+        if data is None:
+            data = json.dumps({"data": models.Term.ehv_dataframe().to_csv(index=False)})
+            cache.set(key, data, settings.CACHE_10_MIN)
+        return data
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["config"] = json.dumps({"data": models.Term.ehv_dataframe().to_csv(index=False)})
+        context["config"] = self._get_ehv_json()
         return context
 
 


### PR DESCRIPTION
The combination of a cache and login_required made the page-cache dependent on login rules. This caches the expensive part but still does the login and permissions check.