### PR TITLE
fix bug in exploratory heatmap header text

### DIFF
--- a/frontend/summary/summaryForms/heatmap/AxisLabelTable.js
+++ b/frontend/summary/summaryForms/heatmap/AxisLabelTable.js
@@ -68,9 +68,7 @@ class AxisLabelTable extends Component {
                     <TextInput
                         name={`${key}-delimiter-${index}`}
                         value={row.delimiter}
-                        onChange={e =>
-                            changeArraySettings(key, index, "delimiter", e.target.value.trim())
-                        }
+                        onChange={e => changeArraySettings(key, index, "delimiter", e.target.value)}
                     />
                 </td>
                 <td>

--- a/frontend/summary/summaryForms/heatmap/DetailTable.js
+++ b/frontend/summary/summaryForms/heatmap/DetailTable.js
@@ -70,18 +70,14 @@ class DetailTable extends Component {
                     <TextInput
                         name={`${key}-header-${index}`}
                         value={row.header}
-                        onChange={e =>
-                            changeArraySettings(key, index, "header", e.target.value.trim())
-                        }
+                        onChange={e => changeArraySettings(key, index, "header", e.target.value)}
                     />
                 </td>
                 <td>
                     <TextInput
                         name={`${key}-delimiter-${index}`}
                         value={row.delimiter}
-                        onChange={e =>
-                            changeArraySettings(key, index, "delimiter", e.target.value.trim())
-                        }
+                        onChange={e => changeArraySettings(key, index, "delimiter", e.target.value)}
                     />
                 </td>
                 <td>

--- a/frontend/summary/summaryForms/heatmap/FilterWidgetTable.js
+++ b/frontend/summary/summaryForms/heatmap/FilterWidgetTable.js
@@ -70,9 +70,7 @@ class FilterWidgetTable extends Component {
                     <TextInput
                         name={`${key}-header-${index}`}
                         value={row.header}
-                        onChange={e =>
-                            changeArraySettings(key, index, "header", e.target.value.trim())
-                        }
+                        onChange={e => changeArraySettings(key, index, "header", e.target.value)}
                     />
                 </td>
                 <td>
@@ -80,9 +78,7 @@ class FilterWidgetTable extends Component {
                         name={`${key}-delimiter-${index}`}
                         className="col-md-12"
                         value={row.delimiter}
-                        onChange={e =>
-                            changeArraySettings(key, index, "delimiter", e.target.value.trim())
-                        }
+                        onChange={e => changeArraySettings(key, index, "delimiter", e.target.value)}
                     />
                 </td>
                 <td>


### PR DESCRIPTION
User-reported bug where a space couldn't be added to a header column because trim() was applied with all changes; this removes the trim() method on all text boxes when editing exploratory heatmap

<img width="1109" alt="Screen Shot 2021-05-24 at 11 18 15 AM" src="https://user-images.githubusercontent.com/999952/119369075-c2352d00-bc81-11eb-86eb-b348b7f82a30.png">
