### PR TITLE
dosing regime dose groups hotfix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
     - name: install
       run: |
         mv ci-webpack-stats.json webpack-stats.json
+        pip install -U pip wheel
         pip install -r requirements/dev.txt
     - name: lint
       run: |

--- a/hawc/apps/animal/signals.py
+++ b/hawc/apps/animal/signals.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from django.db.models.signals import post_save, pre_delete
 from django.dispatch import receiver
 
@@ -36,31 +37,32 @@ def invalidate_endpoint_cache(sender, instance, **kwargs):
 
 @receiver(post_save, sender=models.DosingRegime)
 def change_num_dg(sender, instance, **kwargs):
-    # Ensure number endpoint-groups == dose-groups
+    # Ensure number endpoint-groups == dose-groups;
 
     # get endpoints associated with this dosing-regime
-    eps = models.Endpoint.objects.filter(
-        animal_group_id__in=models.AnimalGroup.objects.filter(dosing_regime=instance)
+    endpoints = models.Endpoint.objects.filter(
+        animal_group_id__in=models.AnimalGroup.objects.filter(dosing_regime=instance),
+        data_extracted=True,
     )
 
-    if eps.count() == 0:
+    # no changes required if we have no endpoints
+    if endpoints.count() == 0:
         return
 
     # get dose-ids
-    dose_ids = instance.doses.all().values_list("dose_group_id", flat=True)
+    dose_group_ids = sorted(set(instance.doses.all().values_list("dose_group_id", flat=True)))
 
     # create endpoint-groups, as needed
-    egs = []
-    for dose_id in dose_ids:
-        egs.extend(
-            [
-                models.EndpointGroup(endpoint_id=ep.id, dose_group_id=dose_id)
-                for ep in eps.exclude(groups__dose_group_id=dose_id)
-            ]
-        )
-    models.EndpointGroup.objects.bulk_create(egs)
+    creates = []
+    for dg_id in dose_group_ids:
+        for ep in endpoints.exclude(groups__dose_group_id=dg_id):
+            creates.append(models.EndpointGroup(endpoint_id=ep.id, dose_group_id=dg_id))
 
     # delete endpoint-groups without a dose-group, as needed
-    models.EndpointGroup.objects.filter(endpoint__in=eps).exclude(
-        dose_group_id__in=dose_ids
-    ).delete()
+    deletes = models.EndpointGroup.objects.filter(endpoint__in=endpoints).exclude(
+        dose_group_id__in=dose_group_ids
+    )
+
+    with transaction.atomic():
+        models.EndpointGroup.objects.bulk_create(creates)
+        deletes.delete()

--- a/tests/hawc/apps/animal/test_animal_signals.py
+++ b/tests/hawc/apps/animal/test_animal_signals.py
@@ -1,0 +1,50 @@
+from collections import Counter
+
+import pytest
+
+from hawc.apps.animal import models
+
+
+@pytest.mark.django_db
+class TestChangeNumDoseGroups:
+    dr_id = 3
+
+    def test_addition(self):
+        # assert that adding a dose-group creates endpoint groups
+
+        dose_regime = models.DosingRegime.objects.get(id=self.dr_id)
+        assert dose_regime.num_dose_groups == 5
+
+        assert set(
+            models.DoseGroup.objects.filter(dose_regime=self.dr_id).values_list(
+                "dose_group_id", flat=True
+            )
+        ) == {0, 1, 2, 3, 4}
+        egs = models.EndpointGroup.objects.filter(endpoint__animal_group__dosing_regime=self.dr_id)
+        assert Counter(eg.dose_group_id for eg in egs) == {0: 3, 1: 3, 2: 3, 3: 3, 4: 3}
+
+        dose_regime.num_dose_groups = 6
+        dose_regime.save()
+
+        egs = models.EndpointGroup.objects.filter(endpoint__animal_group__dosing_regime=self.dr_id)
+        assert Counter(eg.dose_group_id for eg in egs) == {0: 3, 1: 3, 2: 3, 3: 3, 4: 3, 5: 3}
+
+    def test_deletion(self):
+        # assert that deleting a dose-group removes endpoint groups
+
+        dose_regime = models.DosingRegime.objects.get(id=self.dr_id)
+        assert dose_regime.num_dose_groups == 5
+
+        assert set(
+            models.DoseGroup.objects.filter(dose_regime=self.dr_id).values_list(
+                "dose_group_id", flat=True
+            )
+        ) == {0, 1, 2, 3, 4}
+        egs = models.EndpointGroup.objects.filter(endpoint__animal_group__dosing_regime=self.dr_id)
+        assert Counter(eg.dose_group_id for eg in egs) == {0: 3, 1: 3, 2: 3, 3: 3, 4: 3}
+
+        dose_regime.num_dose_groups = 4
+        dose_regime.save()
+
+        egs = models.EndpointGroup.objects.filter(endpoint__animal_group__dosing_regime=self.dr_id)
+        assert Counter(eg.dose_group_id for eg in egs) == {0: 3, 1: 3, 2: 3, 3: 3}


### PR DESCRIPTION
We had a reported data corruption issue where a user edited content in a dosing regime and then after saving, we found multiple endpoint-groups with the same endpoint group id, which shouldn't be possible.

After investigation, we found it was an error in the signal which keeps dose-groups and endpoint-groups synced. If there were multiple representation of dose-groups, for example 5 dose-groups and 2 units, then hawc would create 10 endpoint-groups instead of 5. Further, it would create these even for endpoints where data is not extracted.

Here we fix this issue and write a few tests.