### PR TITLE
Sticky navbar

### DIFF
--- a/hawc/templates/includes/navigation.html
+++ b/hawc/templates/includes/navigation.html
@@ -1,7 +1,7 @@
 {% load static %}
 
 {% block navbar_outer %}
-<nav class="navbar navbar-expand-lg navbar-light bg-light">
+<nav class="navbar navbar-expand-lg navbar-light bg-light sticky-top">
 
     <a class="navbar-brand" href="{% if user.is_authenticated %}{% url 'portal' %}{% else %}{% url 'home' %}{% endif %}">
         <img src="{% static 'img/HAWC-40.png' %}">


### PR DESCRIPTION
Makes the navbar stick to top when scrolling, allows for easier integration tests.