### PR TITLE
Assessment permissions cache

### DIFF
--- a/hawc/apps/assessment/models.py
+++ b/hawc/apps/assessment/models.py
@@ -25,6 +25,7 @@ from ..common.models import IntChoiceEnum, get_private_data_storage
 from ..myuser.models import HAWCUser
 from ..vocab.models import VocabularyNamespace
 from . import jobs, managers
+from .permissions import AssessmentPermissions
 from .tasks import add_time_spent
 
 NOEL_NAME_CHOICES_NOEL = 0
@@ -308,83 +309,43 @@ class Assessment(models.Model):
     def __str__(self):
         return f"{self.name} ({self.year})"
 
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        AssessmentPermissions.clear_cache(self)
+
+    def get_permissions(self) -> AssessmentPermissions:
+        return AssessmentPermissions.get(self)
+
     def user_permissions(self, user):
+        perms = self.get_permissions()
         return {
-            "view": self.user_can_view_object(user),
-            "edit": self.user_can_edit_object(user),
-            "edit_assessment": self.user_can_edit_assessment(user),
+            "view": perms.can_view_object(user),
+            "edit": perms.can_edit_object(user),
+            "edit_assessment": perms.can_edit_assessment(user),
         }
 
-    def user_can_view_object(self, user):
-        """
-        Superusers can view all, noneditible reviews can be viewed, team
-        members or project managers can view.
-        Anonymous users on noneditable projects cannot view, nor can those who
-        are non members of a project.
-        """
-        if self.public or user.is_superuser:
-            return True
-        elif user.is_anonymous:
-            return False
-        else:
-            return (
-                (user in self.project_manager.all())
-                or (user in self.team_members.all())
-                or (user in self.reviewers.all())
-            )
+    def user_can_view_object(self, user, perms: AssessmentPermissions = None) -> bool:
+        if perms is None:
+            perms = self.get_permissions()
+        return perms.can_view_object(user)
 
-    def user_can_edit_object(self, user):
-        """
-        If person has enhanced permissions beyond the general public, which may
-        be used to view attachments associated with a study.
-        """
-        if user.is_superuser:
-            return True
-        elif user.is_anonymous:
-            return False
-        else:
-            return self.editable and (
-                user in self.project_manager.all() or user in self.team_members.all()
-            )
+    def user_can_edit_object(self, user, perms: AssessmentPermissions = None) -> bool:
+        if perms is None:
+            perms = self.get_permissions()
+        return perms.can_edit_object(user)
 
-    def user_can_edit_assessment(self, user):
-        """
-        If person is superuser or assessment is editible and user is a project
-        manager or team member.
-        """
-        if user.is_superuser:
-            return True
-        elif user.is_anonymous:
-            return False
-        else:
-            return user in self.project_manager.all()
+    def user_can_edit_assessment(self, user, perms: AssessmentPermissions = None) -> bool:
+        if perms is None:
+            perms = self.get_permissions()
+        return perms.can_edit_assessment(user)
 
-    def user_is_part_of_team(self, user):
-        """
-        Used for permissions-checking if attachments for a study can be
-        viewed. Checks to ensure user is part of the team.
-        """
-        if user.is_superuser:
-            return True
-        elif user.is_anonymous:
-            return False
-        else:
-            return (
-                (user in self.project_manager.all())
-                or (user in self.team_members.all())
-                or (user in self.reviewers.all())
-            )
+    def user_is_part_of_team(self, user) -> bool:
+        perms = self.get_permissions()
+        return perms.part_of_team(user)
 
     def user_is_team_member_or_higher(self, user) -> bool:
-        """
-        Check if user is superuser, project-manager, or team-member, otherwise False.
-        """
-        if user.is_superuser:
-            return True
-        elif user.is_anonymous:
-            return False
-        else:
-            return user in self.project_manager.all() or user in self.team_members.all()
+        perms = self.get_permissions()
+        return perms.team_member_or_higher(user)
 
     def get_vocabulary_display(self) -> str:
         # override default method

--- a/hawc/apps/assessment/models.py
+++ b/hawc/apps/assessment/models.py
@@ -311,7 +311,7 @@ class Assessment(models.Model):
 
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)
-        AssessmentPermissions.clear_cache(self)
+        AssessmentPermissions.clear_cache(self.id)
 
     def get_permissions(self) -> AssessmentPermissions:
         return AssessmentPermissions.get(self)

--- a/hawc/apps/assessment/permissions.py
+++ b/hawc/apps/assessment/permissions.py
@@ -15,7 +15,7 @@ class AssessmentPermissions(BaseModel):
 
     @classmethod
     def get_cache_key(cls, assessment) -> str:
-        return "assessment-perms-{assessment.id}"
+        return f"assessment-perms-{assessment.id}"
 
     @classmethod
     def clear_cache(cls, assessment):

--- a/hawc/apps/assessment/permissions.py
+++ b/hawc/apps/assessment/permissions.py
@@ -1,9 +1,8 @@
 from typing import Set
 
+from django.conf import settings
 from django.core.cache import cache
 from pydantic import BaseModel
-
-from django.conf import settings
 
 
 class AssessmentPermissions(BaseModel):

--- a/hawc/apps/assessment/permissions.py
+++ b/hawc/apps/assessment/permissions.py
@@ -1,0 +1,110 @@
+from typing import Set
+
+from django.core.cache import cache
+from pydantic import BaseModel
+
+from django.conf import settings
+
+
+class AssessmentPermissions(BaseModel):
+    public: bool
+    editable: bool
+    project_manager: Set[int]
+    team_members: Set[int]
+    reviewers: Set[int]
+
+    @classmethod
+    def get_cache_key(cls, assessment) -> str:
+        return "assessment-perms-{assessment.id}"
+
+    @classmethod
+    def clear_cache(cls, assessment):
+        cache.delete(cls.get_cache_key(assessment))
+
+    @classmethod
+    def get(cls, assessment) -> "AssessmentPermissions":
+        key = cls.get_cache_key(assessment)
+        perms = cache.get(key)
+        if perms is None:
+            perms = cls(
+                public=assessment.public,
+                editable=assessment.editable,
+                project_manager={user.id for user in assessment.project_manager.all()},
+                team_members={user.id for user in assessment.team_members.all()},
+                reviewers={user.id for user in assessment.reviewers.all()},
+            )
+            cache.set(key, perms, settings.CACHE_1_HR)
+        return perms
+
+    def can_view_object(self, user) -> bool:
+        """
+        Superusers can view all, noneditible reviews can be viewed, team
+        members or project managers can view.
+        Anonymous users on noneditable projects cannot view, nor can those who
+        are non members of a project.
+        """
+        if self.public:
+            return True
+        return self.part_of_team(user)
+
+    def can_edit_object(self, user) -> bool:
+        """
+        If person has enhanced permissions beyond the general public, which may
+        be used to view attachments associated with a study.
+        """
+        if user.is_superuser:
+            return True
+        elif user.is_anonymous:
+            return False
+        else:
+            return self.editable and (
+                user.id in self.project_manager or user.id in self.team_members
+            )
+
+    def can_edit_assessment(self, user) -> bool:
+        """
+        If person is superuser or assessment is editible and user is a project
+        manager or team member.
+        """
+        if user.is_superuser:
+            return True
+        elif user.is_anonymous:
+            return False
+        else:
+            return user.id in self.project_manager
+
+    def part_of_team(self, user) -> bool:
+        """
+        Used for permissions-checking if attachments for a study can be
+        viewed. Checks to ensure user is part of the team.
+        """
+        if user.is_superuser:
+            return True
+        elif user.is_anonymous:
+            return False
+        else:
+            return (
+                user.id in self.project_manager
+                or user.id in self.team_members
+                or user.id in self.reviewers
+            )
+
+    def team_member_or_higher(self, user) -> bool:
+        """
+        Check if user is superuser, project-manager, or team-member, otherwise False.
+        """
+        if user.is_superuser:
+            return True
+        elif user.is_anonymous:
+            return False
+        else:
+            return user.id in self.project_manager or user.id in self.team_members
+
+    def can_edit_study(self, study, user) -> bool:
+        """
+        Check if user can edit a study; dependent on if study is editable
+        """
+        if study.editable and self.can_edit_object(user):
+            return True
+
+        return self.can_edit_assessment(user)

--- a/hawc/apps/assessment/permissions.py
+++ b/hawc/apps/assessment/permissions.py
@@ -13,16 +13,17 @@ class AssessmentPermissions(BaseModel):
     reviewers: Set[int]
 
     @classmethod
-    def get_cache_key(cls, assessment) -> str:
-        return f"assessment-perms-{assessment.id}"
+    def get_cache_key(cls, assessment_id: int) -> str:
+        return f"assessment-perms-{assessment_id}"
 
     @classmethod
-    def clear_cache(cls, assessment):
-        cache.delete(cls.get_cache_key(assessment))
+    def clear_cache(cls, assessment_id: int):
+        key = cls.get_cache_key(assessment_id)
+        cache.delete(key)
 
     @classmethod
     def get(cls, assessment) -> "AssessmentPermissions":
-        key = cls.get_cache_key(assessment)
+        key = cls.get_cache_key(assessment.id)
         perms = cache.get(key)
         if perms is None:
             perms = cls(

--- a/hawc/apps/assessment/views.py
+++ b/hawc/apps/assessment/views.py
@@ -361,7 +361,8 @@ class AssessmentClearCache(MessageMixin, View):
     def get(self, request, *args, **kwargs):
         assessment = get_object_or_404(self.model, pk=kwargs["pk"])
         url = get_referrer(self.request, assessment.get_absolute_url())
-        if not assessment.user_can_edit_object(request.user):
+
+        if not assessment.user_is_team_member_or_higher(request.user):
             raise PermissionDenied()
 
         assessment.bust_cache()

--- a/hawc/apps/common/views.py
+++ b/hawc/apps/common/views.py
@@ -319,18 +319,6 @@ class TeamMemberOrHigherMixin:
         return context
 
 
-class IsAuthorMixin:
-    # Throw error if user is not author
-
-    owner_field = "author"
-
-    def get_object(self):
-        obj = super().get_object()
-        if getattr(obj, self.owner_field) != self.request.user:
-            raise PermissionDenied
-        return obj
-
-
 class CanCreateMixin:
     """
     Checks to make sure that the user has appropriate permissions before adding

--- a/hawc/apps/study/models.py
+++ b/hawc/apps/study/models.py
@@ -414,14 +414,9 @@ class Study(Reference):
     def get_study(self):
         return self
 
-    def user_can_edit_study(self, assessment, user):
-        # TODO - remove, or user super()? this is almost already implemented with standard methods?
-        if user.is_superuser or user in assessment.project_manager.all():
-            return True
-        elif user.is_anonymous:
-            return False
-        else:
-            return self.editable and user in assessment.team_members.all()
+    def user_can_edit_study(self, assessment, user) -> bool:
+        perms = assessment.get_permissions()
+        return perms.can_edit_study(self, user)
 
     @classmethod
     def delete_cache(cls, assessment_id: int, delete_reference_cache: bool = True):

--- a/hawc/main/settings/dev.py
+++ b/hawc/main/settings/dev.py
@@ -31,8 +31,6 @@ CACHES = {
         "TIMEOUT": 60 * 10,  # 10 minutes (in seconds)
     }
 }
-CACHE_1_HR = 0  # disable cache in dev mode
-CACHE_10_MIN = 0  # disable cache in dev mode
 
 LOGGING["loggers"][""]["handlers"] = ["console"]
 LOGGING["loggers"][""]["level"] = "INFO"

--- a/hawc/main/settings/local.example.py
+++ b/hawc/main/settings/local.example.py
@@ -14,6 +14,9 @@ DATABASES = {
     }
 }
 
+# disable cache (comment to use cache; uncomment to disable)
+CACHES["default"]["BACKEND"] = "django.core.cache.backends.dummy.DummyCache"
+
 # view all database queries in console
 # LOGGING["loggers"]["django.db.backends"] = {"handlers": ["console"], "level": "DEBUG"}
 

--- a/hawc/main/settings/local.example.py
+++ b/hawc/main/settings/local.example.py
@@ -23,5 +23,5 @@ BMD_HOST = "http://example.com"  # optional; used for BMD module
 # SET HAWC FLAVOR (see docs)
 HAWC_FLAVOR = "PRIME"
 
-# cache for 1 sec instead
-CACHE_1_HR = 1
+# disable cache
+# CACHES["default"]["BACKEND"] = "django.core.cache.backends.dummy.DummyCache"

--- a/hawc/main/settings/local.example.py
+++ b/hawc/main/settings/local.example.py
@@ -25,6 +25,3 @@ BMD_HOST = "http://example.com"  # optional; used for BMD module
 
 # SET HAWC FLAVOR (see docs)
 HAWC_FLAVOR = "PRIME"
-
-# disable cache
-# CACHES["default"]["BACKEND"] = "django.core.cache.backends.dummy.DummyCache"

--- a/tests/hawc/apps/assessment/test_assessment_view_permissions.py
+++ b/tests/hawc/apps/assessment/test_assessment_view_permissions.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from pytest_django.asserts import assertTemplateUsed
 
 from hawc.apps.assessment.models import Assessment
+from hawc.apps.assessment.permissions import AssessmentPermissions
 
 _successful_post = {
     "name": "testing",
@@ -116,6 +117,10 @@ class TestEditPermissions:
                     follow=True,
                 )
                 assert response.status_code == 200
+
+        # rollback in test doesn't clear permissions cache; clear manually
+        AssessmentPermissions.clear_cache(db_keys.assessment_working)
+        AssessmentPermissions.clear_cache(db_keys.assessment_final)
 
     def test_failure(self, db_keys):
         clients = (None, "team@hawcproject.org", "reviewer@hawcproject.org")

--- a/tests/hawc/apps/assessment/test_assessment_views.py
+++ b/tests/hawc/apps/assessment/test_assessment_views.py
@@ -24,11 +24,12 @@ class TestAssessmentClearCache:
         # test successes
         for client in ["pm@hawcproject.org", "team@hawcproject.org"]:
             c = Client()
-            if client:
-                assert c.login(username=client, password="pw") is True
-            # this is success behavior in test environment w/o redis - TODO improve?
-            with pytest.raises(NotImplementedError):
-                response = c.get(url)
+            assert c.login(username=client, password="pw") is True
+
+            # this is "success" using a non-redis cache
+            with pytest.raises(NotImplementedError) as err:
+                c.get(url)
+            assert "Cannot wipe assessment cache using this cache backend" in str(err)
 
     @pytest.mark.django_db
     def test_functionality(self, db_keys):


### PR DESCRIPTION
Build a cache for all assessment setting related to view permissions.  Currently, each view is slowed by querying the assessment, plus multiple many to many relations to check if a specific user has permission to view. This PR implements a cache that's refreshed whenever the assessment is saved, which captures all user ids with permission and other assessment settings in a cache. 

Also update development settings to have a single setting to enable or disable cache in dev mode.

The net result of this PR is a speedup for view permission checking and moving db queries to a cache.