### PR TITLE
bugfix - add underline to accepted table tags

### DIFF
--- a/hawc/apps/common/validators.py
+++ b/hawc/apps/common/validators.py
@@ -23,6 +23,7 @@ valid_html_tags_re = {
     "span",
     "strong",
     "ul",
+    "u",
 }
 valid_scheme = {"", "http", "https"}
 valid_netloc_endings = {".gov", ".edu", ".who.int", "sciencedirect.com", "elsevier.com"}

--- a/hawc/tools/tables/parser.py
+++ b/hawc/tools/tables/parser.py
@@ -31,9 +31,9 @@ def ol_wrapper(texts):
 class QuillParser(HTMLParser):
 
     # Inline tags
-    _inline_tags = ["strong", "em", "a"]
+    _inline_tags = ["strong", "em", "u", "a"]
     # Inline tags to their font attribute
-    _tag_font_attr = {"strong": "bold", "em": "italic"}
+    _tag_font_attr = {"strong": "bold", "em": "italic", "u": "underline"}
     # Cached inline tags
     _tags = set()
 

--- a/tests/data/fixtures/db.yaml
+++ b/tests/data/fixtures/db.yaml
@@ -4955,7 +4955,7 @@
         header: false
         col_span: 1
         row_span: 1
-        quill_text: <p><strong>Other features</strong></p><ul><li>bullets can be added</li><li><a
+        quill_text: <p><strong><em><u>Other features</u></em></strong></p><ul><li>bullets can be added</li><li><a
           href="https://google.com" rel="noopener noreferrer" target="_blank">Hyperlinks</a>
           can be added</li></ul>
       - row: 7


### PR DESCRIPTION
Previously, our html validator erroneously made underlined text invalid. This PR allows makes the `<u>` tag valid.


Text can now be underlined on summary tables:

![image](https://user-images.githubusercontent.com/46504563/115262964-03767200-a103-11eb-83d8-228b6e282491.png)

The underline is rendered correctly in reports:

![image](https://user-images.githubusercontent.com/46504563/115263070-1b4df600-a103-11eb-911f-12c1836c80e0.png)
