### PR TITLE
Dropdown button template

### DIFF
--- a/hawc/apps/common/templates/common/dropdown_button.html
+++ b/hawc/apps/common/templates/common/dropdown_button.html
@@ -1,0 +1,16 @@
+{% if elements %}
+    <div class="dropdown btn-group float-right">
+        <a class="btn btn-primary dropdown-toggle" data-toggle="dropdown">Actions</a>
+        <div class="dropdown-menu dropdown-menu-right">
+            {% for element in elements %}
+                {% if element.type == "header" %}
+                    <h6 class="dropdown-header">{{element.inner}}</h6>
+                {% elif element.type == "item" %}
+                    <a class="dropdown-item" href="{{element.href}}">{{element.inner}}</a>
+                {% elif element.type == "divider" %}
+                    <div class="dropdown-divider"></div>
+                {% endif %}
+            {% endfor %}
+        </div>
+    </div>
+{% endif %}

--- a/hawc/apps/common/templatetags/dropdown_button.py
+++ b/hawc/apps/common/templatetags/dropdown_button.py
@@ -1,0 +1,33 @@
+from django import template
+
+register = template.Library()
+
+
+@register.inclusion_tag("common/dropdown_button.html")
+def dropdown_button(*args):
+    """
+    List of arguments to build dropdown button from. Correct types and properties must be given or else nothing is rendered.
+
+    Format:
+    {% dropdown_button type [inner] [href] ... %}
+
+    Example:
+    {% dropdown_button "header" "Header name" "item" "Item name" "www.example.com" "divider" %}
+    """
+    index = 0
+    elements = []
+    try:
+        while index < len(args):
+            element = {"type": args[index]}
+            if element["type"] == "header":
+                element["inner"] = args[index + 1]
+            elif element["type"] == "item":
+                element["inner"] = args[index + 1]
+                element["href"] = args[index + 1]
+            elif element["type"] != "divider":
+                return []
+            index += len(element)
+            elements.append(element)
+        return {"elements": elements}
+    except IndexError:
+        return []


### PR DESCRIPTION
@shapiromatron An idea of how to use a common dropdown button all within templates.

Current implementation:

`{% dropdown_button "header" "Header name" "item" "Item name" "www.example.com" "divider" %}`

This ordered list of arguments may be too difficult; maybe instead we could do something like this:
```
{% dropdown_element type="header" inner="Assessment Editing" as header1 %}
{% dropdown_element type="item" inner="New Assessment" href="/create_assessment.html" as item1 %}
{% dropdown_button header1 item1 %}
```
What do you think?