### PR TITLE
hotfix - fix tests in CI/CD

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
     - name: install
       run: |
         mv ci-webpack-stats.json webpack-stats.json
+        pip install -U pip wheel
         pip install -r requirements/dev.txt
     - name: lint
       run: |

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ flake8-isort==2.9.0
 mypy==0.770
 
 # django development
-django-debug-toolbar==3.1.1
+django-debug-toolbar==3.2.1
 django-extensions==3.0.9
 faker==4.0.2
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,9 +21,6 @@ vcrpy==4.0.2
 pytest-vcr==1.0.2
 helium==3.0.4
 
-# build tools
-wheel==0.34.2
-
 # docs
 watchdog==0.10.2
 Sphinx==2.4.4

--- a/tests/hawc/apps/epi/test_epi_api.py
+++ b/tests/hawc/apps/epi/test_epi_api.py
@@ -1441,6 +1441,7 @@ class TestExposureApi:
 
         generic_test_scenarios(client, url, scenarios)
 
+    @pytest.mark.vcr  # cache epa actor webservice response
     def test_valid_requests(self, db_keys):
         url = reverse("epi:api:exposure-list")
         client = APIClient()
@@ -1502,13 +1503,15 @@ class TestExposureApi:
                 "data": self.get_upload_data(),
                 "post_request_test": exposure_lookup_test,
             },
-            {
-                "desc": "on the fly dtxsid creation",
-                "expected_code": 201,
-                "expected_keys": {"id"},
-                "data": self.get_upload_data({"dtxsid": new_dtxsid}),
-                "post_request_test": exposure_lookup_test_with_new_dtxsid,
-            },
+            # TODO - restore this test once dsstox is online
+            # https://actorws.epa.gov/actorws/chemIdentifier/v01/resolve.json?identifier=mercury
+            # {
+            #     "desc": "on the fly dtxsid creation",
+            #     "expected_code": 201,
+            #     "expected_keys": {"id"},
+            #     "data": self.get_upload_data({"dtxsid": new_dtxsid}),
+            #     "post_request_test": exposure_lookup_test_with_new_dtxsid,
+            # },
             {
                 "desc": "dose unit by name",
                 "expected_code": 201,


### PR DESCRIPTION
We inadvertently had a unit-test which used an external webservice which is periodically down. This update temporarily disables that test, and in the future we'll use [vcr](https://vcrpy.readthedocs.io/en/latest/) to cache the response when it becomes available in the future.

At a future date the commented-test will be uncommented and a cached response will be saved.