### PR TITLE
Make figure height/width configurable for custom literature tagtrees

### DIFF
--- a/frontend/lit/TagTreeViz.js
+++ b/frontend/lit/TagTreeViz.js
@@ -85,9 +85,10 @@ class TagTreeViz extends D3Plot {
     }
 
     set_defaults() {
+        const {width, height} = this.stateStore.options;
         this.padding = {top: 40, right: 5, bottom: 5, left: 115};
-        this.w = 1280 - this.padding.left - this.padding.right;
-        this.h = 800 - this.padding.top - this.padding.bottom;
+        this.w = width - this.padding.left - this.padding.right;
+        this.h = height - this.padding.top - this.padding.bottom;
         this.path_length = 180;
         this.minimum_radius = 8;
         this.maximum_radius = 30;

--- a/frontend/summary/summary/LiteratureTagtree.js
+++ b/frontend/summary/summary/LiteratureTagtree.js
@@ -49,9 +49,7 @@ class LiteratureTagtree extends BaseVisual {
         // change root node
         tagtree.reset_root_node(this.data.settings.root_node);
 
-        new TagTreeViz(tagtree, $plotDiv, title, url, {
-            hide_empty_tag_nodes: this.data.settings.hide_empty_tag_nodes,
-        });
+        new TagTreeViz(tagtree, $plotDiv, title, url, this.data.settings);
     }
 
     buildViz($plotDiv, data) {

--- a/hawc/apps/lit/templates/lit/reference_visual.html
+++ b/hawc/apps/lit/templates/lit/reference_visual.html
@@ -23,6 +23,8 @@
       tagtree.add_references(data.references);
       new lit.TagTreeViz(tagtree, $('#tagtree'), data.title, data.url, {
         hide_empty_tag_nodes: false,
+        width: 1280,
+        height: 800,
       });
     });
   </script>

--- a/hawc/apps/summary/forms.py
+++ b/hawc/apps/summary/forms.py
@@ -649,11 +649,28 @@ class TagtreeForm(VisualForm):
         help_text="Prune tree; show only tags which contain at least on reference.",
         required=False,
     )
+    width = forms.IntegerField(
+        label="Width",
+        initial=1280,
+        min_value=500,
+        max_value=2000,
+        required=True,
+        help_text="The width of the visual, in pixels.",
+    )
+    height = forms.IntegerField(
+        label="Height",
+        initial=800,
+        min_value=500,
+        max_value=3000,
+        required=True,
+        help_text="The width of the visual, in pixels. If you have overlapping nodes, add more height",
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper = self.setHelper()
         self.helper.add_row("root_node", 3, "col-md-4")
+        self.helper.add_row("hide_empty_tag_nodes", 3, "col-md-4")
 
         choices = [
             (tag.id, tag.get_nested_name())
@@ -677,6 +694,10 @@ class TagtreeForm(VisualForm):
             self.fields["pruned_tags"].initial = data["pruned_tags"]
         if "hide_empty_tag_nodes" in data:
             self.fields["hide_empty_tag_nodes"].initial = data["hide_empty_tag_nodes"]
+        if "width" in data:
+            self.fields["width"].initial = data["width"]
+        if "height" in data:
+            self.fields["height"].initial = data["height"]
 
     def save(self, commit=True):
         self.instance.settings = json.dumps(
@@ -685,6 +706,8 @@ class TagtreeForm(VisualForm):
                 required_tags=self.cleaned_data["required_tags"],
                 pruned_tags=self.cleaned_data["pruned_tags"],
                 hide_empty_tag_nodes=self.cleaned_data["hide_empty_tag_nodes"],
+                width=self.cleaned_data["width"],
+                height=self.cleaned_data["height"],
             )
         )
         return super().save(commit)
@@ -699,6 +722,9 @@ class TagtreeForm(VisualForm):
             "root_node",
             "required_tags",
             "pruned_tags",
+            "hide_empty_tag_nodes",
+            "width",
+            "height",
         )
 
 

--- a/hawc/apps/summary/forms.py
+++ b/hawc/apps/summary/forms.py
@@ -646,7 +646,7 @@ class TagtreeForm(VisualForm):
     )
     hide_empty_tag_nodes = forms.BooleanField(
         label="Hide tags with no references",
-        help_text="Prune tree; show only tags which contain at least on reference.",
+        help_text="Prune tree; show only tags which contain at least one reference.",
         required=False,
     )
     width = forms.IntegerField(
@@ -663,7 +663,7 @@ class TagtreeForm(VisualForm):
         min_value=500,
         max_value=3000,
         required=True,
-        help_text="The width of the visual, in pixels. If you have overlapping nodes, add more height",
+        help_text="The height of the visual, in pixels. If you have overlapping nodes, add more height",
     )
 
     def __init__(self, *args, **kwargs):

--- a/hawc/apps/summary/migrations/0029_tagtree_size.py
+++ b/hawc/apps/summary/migrations/0029_tagtree_size.py
@@ -6,32 +6,44 @@ literature_tagtree = 4
 
 
 def add_tagtree_size(apps, schema_editor):
-    for visual in apps.get_model("summary", "Visual").objects.filter(
-        visual_type=literature_tagtree
-    ):
+    Visual = apps.get_model("summary", "Visual")
+    updates = []
+    failures = []
+
+    for visual in Visual.objects.filter(visual_type=literature_tagtree):
         try:
             settings = json.loads(visual.settings)
         except json.JSONDecodeError:
+            failures.append(visual.id)
             continue
 
         settings.update(width=1280, height=800)
         visual.settings = json.dumps(settings)
-        visual.save()
+        updates.append(visual)
+
+    Visual.objects.bulk_update(updates, ["settings"])
+    print(f"{len(updates)} objects updated; {len(failures)} not updated: {failures}")
 
 
 def remove_tagtree_size(apps, schema_editor):
-    for visual in apps.get_model("summary", "Visual").objects.filter(
-        visual_type=literature_tagtree
-    ):
+    Visual = apps.get_model("summary", "Visual")
+    updates = []
+    failures = []
+
+    for visual in Visual.objects.filter(visual_type=literature_tagtree):
         try:
             settings = json.loads(visual.settings)
         except json.JSONDecodeError:
+            failures.append(visual.id)
             continue
 
         settings.pop("width")
         settings.pop("height")
         visual.settings = json.dumps(settings)
-        visual.save()
+        updates.append(visual)
+
+    Visual.objects.bulk_update(updates, ["settings"])
+    print(f"{len(updates)} objects updated; {len(failures)} not updated: {failures}")
 
 
 class Migration(migrations.Migration):

--- a/hawc/apps/summary/migrations/0029_tagtree_size.py
+++ b/hawc/apps/summary/migrations/0029_tagtree_size.py
@@ -1,0 +1,45 @@
+import json
+
+from django.db import migrations
+
+literature_tagtree = 4
+
+
+def add_tagtree_size(apps, schema_editor):
+    for visual in apps.get_model("summary", "Visual").objects.filter(
+        visual_type=literature_tagtree
+    ):
+        try:
+            settings = json.loads(visual.settings)
+        except json.JSONDecodeError:
+            continue
+
+        settings.update(width=1280, height=800)
+        visual.settings = json.dumps(settings)
+        visual.save()
+
+
+def remove_tagtree_size(apps, schema_editor):
+    for visual in apps.get_model("summary", "Visual").objects.filter(
+        visual_type=literature_tagtree
+    ):
+        try:
+            settings = json.loads(visual.settings)
+        except json.JSONDecodeError:
+            continue
+
+        settings.pop("width")
+        settings.pop("height")
+        visual.settings = json.dumps(settings)
+        visual.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("summary", "0028_summarytable"),
+    ]
+
+    operations = [
+        migrations.RunPython(add_tagtree_size, reverse_code=remove_tagtree_size),
+    ]


### PR DESCRIPTION
Users were reporting issues with tag nodes overlapping. 

Now, when creating a custom tagtree, you can set the figure height and width. This will allow for more space when needed to prevent overlap.

**New inputs:**
<img width="617" alt="Screen Shot 2021-03-13 at 10 42 09 AM" src="https://user-images.githubusercontent.com/999952/111035521-f7eba900-83e8-11eb-96ff-74803affb80b.png">

**Example collapsed:**
<img width="476" alt="Screen Shot 2021-03-13 at 10 42 47 AM" src="https://user-images.githubusercontent.com/999952/111035522-f7eba900-83e8-11eb-9f44-6a2327ca8e4d.png">

**Example resized:**
<img width="476" alt="Screen Shot 2021-03-13 at 10 43 18 AM" src="https://user-images.githubusercontent.com/999952/111035523-f7eba900-83e8-11eb-86d8-bc0b25beb7f3.png">
