### PR TITLE
literature tag list to clickable badge on study page

### DIFF
--- a/frontend/assets/shared/utils/helpers.js
+++ b/frontend/assets/shared/utils/helpers.js
@@ -243,6 +243,15 @@ const helpers = {
         WHITE: "#ffffff",
         BLUE: "#003d7b",
     },
+    pushUrlParamsState(key, value) {
+        var queryParams = new URLSearchParams(window.location.search);
+        if (_.isNil(value)) {
+            queryParams.delete(key);
+        } else {
+            queryParams.set(key, value);
+        }
+        history.pushState(null, null, "?" + queryParams.toString());
+    },
 };
 
 export default helpers;

--- a/frontend/assets/shared/utils/urls.js
+++ b/frontend/assets/shared/utils/urls.js
@@ -1,0 +1,3 @@
+export const getReferenceTagListUrl = function(assessmentId, tagId) {
+    return `/lit/assessment/${assessmentId}/references/?tag_id=${tagId}`;
+};

--- a/frontend/lit/NestedTag.js
+++ b/frontend/lit/NestedTag.js
@@ -68,6 +68,8 @@ class NestedTag {
                         .map(datum => new Reference(datum, this.tree))
                         .filter(ref => expected_references.has(ref.data.pk));
 
+                refs = Reference.sorted(refs);
+
                 ReactDOM.render(<ReferenceTable references={refs} showActions={false} />, el);
             } else {
                 ReactDOM.render(<GenericError />, el);

--- a/frontend/lit/Reference.js
+++ b/frontend/lit/Reference.js
@@ -18,6 +18,13 @@ class Reference {
         }
     }
 
+    static sorted(references) {
+        return _.chain(references)
+            .sortBy(d => d.data.year)
+            .reverse()
+            .value();
+    }
+
     get_edit_url() {
         return `/lit/reference/${this.data.pk}/edit/`;
     }

--- a/frontend/lit/ReferenceTreeBrowse/Main.js
+++ b/frontend/lit/ReferenceTreeBrowse/Main.js
@@ -24,7 +24,7 @@ class ReferenceTreeMain extends Component {
     render() {
         const {store} = this.props,
             actions = store.getActionLinks,
-            {selectedReferences, selectedReferencesLoading} = store,
+            {selectedReferences, selectedReferencesLoading, filteredReferences} = store,
             {canEdit} = store.config;
 
         return (
@@ -61,9 +61,16 @@ class ReferenceTreeMain extends Component {
                     {selectedReferencesLoading ? <Loading /> : null}
                     {selectedReferences && selectedReferences.length > 0 ? (
                         <>
-                            <YearHistogram references={selectedReferences} />
-                            <div id="reference-list" className="list-group">
-                                {selectedReferences.map(referenceListItem)}
+                            <YearHistogram
+                                references={selectedReferences}
+                                yearFilter={store.yearFilter}
+                                onFilter={store.updateYearFilter}
+                            />
+                            <div
+                                id="reference-list"
+                                className="list-group"
+                                style={{maxHeight: "50vh"}}>
+                                {filteredReferences.map(referenceListItem)}
                             </div>
                         </>
                     ) : null}
@@ -77,7 +84,7 @@ class ReferenceTreeMain extends Component {
                             </p>
                         ) : null}
                         {selectedReferences ? (
-                            <ReferenceTable references={selectedReferences} showActions={canEdit} />
+                            <ReferenceTable references={filteredReferences} showActions={canEdit} />
                         ) : null}
                     </div>
                 </div>

--- a/frontend/lit/ReferenceTreeBrowse/Main.js
+++ b/frontend/lit/ReferenceTreeBrowse/Main.js
@@ -50,7 +50,9 @@ class ReferenceTreeMain extends Component {
                         <h3>Available references</h3>
                     ) : (
                         <h3>
-                            References tagged:
+                            {selectedReferences && selectedReferences.length > 0
+                                ? `${selectedReferences.length} references tagged:`
+                                : "References tagged:"}
                             <span className="ml-2 refTag">{store.selectedTag.get_full_name()}</span>
                         </h3>
                     )}

--- a/frontend/lit/ReferenceTreeBrowse/Main.js
+++ b/frontend/lit/ReferenceTreeBrowse/Main.js
@@ -5,8 +5,16 @@ import {toJS} from "mobx";
 
 import ReferenceTable from "../components/ReferenceTable";
 import TagTree from "../components/TagTree";
+import YearHistogram from "./YearHistogram";
 import Loading from "shared/components/Loading";
 
+const referenceListItem = ref => {
+    return (
+        <a key={ref.data.pk} className="list-group-item" href={`#referenceId${ref.data.pk}`}>
+            {ref.shortCitation()}
+        </a>
+    );
+};
 @inject("store")
 @observer
 class ReferenceTreeMain extends Component {
@@ -21,23 +29,7 @@ class ReferenceTreeMain extends Component {
 
         return (
             <div className="row">
-                <div className="col-md-3">
-                    <h3>Taglist</h3>
-                    <TagTree
-                        tagtree={toJS(store.tagtree)}
-                        handleTagClick={tag => store.handleTagClick(tag)}
-                        showReferenceCount={true}
-                        selectedTag={store.selectedTag}
-                    />
-                    <br />
-                    <p
-                        className="nestedTag"
-                        id="untaggedReferences"
-                        onClick={() => store.handleUntaggedReferenceClick(null)}>
-                        Untagged References: ({store.config.untaggedReferenceCount})
-                    </p>
-                </div>
-                <div className="col-md-9">
+                <div className="col-md-12 pb-2">
                     {actions.length > 0 ? (
                         <div className="dropdown btn-group float-right">
                             <a className="btn btn-primary dropdown-toggle" data-toggle="dropdown">
@@ -52,19 +44,30 @@ class ReferenceTreeMain extends Component {
                             </div>
                         </div>
                     ) : null}
-
+                    {store.untaggedReferencesSelected === true ? (
+                        <h3>Untagged references</h3>
+                    ) : store.selectedTag === null ? (
+                        <h3>Available references</h3>
+                    ) : (
+                        <h3>
+                            References tagged:
+                            <span className="ml-2 refTag">{store.selectedTag.get_full_name()}</span>
+                        </h3>
+                    )}
+                </div>
+                <div className="col-md-3">
+                    {selectedReferencesLoading ? <Loading /> : null}
+                    {selectedReferences && selectedReferences.length > 0 ? (
+                        <>
+                            <YearHistogram references={selectedReferences} />
+                            <div id="reference-list" className="list-group">
+                                {selectedReferences.map(referenceListItem)}
+                            </div>
+                        </>
+                    ) : null}
+                </div>
+                <div className="col-md-6">
                     <div id="references_detail_div">
-                        {store.untaggedReferencesSelected === true ? (
-                            <h3>Untagged references</h3>
-                        ) : store.selectedTag === null ? (
-                            <h3>Available references</h3>
-                        ) : (
-                            <h3>
-                                References tagged:&nbsp;
-                                <span className="refTag">{store.selectedTag.get_full_name()}</span>
-                            </h3>
-                        )}
-                        {selectedReferencesLoading ? <Loading /> : null}
                         {store.selectedTag === null &&
                         store.untaggedReferencesSelected === false ? (
                             <p className="form-text text-muted">
@@ -75,6 +78,21 @@ class ReferenceTreeMain extends Component {
                             <ReferenceTable references={selectedReferences} showActions={canEdit} />
                         ) : null}
                     </div>
+                </div>
+                <div className="col-md-3">
+                    <TagTree
+                        tagtree={toJS(store.tagtree)}
+                        handleTagClick={tag => store.handleTagClick(tag)}
+                        showReferenceCount={true}
+                        selectedTag={store.selectedTag}
+                    />
+                    <br />
+                    <p
+                        className="nestedTag"
+                        id="untaggedReferences"
+                        onClick={() => store.handleUntaggedReferenceClick(null)}>
+                        Untagged References: ({store.config.untaggedReferenceCount})
+                    </p>
                 </div>
             </div>
         );

--- a/frontend/lit/ReferenceTreeBrowse/Main.js
+++ b/frontend/lit/ReferenceTreeBrowse/Main.js
@@ -10,6 +10,9 @@ import Loading from "shared/components/Loading";
 @inject("store")
 @observer
 class ReferenceTreeMain extends Component {
+    componentDidMount() {
+        this.props.store.tryLoadTag();
+    }
     render() {
         const {store} = this.props,
             actions = store.getActionLinks,
@@ -24,6 +27,7 @@ class ReferenceTreeMain extends Component {
                         tagtree={toJS(store.tagtree)}
                         handleTagClick={tag => store.handleTagClick(tag)}
                         showReferenceCount={true}
+                        selectedTag={store.selectedTag}
                     />
                     <br />
                     <p

--- a/frontend/lit/ReferenceTreeBrowse/YearHistogram.js
+++ b/frontend/lit/ReferenceTreeBrowse/YearHistogram.js
@@ -1,0 +1,77 @@
+import _ from "lodash";
+import React, {Component} from "react";
+import PropTypes from "prop-types";
+import Plot from "react-plotly.js";
+
+// adapted from /lit/api/assessment/:id/reference-year-histogram/
+const dataTemplate = {
+        hovertemplate: "Year=%{x}<br>count=%{y}",
+        marker: {
+            color: "#003d7b",
+        },
+        x: [],
+        name: "",
+        orientation: "v",
+        showlegend: false,
+        xaxis: "x",
+        yaxis: "y",
+        type: "histogram",
+    },
+    layoutTemplate = {
+        xaxis: {
+            title: {
+                text: "Year",
+            },
+        },
+        yaxis: {
+            title: {
+                text: "# References",
+            },
+        },
+        legend: {
+            tracegroupgap: 0,
+        },
+        margin: {
+            t: 30,
+            l: 40,
+            r: 10,
+            b: 40,
+        },
+        barmode: "relative",
+        bargap: 0.1,
+        plot_bgcolor: "white",
+        autosize: true,
+    };
+
+class YearHistogram extends Component {
+    render() {
+        const {references} = this.props,
+            years = _.chain(references)
+                .map(d => d.data.year)
+                .compact()
+                .value();
+
+        if (years.length < 10) {
+            return null;
+        }
+
+        let data = _.cloneDeep(dataTemplate),
+            layout = _.cloneDeep(layoutTemplate);
+
+        data.x = years;
+
+        return (
+            <Plot
+                data={[data]}
+                layout={layout}
+                useResizeHandler={true}
+                style={{width: "100%", height: 300}}
+            />
+        );
+    }
+}
+YearHistogram.propTypes = {
+    references: PropTypes.array,
+};
+
+export default YearHistogram;

--- a/frontend/lit/ReferenceTreeBrowse/YearHistogram.js
+++ b/frontend/lit/ReferenceTreeBrowse/YearHistogram.js
@@ -65,7 +65,7 @@ class YearHistogram extends Component {
                 data={[data]}
                 layout={layout}
                 useResizeHandler={true}
-                style={{width: "100%", height: 300}}
+                style={{width: "100%", height: 180}}
             />
         );
     }

--- a/frontend/lit/ReferenceTreeBrowse/YearHistogram.js
+++ b/frontend/lit/ReferenceTreeBrowse/YearHistogram.js
@@ -42,11 +42,25 @@ const dataTemplate = {
         bargap: 0.1,
         plot_bgcolor: "white",
         autosize: true,
+    },
+    config = {
+        modeBarButtonsToRemove: [
+            "zoom2d",
+            "pan2d",
+            "select2d",
+            "lasso2d",
+            "zoomIn2d",
+            "zoomOut2d",
+            "autoScale2d",
+            "toggleSpikelines",
+            "hoverClosestCartesian",
+            "hoverCompareCartesian",
+        ],
     };
 
 class YearHistogram extends Component {
     render() {
-        const {references, onFilter} = this.props,
+        const {references, onFilter, yearFilter} = this.props,
             years = _.chain(references)
                 .map(d => d.data.year)
                 .compact()
@@ -63,25 +77,32 @@ class YearHistogram extends Component {
 
         return (
             <Plot
+                className="yearHistogram"
                 data={[data]}
                 layout={layout}
+                config={config}
                 useResizeHandler={true}
                 style={{width: "100%", height: 180}}
                 onClick={function(e, d) {
+                    /*
+                    Ideally, the click events could discern if a bar was clicked or the background
+                    is clicked, but that data doesn't appear available. Therefore, we check to see
+                    if the selected item is the same as the current filter, and if it is, we reset.
+                    */
                     let times = [],
                         range;
-                    if (e.points.length > 0) {
-                        e.points.map(point => {
-                            let start =
-                                    point.fullData.xbins.start +
-                                    point.binNumber * point.fullData.xbins.size,
-                                end = start + point.fullData.xbins.size;
-                            times.push(Math.ceil(start), Math.floor(end));
-                        });
-                        range = d3.extent(times);
-                        onFilter({min: range[0], max: range[1]});
-                    } else {
+                    e.points.map(point => {
+                        let start =
+                                point.fullData.xbins.start +
+                                point.binNumber * point.fullData.xbins.size,
+                            end = start + point.fullData.xbins.size;
+                        times.push(Math.ceil(start), Math.floor(end));
+                    });
+                    range = d3.extent(times);
+                    if (yearFilter && yearFilter.min == range[0]) {
                         onFilter(null);
+                    } else {
+                        onFilter({min: range[0], max: range[1]});
                     }
                 }}
             />
@@ -91,6 +112,7 @@ class YearHistogram extends Component {
 YearHistogram.propTypes = {
     references: PropTypes.array,
     onFilter: PropTypes.func,
+    yearFilter: PropTypes.object,
 };
 
 export default YearHistogram;

--- a/frontend/lit/ReferenceTreeBrowse/YearHistogram.js
+++ b/frontend/lit/ReferenceTreeBrowse/YearHistogram.js
@@ -1,3 +1,4 @@
+import * as d3 from "d3";
 import _ from "lodash";
 import React, {Component} from "react";
 import PropTypes from "prop-types";
@@ -45,7 +46,7 @@ const dataTemplate = {
 
 class YearHistogram extends Component {
     render() {
-        const {references} = this.props,
+        const {references, onFilter} = this.props,
             years = _.chain(references)
                 .map(d => d.data.year)
                 .compact()
@@ -66,12 +67,30 @@ class YearHistogram extends Component {
                 layout={layout}
                 useResizeHandler={true}
                 style={{width: "100%", height: 180}}
+                onClick={function(e, d) {
+                    let times = [],
+                        range;
+                    if (e.points.length > 0) {
+                        e.points.map(point => {
+                            let start =
+                                    point.fullData.xbins.start +
+                                    point.binNumber * point.fullData.xbins.size,
+                                end = start + point.fullData.xbins.size;
+                            times.push(Math.ceil(start), Math.floor(end));
+                        });
+                        range = d3.extent(times);
+                        onFilter({min: range[0], max: range[1]});
+                    } else {
+                        onFilter(null);
+                    }
+                }}
             />
         );
     }
 }
 YearHistogram.propTypes = {
     references: PropTypes.array,
+    onFilter: PropTypes.func,
 };
 
 export default YearHistogram;

--- a/frontend/lit/ReferenceTreeBrowse/store.js
+++ b/frontend/lit/ReferenceTreeBrowse/store.js
@@ -40,7 +40,10 @@ class Store {
         }
         this.selectedReferencesLoading = true;
         $.get(url, results => {
-            this.selectedReferences = results.refs.map(datum => new Reference(datum, this.tagtree));
+            const references = Reference.sorted(
+                results.refs.map(datum => new Reference(datum, this.tagtree))
+            );
+            this.selectedReferences = references;
             this.selectedReferencesLoading = false;
         });
     }

--- a/frontend/lit/TagTree.js
+++ b/frontend/lit/TagTree.js
@@ -14,6 +14,10 @@ class TagTree {
         this.rootNode._append_to_dict(this.dict);
     }
 
+    getById(tagId) {
+        return this.dict[tagId];
+    }
+
     add_references(references) {
         references.forEach(el => {
             let node = this.dict[el.tag_id];

--- a/frontend/lit/components/Reference.js
+++ b/frontend/lit/components/Reference.js
@@ -107,10 +107,9 @@ class Reference extends Component {
                 {showTags && tags.length > 0 ? (
                     <p>
                         {tags.map((tag, i) => [
-                            <span key={i} className="badge badge-info">
+                            <span key={i} className="badge badge-info mr-1">
                                 {tag.get_full_name()}
                             </span>,
-                            <span key={i + 1000}>&nbsp;</span>,
                         ])}
                     </p>
                 ) : null}

--- a/frontend/lit/components/Reference.js
+++ b/frontend/lit/components/Reference.js
@@ -3,6 +3,8 @@ import React, {Component} from "react";
 import PropTypes from "prop-types";
 
 import h from "shared/utils/helpers";
+import {getReferenceTagListUrl} from "shared/utils/urls";
+
 import ReferenceButton from "./ReferenceButton";
 
 class Reference extends Component {
@@ -73,7 +75,7 @@ class Reference extends Component {
             year = data.year || "";
 
         return (
-            <div id="reference_detail_div">
+            <div id={`referenceId${data.pk}`}>
                 {
                     <div className="ref_small">
                         <span>
@@ -106,11 +108,14 @@ class Reference extends Component {
                 ) : null}
                 {showTags && tags.length > 0 ? (
                     <p>
-                        {tags.map((tag, i) => [
-                            <span key={i} className="badge badge-info mr-1">
+                        {tags.map((tag, i) => (
+                            <a
+                                key={i}
+                                href={getReferenceTagListUrl(data.assessment_id, tag.data.pk)}
+                                className="badge badge-info mr-1">
                                 {tag.get_full_name()}
-                            </span>,
-                        ])}
+                            </a>
+                        ))}
                     </p>
                 ) : null}
                 {data.searches.length > 0 ? (

--- a/frontend/lit/components/TagTree.js
+++ b/frontend/lit/components/TagTree.js
@@ -1,9 +1,11 @@
 import _ from "lodash";
 import React, {Component} from "react";
 import PropTypes from "prop-types";
+import {observer} from "mobx-react";
 
 import h from "shared/utils/helpers";
 
+@observer
 class TagNode extends Component {
     constructor(props) {
         super(props);
@@ -13,7 +15,9 @@ class TagNode extends Component {
         };
     }
     render() {
-        const {tag, showReferenceCount, handleOnClick} = this.props;
+        const {tag, showReferenceCount, handleOnClick, selectedTag} = this.props,
+            tagClass = tag === selectedTag ? "nestedTag selected" : "nestedTag";
+
         return (
             <div>
                 {tag.children.length > 0 ? (
@@ -27,7 +31,7 @@ class TagNode extends Component {
                         <span className={this.state.expanded ? "fa fa-minus" : "fa fa-plus"}></span>
                     </span>
                 ) : null}
-                <p className="nestedTag" onClick={() => handleOnClick(tag)}>
+                <p className={tagClass} onClick={() => handleOnClick(tag)}>
                     {_.repeat("   ", tag.depth - 1)}
                     {tag.data.name}
                     {showReferenceCount ? ` (${tag.get_references_deep().length})` : null}
@@ -39,6 +43,7 @@ class TagNode extends Component {
                               tag={tag}
                               handleOnClick={handleOnClick}
                               showReferenceCount={showReferenceCount}
+                              selectedTag={selectedTag}
                           />
                       ))
                     : null}
@@ -50,11 +55,13 @@ TagNode.propTypes = {
     tag: PropTypes.object.isRequired,
     handleOnClick: PropTypes.func.isRequired,
     showReferenceCount: PropTypes.bool.isRequired,
+    selectedTag: PropTypes.object,
 };
 
+@observer
 class TagTree extends Component {
     render() {
-        const {tagtree, handleTagClick, showReferenceCount} = this.props;
+        const {tagtree, handleTagClick, showReferenceCount, selectedTag} = this.props;
         return (
             <div>
                 {tagtree.rootNode.children.map((tag, i) => (
@@ -63,6 +70,7 @@ class TagTree extends Component {
                         tag={tag}
                         handleOnClick={handleTagClick}
                         showReferenceCount={showReferenceCount}
+                        selectedTag={selectedTag}
                     />
                 ))}
             </div>
@@ -73,6 +81,7 @@ TagTree.propTypes = {
     tagtree: PropTypes.object.isRequired,
     handleTagClick: PropTypes.func,
     showReferenceCount: PropTypes.bool,
+    selectedTag: PropTypes.object,
 };
 TagTree.defaultProps = {
     showReferenceCount: false,

--- a/frontend/lit/components/TagTree.js
+++ b/frontend/lit/components/TagTree.js
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import React, {Component} from "react";
 import PropTypes from "prop-types";
 import {observer} from "mobx-react";

--- a/frontend/lit/components/TagTree.js
+++ b/frontend/lit/components/TagTree.js
@@ -31,8 +31,10 @@ class TagNode extends Component {
                         <span className={this.state.expanded ? "fa fa-minus" : "fa fa-plus"}></span>
                     </span>
                 ) : null}
-                <p className={tagClass} onClick={() => handleOnClick(tag)}>
-                    {_.repeat("   ", tag.depth - 1)}
+                <p
+                    className={tagClass}
+                    style={{paddingLeft: 2 + tag.depth * 13}}
+                    onClick={() => handleOnClick(tag)}>
                     {tag.data.name}
                     {showReferenceCount ? ` (${tag.get_references_deep().length})` : null}
                 </p>

--- a/frontend/study/Study.js
+++ b/frontend/study/Study.js
@@ -130,15 +130,16 @@ class Study {
 
     build_details_table(div) {
         var tbl = new DescriptiveTable(),
-            links = this._get_identifiers_hyperlinks_ul();
+            links = this._get_identifiers_hyperlinks_ul(),
+            referenceListUrl = `/lit/assessment/${this.data.assessment.id}/references/`;
         tbl.add_tbody_tr("Data type(s)", this._get_data_types());
         tbl.add_tbody_tr("Full citation", this.data.full_citation);
         tbl.add_tbody_tr("Abstract", this.data.abstract);
         if (links.children().length > 0) tbl.add_tbody_tr("Reference hyperlink", links);
-        tbl.add_tbody_tr_list(
+        tbl.add_tbody_tr_badge(
             "Literature review tags",
-            this.data.tags.map(function(d) {
-                return d.name;
+            this.data.tags.map(d => {
+                return {url: `${referenceListUrl}?tag_id=${d.id}`, text: d.name};
             })
         );
         if (this.data.full_text_url)

--- a/frontend/study/Study.js
+++ b/frontend/study/Study.js
@@ -6,6 +6,8 @@ import DescriptiveTable from "utils/DescriptiveTable";
 import HAWCModal from "utils/HAWCModal";
 import HAWCUtils from "utils/HAWCUtils";
 
+import {getReferenceTagListUrl} from "shared/utils/urls";
+
 import RiskOfBiasScore from "riskofbias/RiskOfBiasScore";
 import {renderStudyDisplay} from "riskofbias/robTable/components/StudyDisplay";
 import {SCORE_SHADES, SCORE_TEXT} from "riskofbias/constants";
@@ -130,8 +132,7 @@ class Study {
 
     build_details_table(div) {
         var tbl = new DescriptiveTable(),
-            links = this._get_identifiers_hyperlinks_ul(),
-            referenceListUrl = `/lit/assessment/${this.data.assessment.id}/references/`;
+            links = this._get_identifiers_hyperlinks_ul();
         tbl.add_tbody_tr("Data type(s)", this._get_data_types());
         tbl.add_tbody_tr("Full citation", this.data.full_citation);
         tbl.add_tbody_tr("Abstract", this.data.abstract);
@@ -139,7 +140,7 @@ class Study {
         tbl.add_tbody_tr_badge(
             "Literature review tags",
             this.data.tags.map(d => {
-                return {url: `${referenceListUrl}?tag_id=${d.id}`, text: d.name};
+                return {url: getReferenceTagListUrl(this.data.assessment.id, d.id), text: d.name};
             })
         );
         if (this.data.full_text_url)

--- a/frontend/utils/DescriptiveTable.js
+++ b/frontend/utils/DescriptiveTable.js
@@ -51,6 +51,20 @@ class DescriptiveTable {
         return this;
     }
 
+    add_tbody_tr_badge(description, items) {
+        if (items.length > 0) {
+            const badges = items.map(
+                    item => `<a href="${item.url}" class="badge badge-info mr-1">${item.text}</a>`
+                ),
+                tr = $("<tr>")
+                    .append(`<th>${description}</th>`)
+                    .append($("<td>").append(badges));
+
+            this._tbody.append(tr);
+        }
+        return this;
+    }
+
     get_tbl() {
         return this._tbl;
     }

--- a/hawc/apps/animal/models.py
+++ b/hawc/apps/animal/models.py
@@ -149,7 +149,7 @@ class Experiment(models.Model):
         return self.name
 
     def get_absolute_url(self):
-        return reverse("animal:experiment_detail", args=[str(self.pk)])
+        return reverse("animal:experiment_detail", args=(self.pk,))
 
     def is_generational(self):
         return self.has_multiple_generations
@@ -345,7 +345,7 @@ class AnimalGroup(models.Model):
         return self.name
 
     def get_absolute_url(self):
-        return reverse("animal:animal_group_detail", args=[str(self.pk)])
+        return reverse("animal:animal_group_detail", args=(self.pk,))
 
     def get_assessment(self):
         return self.experiment.get_assessment()
@@ -1117,7 +1117,7 @@ class Endpoint(BaseEndpoint):
         return self.name
 
     def get_absolute_url(self):
-        return reverse("animal:endpoint_detail", args=[str(self.pk)])
+        return reverse("animal:endpoint_detail", args=(self.pk,))
 
     def save(self, *args, **kwargs):
         # ensure our controlled vocabulary terms don't have leading/trailing whitespace

--- a/hawc/apps/epi/models.py
+++ b/hawc/apps/epi/models.py
@@ -302,7 +302,7 @@ class StudyPopulation(models.Model):
         ordering = ("name",)
 
     def get_absolute_url(self):
-        return reverse("epi:sp_detail", kwargs={"pk": self.pk})
+        return reverse("epi:sp_detail",  args=(self.pk,))
 
     def get_assessment(self):
         return self.study.get_assessment()
@@ -447,7 +447,7 @@ class Outcome(BaseEndpoint):
         SerializerHelper.delete_caches(cls, ids)
 
     def get_absolute_url(self):
-        return reverse("epi:outcome_detail", kwargs={"pk": self.pk})
+        return reverse("epi:outcome_detail",  args=(self.pk,))
 
     def can_create_sets(self):
         return not self.study_population.can_create_sets()
@@ -581,7 +581,7 @@ class ComparisonSet(models.Model):
         super().save(*args, **kwargs)
 
     def get_absolute_url(self):
-        return reverse("epi:cs_detail", kwargs={"pk": self.pk})
+        return reverse("epi:cs_detail",  args=(self.pk,))
 
     def get_assessment(self):
         if self.outcome:
@@ -715,7 +715,7 @@ class Group(models.Model):
         )
 
     def get_absolute_url(self):
-        return reverse("epi:g_detail", kwargs={"pk": self.pk})
+        return reverse("epi:g_detail",  args=(self.pk,))
 
     def get_assessment(self):
         return self.comparison_set.get_assessment()
@@ -914,7 +914,7 @@ class Exposure(models.Model):
         return self.study_population.get_assessment()
 
     def get_absolute_url(self):
-        return reverse("epi:exp_detail", kwargs={"pk": self.pk})
+        return reverse("epi:exp_detail",  args=(self.pk,))
 
     @classmethod
     def delete_caches(cls, ids):
@@ -1356,7 +1356,7 @@ class Result(models.Model):
         return self.outcome.get_assessment()
 
     def get_absolute_url(self):
-        return reverse("epi:result_detail", kwargs={"pk": self.pk})
+        return reverse("epi:result_detail", args=(self.pk,))
 
     @staticmethod
     def flat_complete_header_row():

--- a/hawc/apps/epimeta/models.py
+++ b/hawc/apps/epimeta/models.py
@@ -67,7 +67,7 @@ class MetaProtocol(models.Model):
         return self.study.get_assessment()
 
     def get_absolute_url(self):
-        return reverse("meta:protocol_detail", kwargs={"pk": self.pk})
+        return reverse("meta:protocol_detail", args=(self.pk,))
 
     def get_json(self, json_encode=True):
         return SerializerHelper.get_serialized(self, json=json_encode, from_cache=False)
@@ -177,7 +177,7 @@ class MetaResult(models.Model):
         return self.protocol.get_assessment()
 
     def get_absolute_url(self):
-        return reverse("meta:result_detail", kwargs={"pk": self.pk})
+        return reverse("meta:result_detail", args=(self.pk,))
 
     @property
     def estimate_formatted(self):

--- a/hawc/apps/invitro/models.py
+++ b/hawc/apps/invitro/models.py
@@ -64,13 +64,13 @@ class IVChemical(models.Model):
         return self.name
 
     def get_absolute_url(self):
-        return reverse("invitro:chemical_detail", args=[str(self.id)])
+        return reverse("invitro:chemical_detail", args=(self.id,))
 
     def get_update_url(self):
-        return reverse("invitro:chemical_update", args=[str(self.id)])
+        return reverse("invitro:chemical_update", args=(self.id,))
 
     def get_delete_url(self):
-        return reverse("invitro:chemical_delete", args=[str(self.id)])
+        return reverse("invitro:chemical_delete", args=(self.id,))
 
     def get_assessment(self):
         return self.study.assessment
@@ -131,13 +131,13 @@ class IVCellType(models.Model):
         return f"{self.cell_type} {self.species} {self.tissue}"
 
     def get_absolute_url(self):
-        return reverse("invitro:celltype_detail", args=[str(self.id)])
+        return reverse("invitro:celltype_detail", args=(self.id,))
 
     def get_update_url(self):
-        return reverse("invitro:celltype_update", args=[str(self.id)])
+        return reverse("invitro:celltype_update", args=(self.id,))
 
     def get_delete_url(self):
-        return reverse("invitro:celltype_delete", args=[str(self.id)])
+        return reverse("invitro:celltype_delete", args=(self.id,))
 
     def get_sex_symbol(self):
         return self.SEX_SYMBOLS.get(self.sex)
@@ -224,16 +224,16 @@ class IVExperiment(models.Model):
         return self.study.assessment
 
     def get_absolute_url(self):
-        return reverse("invitro:experiment_detail", args=[str(self.id)])
+        return reverse("invitro:experiment_detail", args=(self.id,))
 
     def get_update_url(self):
-        return reverse("invitro:experiment_update", args=[str(self.id)])
+        return reverse("invitro:experiment_update", args=(self.id,))
 
     def get_delete_url(self):
-        return reverse("invitro:experiment_delete", args=[str(self.id)])
+        return reverse("invitro:experiment_delete", args=(self.id,))
 
     def get_endpoint_create_url(self):
-        return reverse("invitro:endpoint_create", args=[str(self.id)])
+        return reverse("invitro:endpoint_create", args=(self.id,))
 
     def copy_across_assessments(self, cw):
         children = list(self.endpoints.all().order_by("id"))
@@ -419,13 +419,13 @@ class IVEndpoint(BaseEndpoint):
             return endpoints
 
     def get_absolute_url(self):
-        return reverse("invitro:endpoint_detail", args=[str(self.id)])
+        return reverse("invitro:endpoint_detail", args=(self.id,))
 
     def get_update_url(self):
-        return reverse("invitro:endpoint_update", args=[str(self.id)])
+        return reverse("invitro:endpoint_update", args=(self.id,))
 
     def get_delete_url(self):
-        return reverse("invitro:endpoint_delete", args=[str(self.id)])
+        return reverse("invitro:endpoint_delete", args=(self.id,))
 
     @classmethod
     def delete_caches(cls, ids):

--- a/hawc/apps/lit/models.py
+++ b/hawc/apps/lit/models.py
@@ -100,7 +100,7 @@ class LiteratureAssessment(models.Model):
         return self.assessment
 
     def get_absolute_url(self):
-        return reverse("lit:tags_update", args=(self.assessment.id,))
+        return reverse("lit:tags_update", args=(self.assessment_id,))
 
     def get_update_url(self) -> str:
         return reverse("lit:literature_assessment_update", args=(self.id,))
@@ -247,7 +247,7 @@ class Search(models.Model):
             raise ValidationError("Error- slug name must be unique for assessment.")
 
     def get_absolute_url(self):
-        return reverse("lit:search_detail", kwargs={"pk": self.assessment.pk, "slug": self.slug})
+        return reverse("lit:search_detail", args=(self.assessment_id, self.slug))
 
     def get_assessment(self):
         return self.assessment
@@ -402,7 +402,7 @@ class Search(models.Model):
         dicts = []
         pubmed_queries = PubMedQuery.objects.filter(search=self)
         for pubmed_query in pubmed_queries:
-            dicts.append(pubmed_query.get_json(json_encode=False))
+            dicts.append(pubmed_query.to_dict())
         return dicts
 
     def get_all_reference_tags(self, json_encode=True):
@@ -449,14 +449,13 @@ class Search(models.Model):
     def references_untagged(self):
         return self.references.all().annotate(tag_count=models.Count("tags")).filter(tag_count=0)
 
-    def get_json(self):
-        d = {}
-        fields = ("pk", "title")
-        for field in fields:
-            d[field] = getattr(self, field)
-        d["url"] = self.get_absolute_url()
-        d["search_type"] = self.get_search_type_display()
-        return d
+    def to_dict(self):
+        return dict(
+            pk=self.pk,
+            title=self.title,
+            url=self.get_absolute_url(),
+            search_type=self.get_search_type_display(),
+        )
 
 
 class PubMedQuery(models.Model):
@@ -527,7 +526,7 @@ class PubMedQuery(models.Model):
                 )
             Identifiers.objects.bulk_create(identifiers)
 
-    def get_json(self, json_encode=True):
+    def to_dict(self):
         def get_len(obj):
             if obj is not None:
                 return len(obj)
@@ -541,10 +540,7 @@ class PubMedQuery(models.Model):
             "total_added": get_len(details["added"]),
             "total_removed": get_len(details["removed"]),
         }
-        if json_encode:
-            return json.dumps(d, cls=HAWCDjangoJSONEncoder)
-        else:
-            return d
+        return d
 
 
 class Identifiers(models.Model):
@@ -607,7 +603,7 @@ class Identifiers(models.Model):
 
         return ref
 
-    def get_json(self, json_encode=True):
+    def to_dict(self):
         return {
             "id": self.unique_id,
             "database": self.get_database_display(),
@@ -724,12 +720,12 @@ class Reference(models.Model):
     BREADCRUMB_PARENT = "assessment"
 
     def get_absolute_url(self):
-        return reverse("lit:ref_detail", kwargs={"pk": self.pk})
+        return reverse("lit:ref_detail", args=(self.pk,))
 
     def __str__(self):
         return self.ref_short_citation
 
-    def get_json(self, json_encode=True):
+    def to_dict(self):
         d = {}
         fields = (
             "pk",
@@ -750,15 +746,12 @@ class Reference(models.Model):
         d["editReferenceUrl"] = reverse("lit:ref_edit", kwargs={"pk": self.pk})
         d["deleteReferenceUrl"] = reverse("lit:ref_delete", kwargs={"pk": self.pk})
 
-        d["identifiers"] = [ident.get_json(json_encode=False) for ident in self.identifiers.all()]
-        d["searches"] = [ref.get_json() for ref in self.searches.all()]
+        d["identifiers"] = [ident.to_dict() for ident in self.identifiers.all()]
+        d["searches"] = [search.to_dict() for search in self.searches.all()]
 
-        d["tags"] = list(self.tags.all().values_list("pk", flat=True))
-        d["tags_text"] = list(self.tags.all().values_list("name", flat=True))
-        if json_encode:
-            return json.dumps(d, cls=HAWCDjangoJSONEncoder)
-        else:
-            return d
+        d["tags"] = [tag.id for tag in self.tags.all()]
+        d["tags_text"] = [tag.name for tag in self.tags.all()]
+        return d
 
     @classmethod
     def delete_caches(cls, ids):

--- a/hawc/apps/lit/models.py
+++ b/hawc/apps/lit/models.py
@@ -733,6 +733,7 @@ class Reference(models.Model):
         d = {}
         fields = (
             "pk",
+            "assessment_id",
             "title",
             "authors_short",
             "authors",

--- a/hawc/apps/lit/serializers.py
+++ b/hawc/apps/lit/serializers.py
@@ -123,7 +123,7 @@ class ReferenceQuerySerializer(serializers.Serializer):
             query &= Q(abstract__icontains=self.data["abstract"])
 
         qs = models.Reference.objects.filter(query)[:100]
-        return [ref.get_json(json_encode=False) for ref in qs]
+        return [ref.to_dict() for ref in qs]
 
 
 class ReferenceTagsSerializer(serializers.ModelSerializer):

--- a/hawc/apps/lit/templates/lit/search_tags_edit.html
+++ b/hawc/apps/lit/templates/lit/search_tags_edit.html
@@ -9,9 +9,7 @@
 <script id="config" type="text/json" charset="utf-8">
 {
   "tags": {{ tags | safe }},
-  "refs": [{% for ref in references %}
-    {{ ref.get_json | safe }}{% if not forloop.last %},{% endif %}
-  {% endfor %}],
+  "refs": {{ refs_json | safe }},
   "csrf": "{{csrf_token}}"
 }
 </script>

--- a/hawc/apps/lit/views.py
+++ b/hawc/apps/lit/views.py
@@ -1,5 +1,5 @@
 import json
-from typing import List
+from typing import Dict, List
 
 from django.forms.models import model_to_dict
 from django.http import Http404, HttpResponse, HttpResponseRedirect
@@ -270,10 +270,20 @@ class TagReferences(TeamMemberOrHigherMixin, FormView):
             response["status"] = "success"
         return response
 
+    def get_ref_qs_filters(self) -> Dict:
+        ...
+
     def get_context_data(self, **kwargs):
+        if hasattr(self, "qs_reference"):
+            refs = self.qs_reference
+        else:
+            refs = refs = models.Reference.objects.filter(**self.get_ref_qs_filters()).distinct()
+        refs = refs.prefetch_related("searches", "identifiers", "tags")
         context = super().get_context_data(**kwargs)
         context["object"] = self.object
         context["model"] = self.model.__name__
+        context["tags"] = models.ReferenceFilterTag.get_all_tags(self.assessment.id)
+        context["refs_json"] = json.dumps([ref.to_dict() for ref in refs])
         context["breadcrumbs"] = lit_overview_crumbs(self.request.user, self.assessment, "CHANGE")
         return context
 
@@ -291,13 +301,11 @@ class TagBySearch(TagReferences):
         )
         return self.object.get_assessment()
 
+    def get_ref_qs_filters(self):
+        return dict(searches=self.object)
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        qs = models.Reference.objects.filter(searches=self.object).prefetch_related(
-            "searches", "identifiers"
-        )
-        context["references"] = qs
-        context["tags"] = models.ReferenceFilterTag.get_all_tags(self.assessment.id)
         context["breadcrumbs"][3] = Breadcrumb.from_object(self.object)
         context["breadcrumbs"].append(Breadcrumb(name="Update tags"))
         return context
@@ -314,13 +322,11 @@ class TagByReference(TagReferences):
         self.object = get_object_or_404(self.model, pk=self.kwargs.get("pk"))
         return self.object.get_assessment()
 
+    def get_ref_qs_filters(self):
+        return dict(pk=self.object.pk)
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        qs = self.model.objects.filter(pk=self.object.pk).prefetch_related(
-            "searches", "identifiers"
-        )
-        context["references"] = qs
-        context["tags"] = models.ReferenceFilterTag.get_all_tags(self.assessment.id)
         context["breadcrumbs"][3] = Breadcrumb.from_object(self.object)
         context["breadcrumbs"].append(Breadcrumb(name="Update tags"))
         return context
@@ -337,15 +343,11 @@ class TagByTag(TagReferences):
         self.object = get_object_or_404(self.model, pk=self.kwargs.get("pk"))
         return self.object.get_assessment()
 
+    def get_ref_qs_filters(self):
+        return dict(tags=self.object.pk)
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        qs = (
-            models.Reference.objects.filter(tags=self.object.pk)
-            .distinct()
-            .prefetch_related("searches", "identifiers")
-        )
-        context["references"] = qs
-        context["tags"] = models.ReferenceFilterTag.get_all_tags(self.assessment.id)
         context["breadcrumbs"][3] = Breadcrumb(name=f'Update "{self.object.name}" tags')
         return context
 
@@ -361,13 +363,12 @@ class TagByUntagged(TagReferences):
         self.object = get_object_or_404(Assessment, id=self.kwargs.get("pk"))
         return self.object
 
+    def get_ref_qs_filters(self):
+        return dict(tags=self.object.pk)
+
     def get_context_data(self, **kwargs):
+        self.qs_reference = models.Reference.objects.get_untagged_references(self.assessment)
         context = super().get_context_data(**kwargs)
-        qs = models.Reference.objects.get_untagged_references(self.assessment).prefetch_related(
-            "searches", "identifiers"
-        )
-        context["references"] = qs
-        context["tags"] = models.ReferenceFilterTag.get_all_tags(self.assessment.id)
         context["breadcrumbs"][3] = Breadcrumb(name="Tag untagged references")
         return context
 
@@ -494,7 +495,7 @@ class RefDetail(BaseDetail):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["tags"] = models.ReferenceFilterTag.get_all_tags(self.assessment.id)
-        context["object_json"] = self.object.get_json()
+        context["object_json"] = self.object.to_dict()
         context["breadcrumbs"].insert(2, lit_overview_breadcrumb(self.assessment))
         return context
 
@@ -520,7 +521,7 @@ class RefDelete(BaseDelete):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["tags"] = models.ReferenceFilterTag.get_all_tags(self.assessment.id)
-        context["object_json"] = self.object.get_json()
+        context["object_json"] = self.object.to_dict()
         context["breadcrumbs"].insert(2, lit_overview_breadcrumb(self.assessment))
         return context
 
@@ -554,18 +555,18 @@ class RefsByTagJSON(BaseDetail):
         if search_id:
             search = models.Search.objects.get(id=search_id)
             refs = search.get_references_with_tag(tag=tag, descendants=True).prefetch_related(
-                "searches", "identifiers"
+                "searches", "identifiers", "tags",
             )
         elif tag:
             refs = models.Reference.objects.get_references_with_tag(
                 tag, descendants=True
-            ).prefetch_related("searches", "identifiers")
+            ).prefetch_related("searches", "identifiers", "tags",)
         else:
             refs = models.Reference.objects.get_untagged_references(
                 self.assessment
-            ).prefetch_related("searches", "identifiers")
+            ).prefetch_related("searches", "identifiers", "tags",)
 
-        response["refs"] = [ref.get_json(json_encode=False) for ref in refs]
+        response["refs"] = [ref.to_dict() for ref in refs]
         self.response = response
 
     def render_to_response(self, context, **response_kwargs):

--- a/hawc/apps/riskofbias/models.py
+++ b/hawc/apps/riskofbias/models.py
@@ -189,7 +189,7 @@ class RiskOfBias(models.Model):
         return reverse("riskofbias:rob_detail", args=[self.study_id])
 
     def get_absolute_url(self):
-        return reverse("riskofbias:arob_reviewers", args=[self.get_assessment().pk])
+        return reverse("riskofbias:arob_reviewers", args=[self.study.assessment_id])
 
     def get_edit_url(self):
         return reverse("riskofbias:rob_update", args=[self.pk])
@@ -740,7 +740,7 @@ class RiskOfBiasAssessment(models.Model):
     BREADCRUMB_PARENT = "assessment"
 
     def get_absolute_url(self):
-        return reverse("riskofbias:arob_reviewers", args=[self.assessment.pk])
+        return reverse("riskofbias:arob_reviewers", args=[self.assessment_id])
 
     @classmethod
     def build_default(cls, assessment):

--- a/hawc/apps/riskofbias/views.py
+++ b/hawc/apps/riskofbias/views.py
@@ -140,7 +140,9 @@ class ARoBReviewersList(TeamMemberOrHigherMixin, BaseList):
         return self.model.objects.get_qs(self.assessment).prefetch_related(
             Prefetch(
                 "riskofbiases",
-                queryset=models.RiskOfBias.objects.all_active().prefetch_related("author"),
+                queryset=models.RiskOfBias.objects.all_active().prefetch_related(
+                    "author", "scores",
+                ),
                 to_attr="active_riskofbiases",
             )
         )
@@ -230,7 +232,7 @@ class ARoBReviewersUpdate(ProjectManagerOrHigherMixin, BaseUpdateWithFormset):
                         rob.activate()
 
     def get_success_url(self):
-        return reverse_lazy("riskofbias:arob_reviewers", kwargs={"pk": self.assessment.pk})
+        return reverse_lazy("riskofbias:arob_reviewers", args=(self.assessment_id,))
 
 
 # Risk of bias domain views

--- a/hawc/apps/study/models.py
+++ b/hawc/apps/study/models.py
@@ -251,7 +251,7 @@ class Study(Reference):
         return self.short_citation
 
     def get_absolute_url(self):
-        return reverse("study:detail", args=[str(self.pk)])
+        return reverse("study:detail", args=(self.pk,))
 
     def get_update_url(self):
         return reverse("study:update", args=[str(self.pk)])
@@ -438,7 +438,7 @@ class Attachment(models.Model):
         return self.filename
 
     def get_absolute_url(self):
-        return reverse("study:attachment_detail", args=[self.pk])
+        return reverse("study:attachment_detail", args=(self.pk,))
 
     def get_delete_url(self):
         return reverse("study:attachment_delete", args=[self.pk])

--- a/hawc/apps/summary/models.py
+++ b/hawc/apps/summary/models.py
@@ -122,7 +122,7 @@ class SummaryText(MP_Node):
         return cls.get_tree(parent=root)
 
     def get_absolute_url(self):
-        return f"{reverse('summary:list', kwargs={'assessment': self.assessment.pk})}#{self.slug}"
+        return f"{reverse('summary:list', args=(self.assessment_id,))}#{self.slug}"
 
     def get_assessment(self):
         return self.assessment
@@ -230,16 +230,16 @@ class Visual(models.Model):
 
     @staticmethod
     def get_list_url(assessment_id):
-        return reverse("summary:visualization_list", args=[str(assessment_id)])
+        return reverse("summary:visualization_list", args=(assessment_id,))
 
     def get_absolute_url(self):
-        return reverse("summary:visualization_detail", args=[str(self.pk)])
+        return reverse("summary:visualization_detail", args=(self.pk,))
 
     def get_update_url(self):
-        return reverse("summary:visualization_update", args=[str(self.pk)])
+        return reverse("summary:visualization_update", args=(self.pk,))
 
     def get_delete_url(self):
-        return reverse("summary:visualization_delete", args=[str(self.pk)])
+        return reverse("summary:visualization_delete", args=(self.pk,))
 
     def get_assessment(self):
         return self.assessment
@@ -528,10 +528,10 @@ class DataPivot(models.Model):
         return reverse("summary:visualization_list", args=[str(assessment_id)])
 
     def get_absolute_url(self):
-        return reverse("summary:dp_detail", kwargs={"pk": self.assessment_id, "slug": self.slug})
+        return reverse("summary:dp_detail", args=(self.assessment_id, self.slug))
 
     def get_visualization_update_url(self):
-        return reverse("summary:dp_update", kwargs={"pk": self.assessment_id, "slug": self.slug})
+        return reverse("summary:dp_update", args=(self.assessment_id, self.slug))
 
     def get_assessment(self):
         return self.assessment

--- a/hawc/static/css/hawc.css
+++ b/hawc/static/css/hawc.css
@@ -326,16 +326,13 @@ div.smart-tag.active {
     font-weight: bold;
 }
 .nestedTag {
-    padding-left: 14px;
-    white-space: pre;
     border: 2px solid transparent;
     margin: 0;
     cursor: pointer;
 }
 .nestedTag:hover {
-    font-weight: bold;
     border: 2px solid #ababab;
-    background-color: #ffef8e;
+    background-color: #8ee8ff;
 }
 .nestedTag.selected {
     color: #0044cc;


### PR DESCRIPTION
- [x]  Reference tags should be clickable on a study page and should send you to the reference list view:
![Screen Shot 2021-01-15 at 10 38 09 AM](https://user-images.githubusercontent.com/999952/104746861-d5594e80-571d-11eb-811b-f34968ccad4f.png)
- [x] Reference list view should should default tag_id  if one is present
- [x] Reorganize ref view to show ref list on left, content center, tags on right (similar to the tagging view)
- [x] Show histogram of year above reference list, like pubmed?
![Screen Shot 2021-01-15 at 2 50 51 PM](https://user-images.githubusercontent.com/999952/104772246-1d3d9d00-5741-11eb-8594-6e4de2bf7522.png)
