### PR TITLE
Bmd dose dropped

### DIFF
--- a/frontend/bmd/bmds2/components/ModelOptionModal.js
+++ b/frontend/bmd/bmds2/components/ModelOptionModal.js
@@ -117,6 +117,13 @@ class ModelOptionModal extends BaseModal {
                                     );
                                 })}
                             </div>
+                            <p className="text-muted">
+                                When ‟Doses to drop” is 0, no doses are dropped. If doses dropped is
+                                greater than zero, doses are dropped from the maximum dose in
+                                reverse order (e.g., a value of 1 drops the highest dose). All
+                                models must have the same ‟Doses to Drop” value in order for a dose
+                                to actually be dropped; otherwise it is ignored.
+                            </p>
                         </fieldset>
                         <fieldset className="col-md-6">
                             <legend>Optimizer assignments</legend>

--- a/frontend/bmd/bmds2/components/ModelOptionTable.js
+++ b/frontend/bmd/bmds2/components/ModelOptionTable.js
@@ -73,6 +73,7 @@ class ModelOptionTable extends React.Component {
                             {showVariance ? (
                                 <li>
                                     <a
+                                        className="dropdown-item"
                                         href="#"
                                         onClick={event => {
                                             event.preventDefault();

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ flake8-isort==2.9.0
 mypy==0.770
 
 # django development
-django-debug-toolbar==3.1.1
+django-debug-toolbar==3.2.1
 django-extensions==3.0.9
 faker==4.0.2
 


### PR DESCRIPTION
Update frontend to describe dose-dropping functionality since the UI is different than the backend implementation. This is a short-term fix; the correct approach for fixing would be more time consuming and is not worth the effort since we will be moving to bmds 3.4 in the next year and 2.7 will be deprecated.

<img width="573" alt="Screen Shot 2021-04-23 at 4 52 21 PM" src="https://user-images.githubusercontent.com/999952/115928584-5da16b00-a454-11eb-8281-08f94e89f1b8.png">
