### PR TITLE
Fix django-selectable render problems

### DIFF
--- a/hawc/apps/animal/forms.py
+++ b/hawc/apps/animal/forms.py
@@ -8,10 +8,10 @@ from django.db.models import Q
 from django.forms import ModelForm
 from django.forms.models import BaseModelFormSet, modelformset_factory
 from django.urls import reverse
-from selectable import forms as selectable
 
 from ..assessment.lookups import DssToxIdLookup, EffectTagLookup, SpeciesLookup, StrainLookup
 from ..assessment.models import DoseUnits
+from ..common import selectable
 from ..common.forms import BaseFormHelper, CopyAsNewSelectorForm
 from ..study.lookups import AnimalStudyLookup
 from ..vocab.models import VocabularyNamespace

--- a/hawc/apps/assessment/forms.py
+++ b/hawc/apps/assessment/forms.py
@@ -11,7 +11,8 @@ from selectable.forms import AutoCompleteWidget
 
 from hawc.services.epa.dsstox import DssSubstance
 
-from ..common.forms import AutoCompleteSelectMultipleWidget, BaseFormHelper
+from ..common.forms import BaseFormHelper
+from ..common.selectable import AutoCompleteSelectMultipleWidget
 from ..myuser.lookups import HAWCUserLookup
 from . import lookups, models
 

--- a/hawc/apps/assessment/forms.py
+++ b/hawc/apps/assessment/forms.py
@@ -7,11 +7,11 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.mail import mail_admins
 from django.db import transaction
 from django.urls import reverse, reverse_lazy
-from selectable.forms import AutoCompleteSelectMultipleWidget, AutoCompleteWidget
+from selectable.forms import AutoCompleteWidget
 
 from hawc.services.epa.dsstox import DssSubstance
 
-from ..common.forms import BaseFormHelper
+from ..common.forms import AutoCompleteSelectMultipleWidget, BaseFormHelper
 from ..myuser.lookups import HAWCUserLookup
 from . import lookups, models
 

--- a/hawc/apps/assessment/forms.py
+++ b/hawc/apps/assessment/forms.py
@@ -7,12 +7,11 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.mail import mail_admins
 from django.db import transaction
 from django.urls import reverse, reverse_lazy
-from selectable.forms import AutoCompleteWidget
 
 from hawc.services.epa.dsstox import DssSubstance
 
 from ..common.forms import BaseFormHelper
-from ..common.selectable import AutoCompleteSelectMultipleWidget
+from ..common.selectable import AutoCompleteSelectMultipleWidget, AutoCompleteWidget
 from ..myuser.lookups import HAWCUserLookup
 from . import lookups, models
 

--- a/hawc/apps/common/forms.py
+++ b/hawc/apps/common/forms.py
@@ -25,7 +25,7 @@ class SelectableBootstrapMediaMixin(SelectableMediaMixin):
         css = SelectableMediaMixin.Media.css
         js = (
             *SelectableMediaMixin.Media.js,
-            str(settings.PROJECT_PATH / "static/js/selectable_bootstrap.js"),
+            settings.STATIC_URL + "js/selectable_bootstrap.js",
         )
 
 

--- a/hawc/apps/common/forms.py
+++ b/hawc/apps/common/forms.py
@@ -1,6 +1,5 @@
 from typing import Any, List, Tuple, Union
 
-import selectable.forms as selectable
 from crispy_forms import bootstrap as cfb
 from crispy_forms import helper as cf
 from crispy_forms import layout as cfl
@@ -8,7 +7,8 @@ from crispy_forms.utils import TEMPLATE_PACK, flatatt
 from django import forms
 from django.conf import settings
 from django.template.loader import render_to_string
-from selectable.forms.widgets import SelectableMediaMixin
+from selectable import forms as selectable
+from selectable.forms.widgets import SelectableMediaMixin, SelectableMultiWidget
 
 from . import validators
 
@@ -29,26 +29,10 @@ class SelectableBootstrapMediaMixin(SelectableMediaMixin):
         )
 
 
-class AutoCompleteWidget(selectable.AutoCompleteWidget, SelectableBootstrapMediaMixin):
-    pass
-
-
-class AutoCompleteSelectWidget(selectable.AutoCompleteSelectWidget, SelectableBootstrapMediaMixin):
-    primary_widget = AutoCompleteWidget
-
-
 class AutoCompleteSelectMultipleWidget(
     selectable.AutoCompleteSelectMultipleWidget, SelectableBootstrapMediaMixin
 ):
-    primary_widget = AutoCompleteWidget
-
-
-class AutoCompleteSelectField(selectable.AutoCompleteSelectField):
-    widget = AutoCompleteSelectWidget
-
-
-class AutoCompleteSelectMultipleField(selectable.AutoCompleteSelectMultipleField):
-    widget = AutoCompleteSelectMultipleWidget
+    pass
 
 
 class BaseFormHelper(cf.FormHelper):
@@ -146,7 +130,7 @@ class CopyAsNewSelectorForm(forms.Form):
         return BaseFormHelper(self)
 
     def setupSelector(self, parent_id):
-        fld = AutoCompleteSelectField(
+        fld = selectable.AutoCompleteSelectField(
             lookup_class=self.lookup_class,
             allow_new=False,
             label=self.label,

--- a/hawc/apps/common/forms.py
+++ b/hawc/apps/common/forms.py
@@ -1,5 +1,6 @@
 from typing import Any, List, Tuple, Union
 
+import selectable.forms as selectable
 from crispy_forms import bootstrap as cfb
 from crispy_forms import helper as cf
 from crispy_forms import layout as cfl
@@ -7,8 +8,7 @@ from crispy_forms.utils import TEMPLATE_PACK, flatatt
 from django import forms
 from django.conf import settings
 from django.template.loader import render_to_string
-from selectable import forms as selectable
-from selectable.forms.widgets import SelectableMediaMixin, SelectableMultiWidget
+from selectable.forms.widgets import SelectableMediaMixin
 
 from . import validators
 
@@ -29,10 +29,26 @@ class SelectableBootstrapMediaMixin(SelectableMediaMixin):
         )
 
 
+class AutoCompleteWidget(selectable.AutoCompleteWidget, SelectableBootstrapMediaMixin):
+    pass
+
+
+class AutoCompleteSelectWidget(selectable.AutoCompleteSelectWidget, SelectableBootstrapMediaMixin):
+    primary_widget = AutoCompleteWidget
+
+
 class AutoCompleteSelectMultipleWidget(
     selectable.AutoCompleteSelectMultipleWidget, SelectableBootstrapMediaMixin
 ):
-    pass
+    primary_widget = AutoCompleteWidget
+
+
+class AutoCompleteSelectField(selectable.AutoCompleteSelectField):
+    widget = AutoCompleteSelectWidget
+
+
+class AutoCompleteSelectMultipleField(selectable.AutoCompleteSelectMultipleField):
+    widget = AutoCompleteSelectMultipleWidget
 
 
 class BaseFormHelper(cf.FormHelper):
@@ -130,7 +146,7 @@ class CopyAsNewSelectorForm(forms.Form):
         return BaseFormHelper(self)
 
     def setupSelector(self, parent_id):
-        fld = selectable.AutoCompleteSelectField(
+        fld = AutoCompleteSelectField(
             lookup_class=self.lookup_class,
             allow_new=False,
             label=self.label,

--- a/hawc/apps/common/forms.py
+++ b/hawc/apps/common/forms.py
@@ -5,8 +5,10 @@ from crispy_forms import helper as cf
 from crispy_forms import layout as cfl
 from crispy_forms.utils import TEMPLATE_PACK, flatatt
 from django import forms
+from django.conf import settings
 from django.template.loader import render_to_string
 from selectable import forms as selectable
+from selectable.forms.widgets import SelectableMediaMixin, SelectableMultiWidget
 
 from . import validators
 
@@ -16,6 +18,21 @@ def build_form_actions(cancel_url: str, save_text: str = "Save", cancel_text: st
         cfl.Submit("save", save_text),
         cfl.HTML(f'<a role="button" class="btn btn-light" href="{cancel_url}">{cancel_text}</a>'),
     ]
+
+
+class SelectableBootstrapMediaMixin(SelectableMediaMixin):
+    class Media:
+        css = SelectableMediaMixin.Media.css
+        js = (
+            *SelectableMediaMixin.Media.js,
+            str(settings.PROJECT_PATH / "static/js/selectable_bootstrap.js"),
+        )
+
+
+class AutoCompleteSelectMultipleWidget(
+    selectable.AutoCompleteSelectMultipleWidget, SelectableBootstrapMediaMixin
+):
+    pass
 
 
 class BaseFormHelper(cf.FormHelper):

--- a/hawc/apps/common/forms.py
+++ b/hawc/apps/common/forms.py
@@ -5,12 +5,9 @@ from crispy_forms import helper as cf
 from crispy_forms import layout as cfl
 from crispy_forms.utils import TEMPLATE_PACK, flatatt
 from django import forms
-from django.conf import settings
 from django.template.loader import render_to_string
-from selectable import forms as selectable
-from selectable.forms.widgets import SelectableMediaMixin, SelectableMultiWidget
 
-from . import validators
+from . import selectable, validators
 
 
 def build_form_actions(cancel_url: str, save_text: str = "Save", cancel_text: str = "Cancel"):
@@ -18,21 +15,6 @@ def build_form_actions(cancel_url: str, save_text: str = "Save", cancel_text: st
         cfl.Submit("save", save_text),
         cfl.HTML(f'<a role="button" class="btn btn-light" href="{cancel_url}">{cancel_text}</a>'),
     ]
-
-
-class SelectableBootstrapMediaMixin(SelectableMediaMixin):
-    class Media:
-        css = SelectableMediaMixin.Media.css
-        js = (
-            *SelectableMediaMixin.Media.js,
-            settings.STATIC_URL + "js/selectable_bootstrap.js",
-        )
-
-
-class AutoCompleteSelectMultipleWidget(
-    selectable.AutoCompleteSelectMultipleWidget, SelectableBootstrapMediaMixin
-):
-    pass
 
 
 class BaseFormHelper(cf.FormHelper):

--- a/hawc/apps/common/selectable.py
+++ b/hawc/apps/common/selectable.py
@@ -4,6 +4,6 @@ from selectable.forms.widgets import SelectableMediaMixin
 
 SelectableMediaMixin.Media.js = (
     *SelectableMediaMixin.Media.js,
-    str(settings.PROJECT_PATH / "static/js/selectable_bootstrap.js"),
+    settings.STATIC_URL + "js/selectable_bootstrap.js",
 )
 

--- a/hawc/apps/common/selectable.py
+++ b/hawc/apps/common/selectable.py
@@ -1,0 +1,9 @@
+from django.conf import settings
+from selectable.forms import *  # noqa
+from selectable.forms.widgets import SelectableMediaMixin
+
+SelectableMediaMixin.Media.js = (
+    *SelectableMediaMixin.Media.js,
+    str(settings.PROJECT_PATH / "static/js/selectable_bootstrap.js"),
+)
+

--- a/hawc/apps/common/selectable.py
+++ b/hawc/apps/common/selectable.py
@@ -6,4 +6,3 @@ SelectableMediaMixin.Media.js = (
     *SelectableMediaMixin.Media.js,
     settings.STATIC_URL + "js/selectable_bootstrap.js",
 )
-

--- a/hawc/apps/epi/forms.py
+++ b/hawc/apps/epi/forms.py
@@ -5,9 +5,9 @@ from django import forms
 from django.db.models import Q
 from django.forms.models import BaseModelFormSet, modelformset_factory
 from django.urls import reverse
-from selectable import forms as selectable
 
 from ..assessment.lookups import BaseEndpointLookup, DssToxIdLookup, EffectTagLookup
+from ..common import selectable
 from ..common.forms import BaseFormHelper, CopyAsNewSelectorForm
 from ..common.helper import tryParseInt
 from ..study.lookups import EpiStudyLookup

--- a/hawc/apps/epimeta/forms.py
+++ b/hawc/apps/epimeta/forms.py
@@ -5,8 +5,8 @@ from django import forms
 from django.db.models import Q
 from django.forms.models import modelformset_factory
 from django.urls import reverse
-from selectable import forms as selectable
 
+from ..common import selectable
 from ..common.forms import BaseFormHelper, CopyAsNewSelectorForm
 from ..epi.lookups import AdjustmentFactorLookup, CriteriaLookup
 from ..study.lookups import EpimetaStudyLookup

--- a/hawc/apps/invitro/forms.py
+++ b/hawc/apps/invitro/forms.py
@@ -6,10 +6,10 @@ from django.db.models import Q
 from django.forms.models import BaseModelFormSet, inlineformset_factory, modelformset_factory
 from django.forms.widgets import Select
 from django.urls import reverse
-from selectable import forms as selectable
 
 from ..assessment.lookups import DssToxIdLookup, EffectTagLookup
 from ..assessment.models import DoseUnits
+from ..common import selectable
 from ..common.forms import BaseFormHelper
 from ..study.lookups import InvitroStudyLookup
 from . import lookups, models

--- a/hawc/apps/myuser/forms.py
+++ b/hawc/apps/myuser/forms.py
@@ -9,10 +9,10 @@ from django.contrib.auth.forms import (
 )
 from django.forms import ModelForm
 from django.urls import reverse
-from selectable.forms import AutoCompleteSelectMultipleField
 
 from ..assessment import lookups
 from ..common.forms import BaseFormHelper
+from ..common.selectable import AutoCompleteSelectMultipleField
 from . import models
 
 _PASSWORD_HELP = (

--- a/hawc/apps/riskofbias/forms.py
+++ b/hawc/apps/riskofbias/forms.py
@@ -3,9 +3,9 @@ from django import forms
 from django.core.exceptions import ObjectDoesNotExist
 from django.forms.models import BaseModelFormSet, modelformset_factory
 from django.urls import reverse
-from selectable import forms as selectable
 
 from ..assessment.models import Assessment
+from ..common import selectable
 from ..common.forms import BaseFormHelper
 from ..myuser.lookups import AssessmentTeamMemberOrHigherLookup
 from ..study.models import Study

--- a/hawc/apps/summary/forms.py
+++ b/hawc/apps/summary/forms.py
@@ -7,11 +7,11 @@ from django import forms
 from django.urls import reverse
 from openpyxl import load_workbook
 from openpyxl.utils.exceptions import InvalidFileException
-from selectable import forms as selectable
 
 from ..animal.lookups import EndpointByAssessmentLookup, EndpointByAssessmentLookupHtml
 from ..animal.models import Endpoint
 from ..assessment.models import EffectTag
+from ..common import selectable
 from ..common.forms import BaseFormHelper
 from ..common.helper import read_excel
 from ..epi.models import Outcome

--- a/hawc/static/js/selectable_bootstrap.js
+++ b/hawc/static/js/selectable_bootstrap.js
@@ -1,6 +1,6 @@
 $.ui.djselectable.prototype.options.defaultClasses = {
-  text: "form-control",
-  combobox: "form-control",
+  text: "form-control mb-2",
+  combobox: "form-control mb-2",
 };
 (function () {
   let _create = $.ui.menu.prototype._create;

--- a/hawc/static/js/selectable_bootstrap.js
+++ b/hawc/static/js/selectable_bootstrap.js
@@ -1,0 +1,17 @@
+$.ui.djselectable.prototype.options.defaultClasses = {
+  text: "form-control",
+  combobox: "form-control",
+};
+(function () {
+  let _create = $.ui.menu.prototype._create;
+  $.ui.menu.prototype._create = function () {
+    _create.apply(this);
+    $(this.element).removeClass("ui-widget");
+  };
+
+  let _initDeck = $.ui.djselectable.prototype._initDeck;
+  $.ui.djselectable.prototype._initDeck = function () {
+    _initDeck.apply(this);
+    this.deck.removeClass("ui-widget");
+  };
+})();

--- a/hawc/templates/base.html
+++ b/hawc/templates/base.html
@@ -65,15 +65,15 @@
     {% if debug %}
     <script type="text/javascript" src="{% static 'debug/jquery/3.5.1/jquery.js' %}"></script>
     <script type="text/javascript" src="{% static 'debug/jquery-migrate/3.3.1/jquery-migrate.js' %}"></script>
-    <script type="text/javascript" src="{% static 'debug/jqueryui/1.10.3/jquery-ui.js' %}"></script>
     <script type="text/javascript" src="{% static 'debug/popper.js/1.16.1/umd/popper.js' %}"></script>
     <script type="text/javascript" src="{% static 'debug/twitter-bootstrap/4.5.2/js/bootstrap.js' %}"></script>
+    <script type="text/javascript" src="{% static 'debug/jqueryui/1.10.3/jquery-ui.js' %}"></script>
     {% else %}
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery-migrate/3.3.1/jquery-migrate.min.js"></script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.16.1/umd/popper.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.10.3/jquery-ui.min.js"></script>
       {% block google_analytics %}
         <script>
           (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
Changed the order of script imports so that conflicting namespaces don't cause django-selectable buttons to not render. Also added custom scripting to render the selectable inputs using bootstrap stylings.
Reference: https://django-selectable.readthedocs.io/en/latest/advanced.html#using-with-twitter-bootstrap