### PR TITLE
require UID for vocab.Term EHV

### DIFF
--- a/hawc/apps/vocab/migrations/0006_require_uid.py
+++ b/hawc/apps/vocab/migrations/0006_require_uid.py
@@ -1,0 +1,14 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("vocab", "0005_delete_comment"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="term", name="uid", field=models.PositiveIntegerField(unique=True),
+        ),
+    ]

--- a/hawc/apps/vocab/models.py
+++ b/hawc/apps/vocab/models.py
@@ -67,7 +67,7 @@ class VocabularyTermType(IntChoiceEnum):
 class Term(models.Model):
     objects = managers.TermManager()
 
-    uid = models.PositiveIntegerField(unique=True, blank=True, null=True)
+    uid = models.PositiveIntegerField(unique=True)
     namespace = models.PositiveSmallIntegerField(
         choices=VocabularyNamespace.choices(), default=VocabularyNamespace.EHV
     )


### PR DESCRIPTION
(cherry picked from commit 2cb993abcb89f88b0e0ac15e74e647dc0e55ef87)

This is a separate PR from #417 so that new vocabularies can be loaded before the requirement is added.