### PR TITLE
Middleware - Referer checking on safe http methods

### DIFF
--- a/hawc/apps/common/middleware.py
+++ b/hawc/apps/common/middleware.py
@@ -23,3 +23,14 @@ class MicrosoftOfficeLinkMiddleware(MiddlewareMixin):
             return HttpResponse(self.RESPONSE_TEXT)
         response = self.get_response(request)
         return response
+
+
+class RemoveRefererMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        response._headers.pop("Referer", None)
+        response._headers.pop("Origin", None)
+        return response

--- a/hawc/apps/common/middleware.py
+++ b/hawc/apps/common/middleware.py
@@ -39,9 +39,7 @@ class CsrfRefererCheckMiddleware:
     """
 
     SAFE_METHODS = {"GET", "HEAD", "OPTIONS", "TRACE"}
-    RESPONSE_TEXT = (
-        '<html><head><meta http-equiv="refresh" content="0"/></head><body></body></html>'
-    )
+    REFRESH = b'<html><head><meta http-equiv="refresh" content="0"/></head><body></body></html>'
 
     def __init__(self, get_response):
         self.get_response = get_response
@@ -49,12 +47,12 @@ class CsrfRefererCheckMiddleware:
     def __call__(self, request):
         if request.method in self.SAFE_METHODS:
             this_host = request.get_host()
-            for header in ["referer", "origin"]:
-                value = request.headers.get(header)
+            for header in ["HTTP_REFERER", "HTTP_ORIGIN"]:
+                value = request.META.get(header)
                 if value:
                     parsed = urlparse(value)
                     if not is_same_domain(parsed.netloc, this_host):
-                        return HttpResponse(self.RESPONSE_TEXT)
+                        return HttpResponse(self.REFRESH)
 
         # continue standard parsing; no need to redirect
         response = self.get_response(request)

--- a/hawc/apps/common/middleware.py
+++ b/hawc/apps/common/middleware.py
@@ -1,6 +1,8 @@
 import re
+from urllib.parse import urlparse
 
 from django.http import HttpResponse
+from django.utils.http import is_same_domain
 
 
 class MicrosoftOfficeLinkMiddleware:
@@ -25,11 +27,36 @@ class MicrosoftOfficeLinkMiddleware:
 
 
 class CsrfRefererCheckMiddleware:
+    """
+    Django has built-in middleware for CSRF checks for POST requests, but not for GET. This is
+    by design and per RFC 7231 and "safe methods". For more information, see
+    https://docs.djangoproject.com/en/3.1/ref/csrf/#how-it-works.
+
+    To check "safe" methods, we validate that the Referer if one exists is from the same domain
+    as our site. If not, we request a refresh of the page, which will set the Referer to the
+    current site.  This would only be of importance if a SAFE method was modifying state and
+    doing so with the Referer attribute, which we should not be doing anyways.
+    """
+
+    SAFE_METHODS = {"GET", "HEAD", "OPTIONS", "TRACE"}
+    RESPONSE_TEXT = (
+        '<html><head><meta http-equiv="refresh" content="0"/></head><body></body></html>'
+    )
+
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
+        if request.method in self.SAFE_METHODS:
+            this_host = request.get_host()
+            for header in ["referer", "origin"]:
+                value = request.headers.get(header)
+                if value:
+                    parsed = urlparse(value)
+                    if not is_same_domain(parsed.netloc, this_host):
+                        return HttpResponse(self.RESPONSE_TEXT)
+
+        # continue standard parsing; no need to redirect
         response = self.get_response(request)
-        response._headers.pop("Referer", None)
-        response._headers.pop("Origin", None)
+
         return response

--- a/hawc/apps/common/middleware.py
+++ b/hawc/apps/common/middleware.py
@@ -1,10 +1,9 @@
 import re
 
 from django.http import HttpResponse
-from django.utils.deprecation import MiddlewareMixin
 
 
-class MicrosoftOfficeLinkMiddleware(MiddlewareMixin):
+class MicrosoftOfficeLinkMiddleware:
     # https://support.microsoft.com/en-us/kb/899927
     # https://github.com/spilliton/fix_microsoft_links
 
@@ -25,7 +24,7 @@ class MicrosoftOfficeLinkMiddleware(MiddlewareMixin):
         return response
 
 
-class RemoveRefererMiddleware:
+class CsrfRefererCheckMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
 

--- a/hawc/apps/common/views.py
+++ b/hawc/apps/common/views.py
@@ -6,13 +6,13 @@ from urllib.parse import urlparse
 from django.contrib import messages
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.decorators import login_required, user_passes_test
-from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import EmptyResultSet, PermissionDenied
 from django.forms.models import model_to_dict
 from django.http import HttpRequest, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.urls import Resolver404, resolve, reverse
 from django.utils.decorators import method_decorator
+from django.utils.http import is_same_domain
 from django.views.generic import DetailView, ListView
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
 
@@ -49,18 +49,18 @@ def get_referrer(request: HttpRequest, default: str) -> str:
         str: A valid URL, with query params dropped
     """
     url = request.META.get("HTTP_REFERER")
+    this_host = request.get_host()
 
     if default.startswith("https"):
         default_url = default
     else:
-        default_url = f"https://{get_current_site(request).domain}{default}"
+        default_url = f"https://{this_host}{default}"
 
     if url is None:
         return default_url
 
     parsed_url = urlparse(url)
-
-    if get_current_site(request).domain != parsed_url.hostname:
+    if not is_same_domain(parsed_url.netloc, this_host):
         return default_url
 
     try:

--- a/hawc/main/settings/base.py
+++ b/hawc/main/settings/base.py
@@ -75,6 +75,7 @@ MIDDLEWARE = (
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "hawc.apps.common.middleware.MicrosoftOfficeLinkMiddleware",
+    "hawc.apps.common.middleware.RemoveRefererMiddleware",
 )
 
 

--- a/hawc/main/settings/base.py
+++ b/hawc/main/settings/base.py
@@ -75,7 +75,7 @@ MIDDLEWARE = (
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "hawc.apps.common.middleware.MicrosoftOfficeLinkMiddleware",
-    "hawc.apps.common.middleware.RemoveRefererMiddleware",
+    "hawc.apps.common.middleware.CsrfRefererCheckMiddleware",
 )
 
 

--- a/hawc/main/settings/base.py
+++ b/hawc/main/settings/base.py
@@ -69,13 +69,13 @@ MIDDLEWARE = (
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
+    "hawc.apps.common.middleware.CsrfRefererCheckMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "reversion.middleware.RevisionMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "hawc.apps.common.middleware.MicrosoftOfficeLinkMiddleware",
-    "hawc.apps.common.middleware.CsrfRefererCheckMiddleware",
 )
 
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,16 +1,16 @@
 # web application
-Django==3.1.7
+Django==3.1.8
 django-crispy-forms==1.9.1
 django-filter==2.4.0
 django-redis==4.12.1
 django-reversion==3.0.8
 django-selectable==1.3.0
 django-taggit==1.2.0
-django-treebeard==4.3.1
+django-treebeard==4.5.1
 django-webpack-loader==0.7.0
-djangorestframework==3.12.2
+djangorestframework==3.12.4
   uritemplate==3.0.1  # schema dependencies
-  pyyaml==5.3.1       # schema dependencies
+  pyyaml==5.4.1       # schema dependencies
 
 # tasks
 celery==4.4.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,7 +13,6 @@ django-extensions==3.0.9
 faker==4.0.2
 
 # tests
-PyYAML==5.3.1
 coverage==5.0.4
 selenium==3.141.0
 pytest==5.4.1

--- a/tests/hawc/apps/assessment/test_assessment_views.py
+++ b/tests/hawc/apps/assessment/test_assessment_views.py
@@ -1,7 +1,6 @@
 from urllib.parse import urlparse
 
 import pytest
-from django.contrib.sites.shortcuts import get_current_site
 from django.test.client import Client
 from django.urls import reverse
 
@@ -132,24 +131,26 @@ class TestContactUsPage:
         assert resp.status_code == 200
 
     def test_referrer(self):
-        portal_url = reverse("portal")
-        about_url = reverse("about")
         contact_url = reverse("contact")
+        client = Client(SERVER_NAME="testserver")
+        domain = client._base_environ()["SERVER_NAME"]
+        about_url = f"https://{domain}{reverse('about')}"
+        portal_url = f"https://{domain}{reverse('portal')}"
 
-        client = Client()
         client.login(username="pm@hawcproject.org", password="pw")
 
         # no referrer; use default
         resp = client.get(contact_url)
-        assert urlparse(resp.context["form"].fields["previous_page"].initial).path == portal_url
+        assert resp.context["form"].fields["previous_page"].initial == portal_url
 
         # valid referrer; use valid
-        domain = get_current_site(resp.request).domain
-        valid_url = f"https://{domain}{about_url}"
-        resp = client.get(contact_url, HTTP_REFERER=valid_url)
-        assert resp.context["form"].fields["previous_page"].initial == valid_url
+        resp = client.get(contact_url, HTTP_REFERER=about_url)
+        assert resp.context["form"].fields["previous_page"].initial == about_url
+
+        # valid referer; remove arguments
+        resp = client.get(contact_url, HTTP_REFERER=about_url + '?"onmouseover="alert(26)"')
+        assert resp.context["form"].fields["previous_page"].initial == about_url
 
         # invalid referrer; use default
-        about_url = reverse("about")
         resp = client.get(contact_url, HTTP_REFERER=about_url + '"onmouseover="alert(26)"')
-        assert urlparse(resp.context["form"].fields["previous_page"].initial).path == portal_url
+        assert resp.context["form"].fields["previous_page"].initial == portal_url

--- a/tests/hawc/apps/common/test_common_views.py
+++ b/tests/hawc/apps/common/test_common_views.py
@@ -1,5 +1,4 @@
 import pytest
-from django.contrib.sites.shortcuts import get_current_site
 from django.test import RequestFactory
 from django.urls import reverse
 
@@ -11,8 +10,8 @@ def test_get_referrer():
     factory = RequestFactory()
 
     request = factory.get("/")
-    current_site = get_current_site(request)
-    default_url = f'https://{get_current_site(request)}{reverse("portal")}'
+    current_site = "testserver"
+    default_url = f'https://{current_site}{reverse("portal")}'
 
     # url should resolve and will pass-through
     for good_url in [
@@ -34,9 +33,16 @@ def test_get_referrer():
         request = factory.get("/", HTTP_REFERER=bad_url)
         assert get_referrer(request, default_url) == default_url
 
+    # extra arguments removed
+    for bad_url in [
+        f'https://{current_site}/portal/?onmouseover="alert(26)"&extra=true',
+    ]:
+        request = factory.get("/", HTTP_REFERER=bad_url)
+        assert get_referrer(request, default_url) == f"https://{current_site}/portal/"
+
     # check default options
     request = factory.get("/")
-    assert get_referrer(request, "/path-test/") == f"https://{get_current_site(request)}/path-test/"
+    assert get_referrer(request, "/path-test/") == f"https://{current_site}/path-test/"
     assert (
         get_referrer(request, "https://complete-url.com/path-test/")
         == "https://complete-url.com/path-test/"


### PR DESCRIPTION
Add new middleware to validate Referer header on safe requests, per updated security scanning requirements. 

CSRF checking in django middleware is only performed for "unsafe" methods per django [documentation](https://docs.djangoproject.com/en/3.1/ref/csrf/#how-it-works) and [IETF](https://tools.ietf.org/html/rfc7231.html#section-4.2.1).   This PR adds Referer middleware checking on safe requests such as a GET. If the Referer doesn't match the server host name, the middleware returns a valid html page that requests a refresh. This will modify the Referer header to the current domain as expected.

This would only be an real issue if a GET request modified server state and used a Referer header to do so, which isn't a real-world condition for this application.

To test real-world conditions, I made a mock website, and started the django server as normal on port 8000:

```html
<html>
    <body>
        <a href="http://127.0.0.1:8000">GO!</a>
    </body>
</html>
````

Start a webserver via:

```bash
python -m http.server 5000
```

When clicking the link to the django site from an external site, the page load as expected, but the first (small) request issues a refresh:

```text
INFO "GET / HTTP/1.1" 200 79
INFO "GET / HTTP/1.1" 200 23633
```
