### PR TITLE
Deployment updates

### DIFF
--- a/compose/app/sync.sh
+++ b/compose/app/sync.sh
@@ -8,5 +8,5 @@ manage.py collectstatic --noinput
 
 if [[ $HAWC_LOAD_TEST_DB == "True" ]]; then
     echo "loading test database..."
-    manage.py load_test_db
+    manage.py load_test_db --ifempty
 fi

--- a/hawc/apps/common/management/commands/load_test_db.py
+++ b/hawc/apps/common/management/commands/load_test_db.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
 
@@ -10,6 +11,14 @@ HELP_TEXT = """Load the test database from a fixture."""
 class Command(BaseCommand):
     help = HELP_TEXT
 
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            "--ifempty",
+            action="store_true",
+            dest="ifempty",
+            help="Only flush/load if database is empty",
+        )
+
     def handle(self, *args, **options):
 
         if "test" not in settings.DATABASES["default"]["NAME"]:
@@ -17,5 +26,12 @@ class Command(BaseCommand):
 
         with ignore_signals():
             call_command("migrate", verbosity=0)
-            call_command("flush", verbosity=0, interactive=False)
-            call_command("loaddata", str(settings.TEST_DB_FIXTURE), verbosity=1)
+
+            if options["ifempty"] and get_user_model().objects.count()>0:
+                message = "Migrations complete; fixture not loaded (db not empty)"
+            else:
+                call_command("flush", verbosity=0, interactive=False)
+                call_command("loaddata", str(settings.TEST_DB_FIXTURE), verbosity=1)
+                message = "Migrations complete; fixture loaded"
+
+        self.stdout.write(self.style.SUCCESS(message))

--- a/hawc/apps/common/management/commands/load_test_db.py
+++ b/hawc/apps/common/management/commands/load_test_db.py
@@ -27,7 +27,7 @@ class Command(BaseCommand):
         with ignore_signals():
             call_command("migrate", verbosity=0)
 
-            if options["ifempty"] and get_user_model().objects.count()>0:
+            if options["ifempty"] and get_user_model().objects.count() > 0:
                 message = "Migrations complete; fixture not loaded (db not empty)"
             else:
                 call_command("flush", verbosity=0, interactive=False)

--- a/hawc/apps/myuser/admin.py
+++ b/hawc/apps/myuser/admin.py
@@ -1,5 +1,7 @@
+from django.conf import settings
 from django.contrib import admin, messages
 from django.core.cache import cache
+from django.core.mail import send_mail
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 
@@ -64,6 +66,19 @@ class HAWCUserAdmin(admin.ModelAdmin):
         message = "Cache test executed successfully"
         modeladmin.message_user(request, message)
 
+    def diagnostic_email(modeladmin, request, queryset):
+        to_email = request.user.email
+        send_mail(
+            "Test email",
+            "Test message",
+            settings.DEFAULT_FROM_EMAIL,
+            [to_email],
+            fail_silently=False,
+        )
+
+        message = f"Attempted to send email to {to_email}"
+        modeladmin.message_user(request, message)
+
     def save_model(self, request, obj, form, change):
         form.save(commit=True)
 
@@ -72,6 +87,7 @@ class HAWCUserAdmin(admin.ModelAdmin):
     throw_500.short_description = "Intentionally throw a server error (500)"
     diagnostic_celery_task.short_description = "Diagnostic celery task test"
     diagnostic_cache.short_description = "Diagnostic cache test"
+    diagnostic_email.short_description = "Diagnostic email test"
 
     actions = (
         send_welcome_emails,
@@ -79,4 +95,5 @@ class HAWCUserAdmin(admin.ModelAdmin):
         throw_500,
         diagnostic_celery_task,
         diagnostic_cache,
+        diagnostic_email,
     )

--- a/hawc/main/settings/staging.py
+++ b/hawc/main/settings/staging.py
@@ -1,4 +1,5 @@
 # flake8: noqa
+
 import os
 
 from .base import *


### PR DESCRIPTION
Three updates related to flexibility in deployment environments:

1. Add new diagnostic action in the admin to send a test email to the currently logged in user. This can be used for easily diagnosing email configuration issues.
2. Add new django setting (and django monkeypatch) to set the [FQDN](https://en.wikipedia.org/wiki/Fully_qualified_domain_name) instead of using the default. This domain name may be required when sending emails via SMTP, and the default value when running in a container is the container ID. This change may be removed in future version of django are updated (see comments in implementation)
3. Update `load_test_db` command to add new argument which only loads the test database if the database is not empty. This can be helpful in some test environments where we wish to make the database persistent