### PR TITLE
Hotfix: N/A scores on data pivot

### DIFF
--- a/hawc/apps/animal/exports.py
+++ b/hawc/apps/animal/exports.py
@@ -196,11 +196,7 @@ class EndpointGroupFlatDataPivot(FlatFileExporter):
         else:
             self.rob_headers, self.rob_data = RiskOfBias.get_dp_export(
                 self.queryset.first().assessment_id,
-                list(
-                    self.queryset.values_list(
-                        "animal_group__experiment__study_id", flat=True
-                    ).distinct()
-                ),
+                set(self.queryset.values_list("animal_group__experiment__study_id", flat=True)),
                 "animal",
             )
 
@@ -381,11 +377,7 @@ class EndpointFlatDataPivot(EndpointGroupFlatDataPivot):
         else:
             self.rob_headers, self.rob_data = RiskOfBias.get_dp_export(
                 self.queryset.first().assessment_id,
-                list(
-                    self.queryset.values_list(
-                        "animal_group__experiment__study_id", flat=True
-                    ).distinct()
-                ),
+                set(self.queryset.values_list("animal_group__experiment__study_id", flat=True)),
                 "animal",
             )
 

--- a/hawc/apps/animal/exports.py
+++ b/hawc/apps/animal/exports.py
@@ -194,10 +194,11 @@ class EndpointGroupFlatDataPivot(FlatFileExporter):
         if self.queryset.first() is None:
             self.rob_headers, self.rob_data = {}, {}
         else:
+            study_ids = set(
+                self.queryset.values_list("animal_group__experiment__study_id", flat=True)
+            )
             self.rob_headers, self.rob_data = RiskOfBias.get_dp_export(
-                self.queryset.first().assessment_id,
-                set(self.queryset.values_list("animal_group__experiment__study_id", flat=True)),
-                "animal",
+                self.queryset.first().assessment_id, study_ids, "animal",
             )
 
         noel_names = self.kwargs["assessment"].get_noel_names()
@@ -375,10 +376,11 @@ class EndpointFlatDataPivot(EndpointGroupFlatDataPivot):
         if self.queryset.first() is None:
             self.rob_headers, self.rob_data = {}, {}
         else:
+            study_ids = set(
+                self.queryset.values_list("animal_group__experiment__study_id", flat=True)
+            )
             self.rob_headers, self.rob_data = RiskOfBias.get_dp_export(
-                self.queryset.first().assessment_id,
-                set(self.queryset.values_list("animal_group__experiment__study_id", flat=True)),
-                "animal",
+                self.queryset.first().assessment_id, study_ids, "animal",
             )
 
         noel_names = self.kwargs["assessment"].get_noel_names()

--- a/hawc/apps/epi/exports.py
+++ b/hawc/apps/epi/exports.py
@@ -47,7 +47,7 @@ class OutcomeDataPivot(FlatFileExporter):
         else:
             self.rob_headers, self.rob_data = RiskOfBias.get_dp_export(
                 self.queryset.first().assessment_id,
-                list(self.queryset.values_list("study_population__study_id", flat=True).distinct()),
+                set(self.queryset.values_list("study_population__study_id", flat=True)),
                 "epi",
             )
 

--- a/hawc/apps/epi/exports.py
+++ b/hawc/apps/epi/exports.py
@@ -45,10 +45,9 @@ class OutcomeDataPivot(FlatFileExporter):
         if self.queryset.first() is None:
             self.rob_headers, self.rob_data = {}, {}
         else:
+            study_ids = set(self.queryset.values_list("study_population__study_id", flat=True))
             self.rob_headers, self.rob_data = RiskOfBias.get_dp_export(
-                self.queryset.first().assessment_id,
-                set(self.queryset.values_list("study_population__study_id", flat=True)),
-                "epi",
+                self.queryset.first().assessment_id, study_ids, "epi",
             )
 
         headers = [

--- a/hawc/apps/invitro/exports.py
+++ b/hawc/apps/invitro/exports.py
@@ -29,7 +29,7 @@ class DataPivotEndpoint(FlatFileExporter):
         else:
             self.rob_headers, self.rob_data = RiskOfBias.get_dp_export(
                 self.queryset.first().assessment_id,
-                list(self.queryset.values_list("experiment__study_id", flat=True).distinct()),
+                set(self.queryset.values_list("experiment__study_id", flat=True)),
                 "invitro",
             )
 
@@ -209,7 +209,7 @@ class DataPivotEndpointGroup(FlatFileExporter):
         else:
             self.rob_headers, self.rob_data = RiskOfBias.get_dp_export(
                 self.queryset.first().assessment_id,
-                list(self.queryset.values_list("experiment__study_id", flat=True).distinct()),
+                set(self.queryset.values_list("experiment__study_id", flat=True)),
                 "invitro",
             )
 

--- a/hawc/apps/invitro/exports.py
+++ b/hawc/apps/invitro/exports.py
@@ -27,10 +27,9 @@ class DataPivotEndpoint(FlatFileExporter):
         if self.queryset.first() is None:
             self.rob_headers, self.rob_data = {}, {}
         else:
+            study_ids = set(self.queryset.values_list("experiment__study_id", flat=True))
             self.rob_headers, self.rob_data = RiskOfBias.get_dp_export(
-                self.queryset.first().assessment_id,
-                set(self.queryset.values_list("experiment__study_id", flat=True)),
-                "invitro",
+                self.queryset.first().assessment_id, study_ids, "invitro",
             )
 
         header = [
@@ -207,10 +206,9 @@ class DataPivotEndpointGroup(FlatFileExporter):
         if self.queryset.first() is None:
             self.rob_headers, self.rob_data = {}, {}
         else:
+            study_ids = set(self.queryset.values_list("experiment__study_id", flat=True))
             self.rob_headers, self.rob_data = RiskOfBias.get_dp_export(
-                self.queryset.first().assessment_id,
-                set(self.queryset.values_list("experiment__study_id", flat=True)),
-                "invitro",
+                self.queryset.first().assessment_id, study_ids, "invitro",
             )
 
         header = [

--- a/tests/data/api/api-dp-data-animal-bioassay-endpoint-group.json
+++ b/tests/data/api/api-dp-data-animal-bioassay-endpoint-group.json
@@ -61,8 +61,8 @@
     "percent affected": null,
     "percent lower ci": null,
     "percent upper ci": null,
-    "RoB (domain 1: metric 1)": "{\"sortValue\": -1, \"display\": \"N/A\"}",
-    "Overall study confidence": "{\"sortValue\": -1, \"display\": \"N/A\"}"
+    "RoB (domain 1: metric 1)": "{\"sortValue\": 14, \"display\": \"Definitely high risk of bias\"}",
+    "Overall study confidence": "{\"sortValue\": 16, \"display\": \"Probably low risk of bias\"}"
   },
   {
     "study id": 7,
@@ -126,8 +126,8 @@
     "percent affected": null,
     "percent lower ci": null,
     "percent upper ci": null,
-    "RoB (domain 1: metric 1)": "{\"sortValue\": -1, \"display\": \"N/A\"}",
-    "Overall study confidence": "{\"sortValue\": -1, \"display\": \"N/A\"}"
+    "RoB (domain 1: metric 1)": "{\"sortValue\": 14, \"display\": \"Definitely high risk of bias\"}",
+    "Overall study confidence": "{\"sortValue\": 16, \"display\": \"Probably low risk of bias\"}"
   },
   {
     "study id": 7,
@@ -191,8 +191,8 @@
     "percent affected": null,
     "percent lower ci": null,
     "percent upper ci": null,
-    "RoB (domain 1: metric 1)": "{\"sortValue\": -1, \"display\": \"N/A\"}",
-    "Overall study confidence": "{\"sortValue\": -1, \"display\": \"N/A\"}"
+    "RoB (domain 1: metric 1)": "{\"sortValue\": 14, \"display\": \"Definitely high risk of bias\"}",
+    "Overall study confidence": "{\"sortValue\": 16, \"display\": \"Probably low risk of bias\"}"
   },
   {
     "study id": 7,
@@ -256,8 +256,8 @@
     "percent affected": null,
     "percent lower ci": null,
     "percent upper ci": null,
-    "RoB (domain 1: metric 1)": "{\"sortValue\": -1, \"display\": \"N/A\"}",
-    "Overall study confidence": "{\"sortValue\": -1, \"display\": \"N/A\"}"
+    "RoB (domain 1: metric 1)": "{\"sortValue\": 14, \"display\": \"Definitely high risk of bias\"}",
+    "Overall study confidence": "{\"sortValue\": 16, \"display\": \"Probably low risk of bias\"}"
   },
   {
     "study id": 7,
@@ -321,8 +321,8 @@
     "percent affected": null,
     "percent lower ci": null,
     "percent upper ci": null,
-    "RoB (domain 1: metric 1)": "{\"sortValue\": -1, \"display\": \"N/A\"}",
-    "Overall study confidence": "{\"sortValue\": -1, \"display\": \"N/A\"}"
+    "RoB (domain 1: metric 1)": "{\"sortValue\": 14, \"display\": \"Definitely high risk of bias\"}",
+    "Overall study confidence": "{\"sortValue\": 16, \"display\": \"Probably low risk of bias\"}"
   },
   {
     "study id": 7,
@@ -386,8 +386,8 @@
     "percent affected": null,
     "percent lower ci": null,
     "percent upper ci": null,
-    "RoB (domain 1: metric 1)": "{\"sortValue\": -1, \"display\": \"N/A\"}",
-    "Overall study confidence": "{\"sortValue\": -1, \"display\": \"N/A\"}"
+    "RoB (domain 1: metric 1)": "{\"sortValue\": 14, \"display\": \"Definitely high risk of bias\"}",
+    "Overall study confidence": "{\"sortValue\": 16, \"display\": \"Probably low risk of bias\"}"
   },
   {
     "study id": 7,
@@ -451,8 +451,8 @@
     "percent affected": null,
     "percent lower ci": null,
     "percent upper ci": null,
-    "RoB (domain 1: metric 1)": "{\"sortValue\": -1, \"display\": \"N/A\"}",
-    "Overall study confidence": "{\"sortValue\": -1, \"display\": \"N/A\"}"
+    "RoB (domain 1: metric 1)": "{\"sortValue\": 14, \"display\": \"Definitely high risk of bias\"}",
+    "Overall study confidence": "{\"sortValue\": 16, \"display\": \"Probably low risk of bias\"}"
   },
   {
     "study id": 7,
@@ -516,8 +516,8 @@
     "percent affected": null,
     "percent lower ci": null,
     "percent upper ci": null,
-    "RoB (domain 1: metric 1)": "{\"sortValue\": -1, \"display\": \"N/A\"}",
-    "Overall study confidence": "{\"sortValue\": -1, \"display\": \"N/A\"}"
+    "RoB (domain 1: metric 1)": "{\"sortValue\": 14, \"display\": \"Definitely high risk of bias\"}",
+    "Overall study confidence": "{\"sortValue\": 16, \"display\": \"Probably low risk of bias\"}"
   },
   {
     "study id": 7,
@@ -581,8 +581,8 @@
     "percent affected": null,
     "percent lower ci": null,
     "percent upper ci": null,
-    "RoB (domain 1: metric 1)": "{\"sortValue\": -1, \"display\": \"N/A\"}",
-    "Overall study confidence": "{\"sortValue\": -1, \"display\": \"N/A\"}"
+    "RoB (domain 1: metric 1)": "{\"sortValue\": 14, \"display\": \"Definitely high risk of bias\"}",
+    "Overall study confidence": "{\"sortValue\": 16, \"display\": \"Probably low risk of bias\"}"
   },
   {
     "study id": 7,
@@ -646,7 +646,7 @@
     "percent affected": null,
     "percent lower ci": null,
     "percent upper ci": null,
-    "RoB (domain 1: metric 1)": "{\"sortValue\": -1, \"display\": \"N/A\"}",
-    "Overall study confidence": "{\"sortValue\": -1, \"display\": \"N/A\"}"
+    "RoB (domain 1: metric 1)": "{\"sortValue\": 14, \"display\": \"Definitely high risk of bias\"}",
+    "Overall study confidence": "{\"sortValue\": 16, \"display\": \"Probably low risk of bias\"}"
   }
 ]

--- a/tests/data/api/api-dp-data-animal-bioassay-endpoint.json
+++ b/tests/data/api/api-dp-data-animal-bioassay-endpoint.json
@@ -54,8 +54,8 @@
     "Significant 3": "No",
     "Significant 4": "No",
     "Significant 5": "Yes - \u2193",
-    "RoB (domain 1: metric 1)": "{\"sortValue\": -1, \"display\": \"N/A\"}",
-    "Overall study confidence": "{\"sortValue\": -1, \"display\": \"N/A\"}"
+    "RoB (domain 1: metric 1)": "{\"sortValue\": 14, \"display\": \"Definitely high risk of bias\"}",
+    "Overall study confidence": "{\"sortValue\": 16, \"display\": \"Probably low risk of bias\"}"
   },
   {
     "study id": 7,
@@ -112,7 +112,7 @@
     "Significant 3": "No",
     "Significant 4": "No",
     "Significant 5": "No",
-    "RoB (domain 1: metric 1)": "{\"sortValue\": -1, \"display\": \"N/A\"}",
-    "Overall study confidence": "{\"sortValue\": -1, \"display\": \"N/A\"}"
+    "RoB (domain 1: metric 1)": "{\"sortValue\": 14, \"display\": \"Definitely high risk of bias\"}",
+    "Overall study confidence": "{\"sortValue\": 16, \"display\": \"Probably low risk of bias\"}"
   }
 ]


### PR DESCRIPTION
`distinct` wasn't working since the studies weren't ordered by id, so there was a chance non-unique study ids were being sent to `get_dp_export`

This was causing a problem [here](https://github.com/shapiromatron/hawc/blob/62e253f33c530b012e1507d8ec0b578ec005323f/hawc/apps/riskofbias/models.py#L358), since the json dump would already exist in the mapping, so the default N/A value was being used.