### PR TITLE
sanitize referrer

### DIFF
--- a/hawc/apps/assessment/views.py
+++ b/hawc/apps/assessment/views.py
@@ -29,6 +29,7 @@ from ..common.views import (
     TeamMemberOrHigherMixin,
     TimeSpentOnPageMixin,
     beta_tester_required,
+    get_referrer,
 )
 from . import forms, models, serializers, tasks
 
@@ -201,8 +202,7 @@ class Contact(LoginRequiredMixin, MessageMixin, FormView):
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         kwargs.update(
-            back_href=self.request.META.get("HTTP_REFERER", reverse("portal")),
-            user=self.request.user,
+            back_href=get_referrer(self.request, reverse("portal")), user=self.request.user,
         )
         return kwargs
 
@@ -314,7 +314,7 @@ class AssessmentClearCache(MessageMixin, View):
 
     def get(self, request, *args, **kwargs):
         assessment = get_object_or_404(self.model, pk=kwargs["pk"])
-        url = self.request.META.get("HTTP_REFERER", assessment.get_absolute_url())
+        url = get_referrer(self.request, assessment.get_absolute_url())
         if not assessment.user_can_edit_object(request.user):
             raise PermissionDenied()
 
@@ -577,7 +577,7 @@ class DownloadPlot(FormView):
         # grab input values and create converter object
         extension = request.POST.get("output", None)
         svg = request.POST["svg"]
-        url = request.META["HTTP_REFERER"]
+        url = get_referrer(request, "/<unknown>/")
         width = int(float(request.POST["width"]) * 5)
         height = int(float(request.POST["height"]) * 5)
 

--- a/hawc/apps/common/views.py
+++ b/hawc/apps/common/views.py
@@ -1,14 +1,15 @@
 import abc
 import logging
+from urllib.parse import urlparse
 
 from django.contrib import messages
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.decorators import login_required, user_passes_test
 from django.core.exceptions import EmptyResultSet, PermissionDenied
 from django.forms.models import model_to_dict
-from django.http import HttpResponseRedirect
+from django.http import HttpRequest, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
-from django.urls import reverse
+from django.urls import Resolver404, resolve, reverse
 from django.utils.decorators import method_decorator
 from django.views.generic import DetailView, ListView
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
@@ -30,6 +31,28 @@ def beta_tester_required(function=None, redirect_field_name=REDIRECT_FIELD_NAME,
     if function:
         return actual_decorator(function)
     return actual_decorator
+
+
+def get_referrer(request: HttpRequest, default: str) -> str:
+    """Return the `referer` [sic] attribute if it's a valid HAWC site, otherwise use default.
+
+    `Referer` [sic] header could be malicious or may include injected code. Only return the
+    value if the path can be resolved in HAWC.
+
+    Args:
+        request (HttpRequest): the http request
+
+    Returns:
+        str: A valid URL
+    """
+    url = request.META.get("HTTP_REFERER")
+    if url is None:
+        return default
+    try:
+        _ = resolve(urlparse(url).path)
+        return url
+    except Resolver404:
+        return default
 
 
 class MessageMixin:

--- a/hawc/apps/riskofbias/views.py
+++ b/hawc/apps/riskofbias/views.py
@@ -20,6 +20,7 @@ from ..common.views import (
     ProjectManagerOrHigherMixin,
     TeamMemberOrHigherMixin,
     TimeSpentOnPageMixin,
+    get_referrer,
 )
 from ..study.models import Study
 from . import forms, models
@@ -286,11 +287,7 @@ class RoBEdit(TimeSpentOnPageMixin, BaseDetail):
         context["config"] = json.dumps(
             {
                 "assessment_id": self.assessment.id,
-                "cancelUrl": (
-                    self.request.META["HTTP_REFERER"]
-                    if "HTTP_REFERER" in self.request.META
-                    else self.object.get_absolute_url()
-                ),
+                "cancelUrl": get_referrer(request, self.object.get_absolute_url()),
                 "csrf": get_token(self.request),
                 "host": f"//{self.request.get_host()}",
                 "hawc_flavor": settings.HAWC_FLAVOR,

--- a/hawc/apps/riskofbias/views.py
+++ b/hawc/apps/riskofbias/views.py
@@ -287,7 +287,7 @@ class RoBEdit(TimeSpentOnPageMixin, BaseDetail):
         context["config"] = json.dumps(
             {
                 "assessment_id": self.assessment.id,
-                "cancelUrl": get_referrer(request, self.object.get_absolute_url()),
+                "cancelUrl": get_referrer(self.request, self.object.get_absolute_url()),
                 "csrf": get_token(self.request),
                 "host": f"//{self.request.get_host()}",
                 "hawc_flavor": settings.HAWC_FLAVOR,

--- a/hawc/apps/vocab/views.py
+++ b/hawc/apps/vocab/views.py
@@ -8,7 +8,7 @@ from django.utils.decorators import method_decorator
 from django.views.generic import ListView, TemplateView
 from django.views.generic.edit import CreateView
 
-from ..common.views import MessageMixin
+from ..common.views import MessageMixin, get_referrer
 from . import forms, models
 
 
@@ -42,7 +42,7 @@ class CreateComment(MessageMixin, CreateView):
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
-        kwargs.update(last_url_visited=self.request.META.get("HTTP_REFERER", reverse("portal")))
+        kwargs.update(last_url_visited=get_referrer(self.request, reverse("portal")))
         return kwargs
 
     def form_valid(self, form):

--- a/tests/hawc/apps/common/test_common_views.py
+++ b/tests/hawc/apps/common/test_common_views.py
@@ -1,0 +1,18 @@
+from django.test import RequestFactory
+from django.urls import reverse
+
+from hawc.apps.common.views import get_referrer
+
+
+def test_get_referrer():
+    about_url = "https://example.com" + reverse("about")
+    portal_url = "https://example.com" + reverse("portal")
+    factory = RequestFactory()
+
+    # url should resolve and will pass-through
+    request = factory.get("/", HTTP_REFERER=about_url)
+    assert get_referrer(request, portal_url) == about_url
+
+    # url doesn't resolve; should return default
+    request = factory.get("/", HTTP_REFERER=about_url + '"onmouseover="alert(26)"')
+    assert get_referrer(request, portal_url) == portal_url


### PR DESCRIPTION
Make sure the referrer url can be resolved in the hawc namespace, otherwise return the default