### PR TITLE
fix 500 error if dataset revision does not exist

### DIFF
--- a/hawc/apps/assessment/admin.py
+++ b/hawc/apps/assessment/admin.py
@@ -149,9 +149,8 @@ class DatasetAdmin(admin.ModelAdmin):
     )
     list_display_links = ("id",)
     list_filter = (("assessment", admin.RelatedOnlyFieldListFilter),)
-    inlines = [
-        DatasetRevisionInline,
-    ]
+    inlines = [DatasetRevisionInline]
+    readonly_fields = ("assessment_id", "assessment")
 
 
 @admin.register(models.DoseUnits)

--- a/hawc/apps/assessment/api.py
+++ b/hawc/apps/assessment/api.py
@@ -496,6 +496,8 @@ class DatasetViewset(AssessmentViewset):
     def data(self, request, pk: int = None):
         instance = self.get_object()
         revision = instance.get_latest_revision()
+        if not revision.data_exists():
+            raise Http404()
         export = FlatExport(df=revision.get_df(), filename=Path(revision.metadata["filename"]).stem)
         return Response(export)
 
@@ -505,7 +507,7 @@ class DatasetViewset(AssessmentViewset):
         if not self.assessment.user_is_team_member_or_higher(request.user):
             raise PermissionDenied()
         revision = instance.revisions.filter(version=version).first()
-        if revision is None:
+        if revision is None or not revision.data_exists():
             raise Http404()
         export = FlatExport(df=revision.get_df(), filename=Path(revision.metadata["filename"]).stem)
         return Response(export)

--- a/hawc/apps/assessment/models.py
+++ b/hawc/apps/assessment/models.py
@@ -824,6 +824,13 @@ class DatasetRevision(models.Model):
     def get_df(self) -> pd.DataFrame:
         return self.try_read_df(self.data, self.metadata["extension"], self.excel_worksheet_name)
 
+    def data_exists(self) -> bool:
+        try:
+            _ = self.data.file
+            return True
+        except FileNotFoundError:
+            return False
+
     @classmethod
     def try_read_df(cls, data, suffix: str, worksheet_name: str = None) -> pd.DataFrame:
         """

--- a/hawc/apps/assessment/models.py
+++ b/hawc/apps/assessment/models.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import uuid
 from typing import Any, Dict, List, NamedTuple
 
@@ -28,6 +29,8 @@ from ..vocab.models import VocabularyNamespace
 from . import jobs, managers
 from .permissions import AssessmentPermissions
 from .tasks import add_time_spent
+
+logger = logging.getLogger(__name__)
 
 NOEL_NAME_CHOICES_NOEL = 0
 NOEL_NAME_CHOICES_NOAEL = 1
@@ -791,6 +794,7 @@ class DatasetRevision(models.Model):
             _ = self.data.file
             return True
         except FileNotFoundError:
+            logger.error(f"DatasetRevision {self.id} not found: {self.data.path}")
             return False
 
     @classmethod


### PR DESCRIPTION
If dataset revision does not exist, log the error but return a 404.

Error found in dev/test environments, should not occur in production environment. We still log the error in case it's found.