### PR TITLE
Fix table url validation

### DIFF
--- a/hawc/apps/summary/models.py
+++ b/hawc/apps/summary/models.py
@@ -252,8 +252,11 @@ class SummaryTable(models.Model):
         except ValueError as e:
             raise ValidationError({"content": str(e)})
 
-        # validate tags used in text
+        # clean up control characters before string validation
         content_str = json.dumps(self.content)
+        content_str = content_str.replace('\\"', '"')
+
+        # validate tags used in text
         validate_html_tags(content_str)
         validate_hyperlinks(content_str)
 

--- a/hawc/apps/summary/models.py
+++ b/hawc/apps/summary/models.py
@@ -253,8 +253,7 @@ class SummaryTable(models.Model):
             raise ValidationError({"content": str(e)})
 
         # clean up control characters before string validation
-        content_str = json.dumps(self.content)
-        content_str = content_str.replace('\\"', '"')
+        content_str = json.dumps(self.content).replace('\\"', '"')
 
         # validate tags used in text
         validate_html_tags(content_str)


### PR DESCRIPTION
`json.dumps` injects control characters in the resulting string, so `"href=\"www.example.com\""` becomes `"href=\\"www.example.com\\""`. Our url validator doesn't take this into account, so these control characters should be removed before validation.