### PR TITLE
Fix Pubmed parser in 3.9

### DIFF
--- a/hawc/services/nih/pubmed.py
+++ b/hawc/services/nih/pubmed.py
@@ -124,7 +124,7 @@ class PubMedFetch(PubMedUtility):
                 tree = ET.fromstring(resp.text.encode("utf-8"))
                 if tree.tag != "PubmedArticleSet":
                     raise ValueError(f"Unexpected response type: {tree.tag}")
-                for content in tree.getchildren():
+                for content in tree:
                     result = PubMedParser.parse(content)
                     if result:
                         self.content.append(result)


### PR DESCRIPTION
Python 3.9 removes `getchildren()`.

https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getchildren