### PR TITLE
right-align y-axis labels in heatmap

### DIFF
--- a/frontend/summary/summary/ExploreHeatmapPlot.js
+++ b/frontend/summary/summary/ExploreHeatmapPlot.js
@@ -256,7 +256,7 @@ class ExploreHeatmapPlot {
             let newYOffset = yOffset + box.height + label_padding * 2;
             let border = xAxis
                 .append("g")
-                .attr("fill", "transparent")
+                .attr("fill-opacity", 0)
                 .attr("stroke", show_axis_border ? "black" : null)
                 .selectAll(".none")
                 .data(borderData)
@@ -284,7 +284,7 @@ class ExploreHeatmapPlot {
             xAxis
                 .append("polyline")
                 .attr("points", d => `${x1},${y1} ${x1},${y2} ${x2},${y2} ${x2},${y1}`)
-                .attr("fill", "transparent")
+                .attr("fill-opacity", 0)
                 .attr("stroke", show_axis_border ? "black" : null);
         }
 
@@ -422,7 +422,7 @@ class ExploreHeatmapPlot {
             let newYOffset = yOffset - (box.height + label_padding * 2);
             let border = xAxis
                 .append("g")
-                .attr("fill", "transparent")
+                .attr("fill-opacity", 0)
                 .attr("stroke", show_axis_border ? "black" : null)
                 .selectAll(".none")
                 .data(borderData)
@@ -450,7 +450,7 @@ class ExploreHeatmapPlot {
             xAxis
                 .append("polyline")
                 .attr("points", d => `${x1},${y1} ${x1},${y2} ${x2},${y2} ${x2},${y1}`)
-                .attr("fill", "transparent")
+                .attr("fill-opacity", 0)
                 .attr("stroke", show_axis_border ? "black" : null);
         }
 
@@ -554,7 +554,7 @@ class ExploreHeatmapPlot {
             let border = yAxis
                 .append("g")
                 .attr("transform", `translate(${-xOffset},0)`)
-                .attr("fill", "transparent")
+                .attr("fill-opacity", 0)
                 .attr("stroke", show_axis_border ? "black" : null)
                 .selectAll(".none")
                 .data(borderData)
@@ -581,7 +581,7 @@ class ExploreHeatmapPlot {
             yAxis
                 .append("polyline")
                 .attr("points", d => `${x1},${y1} ${x2},${y1} ${x2},${y2} ${x1},${y2}`)
-                .attr("fill", "transparent")
+                .attr("fill-opacity", 0)
                 .attr("stroke", show_axis_border ? "black" : null);
         }
 

--- a/frontend/summary/summary/ExploreHeatmapPlot.js
+++ b/frontend/summary/summary/ExploreHeatmapPlot.js
@@ -181,10 +181,9 @@ class ExploreHeatmapPlot {
                 itemStartIndex = 0,
                 numItems = 0,
                 borderData = [],
-                wrap_text =
-                    settings.x_fields[i].wrap_text || autorotate_tick_labels
-                        ? AUTOROTATE_TEXT_WRAP_X
-                        : 0;
+                wrap_text = settings.x_fields[i].wrap_text
+                    ? settings.x_fields[i].wrap_text
+                    : AUTOROTATE_TEXT_WRAP_X;
 
             for (let j = 0; j <= xs.length; j++) {
                 thisItem = j < xs.length ? xs[j] : null;
@@ -256,6 +255,9 @@ class ExploreHeatmapPlot {
 
             let newYOffset = yOffset + box.height + label_padding * 2;
             let border = xAxis
+                .append("g")
+                .attr("fill", "transparent")
+                .attr("stroke", show_axis_border ? "black" : null)
                 .selectAll(".none")
                 .data(borderData)
                 .enter()
@@ -266,8 +268,6 @@ class ExploreHeatmapPlot {
                         `${d.x1},${newYOffset} ${d.x1},${yOffset} ${d.x1 +
                             d.width},${yOffset} ${d.x1 + d.width},${newYOffset}`
                 )
-                .attr("fill", "transparent")
-                .attr("stroke", show_axis_border ? "black" : null)
                 .on("click", d => {
                     const cells = this.get_matching_cells(d.filters, "x");
                     this.store.setTableDataFilters(new Set(cells));
@@ -421,6 +421,9 @@ class ExploreHeatmapPlot {
 
             let newYOffset = yOffset - (box.height + label_padding * 2);
             let border = xAxis
+                .append("g")
+                .attr("fill", "transparent")
+                .attr("stroke", show_axis_border ? "black" : null)
                 .selectAll(".none")
                 .data(borderData)
                 .enter()
@@ -431,8 +434,6 @@ class ExploreHeatmapPlot {
                         `${d.x1},${newYOffset} ${d.x1},${yOffset} ${d.x1 +
                             d.width},${yOffset} ${d.x1 + d.width},${newYOffset}`
                 )
-                .attr("fill", "transparent")
-                .attr("stroke", show_axis_border ? "black" : null)
                 .on("click", d => {
                     const cells = this.get_matching_cells(d.filters, "x");
                     this.store.setTableDataFilters(new Set(cells));
@@ -476,15 +477,17 @@ class ExploreHeatmapPlot {
             numYAxes = ys.length == 0 ? 0 : ys[0].length,
             {show_axis_border} = settings;
         for (let i = numYAxes - 1; i >= 0; i--) {
-            let axis = yAxis.append("g").attr("transform", `translate(${-xOffset},0)`),
+            let axis = yAxis
+                    .append("g")
+                    .attr("transform", `translate(${-xOffset - label_padding},0)`)
+                    .attr("text-anchor", y_tick_rotate === 0 ? "end" : "start"),
                 lastItem = ys[0],
                 itemStartIndex = 0,
                 numItems = 0,
                 borderData = [],
-                wrap_text =
-                    settings.y_fields[i].wrap_text || autorotate_tick_labels
-                        ? AUTOROTATE_TEXT_WRAP_Y
-                        : 0;
+                wrap_text = settings.y_fields[i].wrap_text
+                    ? settings.y_fields[i].wrap_text
+                    : AUTOROTATE_TEXT_WRAP_Y;
 
             for (let j = 0; j <= ys.length; j++) {
                 thisItem = j < ys.length ? ys[j] : null;
@@ -510,10 +513,7 @@ class ExploreHeatmapPlot {
                             itemStartIndex * this.cellDimensions.height +
                             (numItems * this.cellDimensions.height) / 2 -
                             box.height / 2;
-                    label.attr(
-                        "transform",
-                        `translate(${-box.x - box.width - label_padding},${-box.y + label_offset})`
-                    );
+                    label.attr("transform", `translate(0,${-box.y + label_offset})`);
 
                     borderData.push({
                         filters: _.slice(lastItem, 0, i + 1),
@@ -550,8 +550,12 @@ class ExploreHeatmapPlot {
             }
 
             let box = axis.node().getBBox(),
-                newXOffset = xOffset + box.width + label_padding * 2;
+                width = box.width + label_padding * 2;
             let border = yAxis
+                .append("g")
+                .attr("transform", `translate(${-xOffset},0)`)
+                .attr("fill", "transparent")
+                .attr("stroke", show_axis_border ? "black" : null)
                 .selectAll(".none")
                 .data(borderData)
                 .enter()
@@ -559,17 +563,15 @@ class ExploreHeatmapPlot {
                 .attr(
                     "points",
                     d =>
-                        `${-newXOffset},${d.y1} ${-xOffset},${d.y1} ${-xOffset},${d.y1 +
-                            d.height} ${-newXOffset},${d.y1 + d.height}`
+                        `${-width},${d.y1} 0,${d.y1} 0,${d.y1 + d.height} ${-width},${d.y1 +
+                            d.height}`
                 )
-                .attr("fill", "transparent")
-                .attr("stroke", show_axis_border ? "black" : null)
                 .on("click", d => {
                     const cells = this.get_matching_cells(d.filters, "y");
                     this.store.setTableDataFilters(new Set(cells));
                 });
             this.bind_tooltip(border, "axis");
-            xOffset = newXOffset;
+            xOffset = xOffset + width;
         }
         if (settings.show_totals) {
             const x1 = -yAxis.node().getBBox().width,

--- a/frontend/summary/summary/heatmap/HeatmapDatastore.js
+++ b/frontend/summary/summary/heatmap/HeatmapDatastore.js
@@ -80,7 +80,7 @@ class HeatmapDatastore {
                         text = d[columnName] || "";
 
                     let raw_values = delimiter ? text.split(delimiter) : [text];
-                    const values = raw_values.map(e => e.trim());
+                    const values = raw_values.map(e => e.toString().trim());
 
                     for (let value of values) {
                         if (!this.settings.show_null && !value) {


### PR DESCRIPTION
## Previously; weird offset left-alignment on y-axis labels:
<img width="216" alt="Screen Shot 2021-06-14 at 10 55 47 PM" src="https://user-images.githubusercontent.com/999952/121986056-e60cff80-cd63-11eb-9d80-d6a77cd73f51.png">


## Now, this is fixed:
<img width="180" alt="Screen Shot 2021-06-14 at 10 57 01 PM" src="https://user-images.githubusercontent.com/999952/121986064-e7d6c300-cd63-11eb-8c27-104eeccf2a14.png">

Additional, related, changes: 

- set text-align to `end` to right-align heatmap labels on the y-axis
- put polyline borders in a group to better nest svg
    - move some svg styles to the group to simplify svg
- update xoffset to move to group instead of individual items