### PR TITLE
hotfix - restore model ordering default when possible

### DIFF
--- a/tests/hawc/apps/common/test_common_models.py
+++ b/tests/hawc/apps/common/test_common_models.py
@@ -1,6 +1,7 @@
 import pytest
 
-# use a concrete implementation to test AssessmentRootMixin
+# use concrete implementations to test
+from hawc.apps.animal.models import DoseGroup, Experiment
 from hawc.apps.lit.models import ReferenceFilterTag
 
 _nested_names = [
@@ -30,3 +31,12 @@ def test_AssessmentRootMixin_annotate_nested_names(db_keys):
 def test_AssessmentRootMixin_as_dataframe(db_keys):
     df = ReferenceFilterTag.as_dataframe(db_keys.assessment_working)
     assert df.nested_name.values.tolist() == _nested_names
+
+
+@pytest.mark.django_db
+class TestBaseManager:
+    def test_get_order_by(self):
+        assert Experiment._meta.ordering == []
+        assert Experiment.objects._get_order_by() == ("id",)
+        assert DoseGroup._meta.ordering == ("dose_units", "dose_group_id")
+        assert DoseGroup.objects._get_order_by() == ("dose_units", "dose_group_id")


### PR DESCRIPTION
A previous change introduced a bug where even if a model had a default ordering, it always default to `id` to prevent non-deterministic query results. This PR introduces a feature to use default ordering where available, and if none is available, default to id.

Prior bug:
https://github.com/shapiromatron/hawc/commit/3ec4783f870cadac282b7e82bdd892ee440f37b5#diff-12d8ff694bfca83829c6d1818f3b0008705913fa5eacb656e41fa9ddc0c5d36cL41