### PR TITLE
Miscellaneous error fixes

### DIFF
--- a/frontend/riskofbias/constants.js
+++ b/frontend/riskofbias/constants.js
@@ -131,9 +131,11 @@ const NA_KEYS = [10, 20],
     },
     getMultiScoreDisplaySettings = function(scores) {
         // Return visualization/color settings for situations where multiple scores may exist for
-        // a given metric (eg, study-level override settings)
+        // a given metric (eg, study-level override settings).
+        // By default, if multiple scores exist and show he defaults score label if one exists.
+        // If the default score does not exist, present the value of the first score (random).
         let sortedScores = _.orderBy(scores, "score", "desc"),
-            defaultScore = _.find(scores, {is_default: true}),
+            defaultScore = _.find(scores, {is_default: true}) || sortedScores[0],
             shades = _.chain(sortedScores)
                 .map(score => score.score_shade)
                 .uniq()

--- a/hawc/apps/assessment/api.py
+++ b/hawc/apps/assessment/api.py
@@ -32,6 +32,11 @@ class RequiresAssessmentID(APIException):
     default_detail = "Please provide an `assessment_id` argument to your GET request."
 
 
+class InvalidAssessmentID(APIException):
+    status_code = status.HTTP_400_BAD_REQUEST
+    default_detail = "Assessment does not exist for given `assessment_id`."
+
+
 class DisabledPagination(PageNumberPagination):
     page_size = None
 
@@ -47,9 +52,12 @@ def get_assessment_id_param(request) -> int:
 
 
 def get_assessment_from_query(request) -> Optional[models.Assessment]:
-    """Returns assessment or None."""
+    """Returns assessment or raises exception if does not exist."""
     assessment_id = get_assessment_id_param(request)
-    return models.Assessment.objects.filter(pk=assessment_id).first()
+    try:
+        return models.Assessment.objects.get(pk=assessment_id)
+    except models.Assessment.DoesNotExist:
+        raise InvalidAssessmentID()
 
 
 class JobPermissions(permissions.BasePermission):
@@ -105,9 +113,6 @@ class AssessmentLevelPermissions(permissions.BasePermission):
             if not hasattr(view, "assessment"):
                 view.assessment = get_assessment_from_query(request)
 
-            if view.assessment is None:
-                return False
-
             return view.assessment.user_can_view_object(request.user)
 
         return True
@@ -134,9 +139,6 @@ class InAssessmentFilter(filters.BaseFilterBackend):
 
         if not hasattr(view, "assessment"):
             view.assessment = get_assessment_from_query(request)
-
-        if view.assessment is None:
-            return queryset.none()
 
         if not view.assessment_filter_args:
             raise ValueError("Viewset requires the `assessment_filter_args` argument")

--- a/hawc/apps/assessment/managers.py
+++ b/hawc/apps/assessment/managers.py
@@ -19,7 +19,11 @@ class AssessmentManager(BaseManager):
         optionally excluding assessment exclusion_id,
         not including public assessments
         """
-        filters = Q(project_manager=user) | Q(team_members=user) | Q(reviewers=user)
+        filters = (
+            Q(project_manager=user) | Q(team_members=user) | Q(reviewers=user)
+            if user.is_authenticated
+            else Q(pk__in=[])
+        )
         if public:
             filters |= Q(public=True) & Q(hide_from_public_page=False)
         return self.filter(filters).exclude(id=exclusion_id).distinct()

--- a/hawc/apps/lit/views.py
+++ b/hawc/apps/lit/views.py
@@ -69,7 +69,7 @@ class LitOverview(BaseList):
         return context
 
 
-class SearchCopyAsNewSelector(AssessmentPermissionsMixin, FormView):
+class SearchCopyAsNewSelector(TeamMemberOrHigherMixin, FormView):
     """
     Select an existing search and copy-as-new
     """
@@ -77,14 +77,11 @@ class SearchCopyAsNewSelector(AssessmentPermissionsMixin, FormView):
     template_name = "lit/search_copy_selector.html"
     form_class = forms.SearchSelectorForm
 
-    def dispatch(self, *args, **kwargs):
-        self.assessment = get_object_or_404(Assessment, pk=kwargs["pk"])
-        self.permission_check_user_can_view()
-        return super().dispatch(*args, **kwargs)
+    def get_assessment(self, request, *args, **kwargs):
+        return get_object_or_404(Assessment, pk=self.kwargs.get("pk"))
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["assessment"] = self.assessment
         context["breadcrumbs"] = lit_overview_crumbs(
             self.request.user, self.assessment, "Copy literature search or import"
         )

--- a/hawc/apps/riskofbias/api.py
+++ b/hawc/apps/riskofbias/api.py
@@ -169,7 +169,7 @@ class AssessmentMetricScoreViewset(AssessmentViewset):
 class AssessmentScoreViewset(AssessmentEditViewset):
     model = models.RiskOfBiasScore
     pagination_class = DisabledPagination
-    assessment_filter_args = "metric__domain_assessment"
+    assessment_filter_args = "metric__domain__assessment"
     serializer_class = serializers.RiskOfBiasScoreSerializer
 
     def get_assessment(self, request, *args, **kwargs):


### PR DESCRIPTION
## Bad related field
The related field was `domain_assessment`, when it should have been `domain__assessment`

![image](https://user-images.githubusercontent.com/46504563/115289517-a689b480-a120-11eb-9b57-87ddef3e9f0e.png)
![image](https://user-images.githubusercontent.com/46504563/115287681-8ce76d80-a11e-11eb-815e-c2d17af735ac.png)

## Cannot call assessment method on None object
`get_assessment_from_query` returns either the assessment or none if `assessment_id` does not correspond with an assessment. It works in all contexts where this function is called to just have it raise an exception if the assessment does not exist instead.

![image](https://user-images.githubusercontent.com/46504563/115288713-c5d41200-a11f-11eb-9151-b5e87418a377.png)
![image](https://user-images.githubusercontent.com/46504563/115287707-953fa880-a11e-11eb-9754-c07ee0049512.png)

Another case I found:

![image](https://user-images.githubusercontent.com/46504563/115289268-64f90980-a120-11eb-8f8b-e8a0aa6d2896.png)
![image](https://user-images.githubusercontent.com/46504563/115289238-5a3e7480-a120-11eb-8999-0750c2cc8a27.png)

## Anonymous user error
This error is thrown when trying to filter by an anonymous user. The fix is to check authentication instead.

![image](https://user-images.githubusercontent.com/46504563/115287859-bef8cf80-a11e-11eb-8d9a-68ed7e1e5d9d.png)
![image](https://user-images.githubusercontent.com/46504563/115287765-a25c9780-a11e-11eb-94c1-a3f66027029c.png)
__*Note:__ Should we even be rendering this page as an anonymous user? It serves as a launch page for copying searches, which anonymous users wouldn't be able to do to begin with (the `Searches` dropdown doesn't have any options for anonymous users)