### PR TITLE
sidebar updates on non-assessment pages

### DIFF
--- a/hawc/static/css/epa-bootstrap.css
+++ b/hawc/static/css/epa-bootstrap.css
@@ -62,3 +62,6 @@ a.btn-warning:visited, a.badge-warning:visited {
 .breadcrumb-item a:visited{
   color: var(--epa-primary);
 }
+.hawc-header .nav-link {
+  padding: 0 0 0 1em;
+}

--- a/hawc/static/css/epa-hawc.css
+++ b/hawc/static/css/epa-hawc.css
@@ -40,6 +40,9 @@
 .sidebar li {
     border-top: 1px solid #5b616b;
 }
+.sidebar li:first-of-type {
+    border-top: 0;
+}
 .sidebar .bg-primary {
     background-color: white !important;
 }

--- a/hawc/templates/assessment-rooted.html
+++ b/hawc/templates/assessment-rooted.html
@@ -5,7 +5,7 @@
 {% endblock title %}
 
 {% block sidebar_outer %}
-<div id="sidebar-container" class="sidebar pl-1 {{request.session.hideSidebar|yesno:'sidebar-collapsed, '}}"
+<div id="sidebar-container" class="sidebar {{request.session.hideSidebar|yesno:'sidebar-collapsed, '}}"
     data-collapsed="{{request.session.hideSidebar|yesno:"true,false"}}" data-url="{% url 'update_session' %}">
 
     {% if user.is_authenticated %}

--- a/hawc/templates/crumbless.html
+++ b/hawc/templates/crumbless.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block sidebar_outer %}
-<div id="sidebar-container" class="sidebar pl-1 {{request.session.hideSidebar|yesno:'sidebar-collapsed, '}}"
+<div id="sidebar-container" class="sidebar {{request.session.hideSidebar|yesno:'sidebar-collapsed, '}}"
     data-collapsed="{{request.session.hideSidebar|yesno:"true,false"}}" data-url="{% url 'update_session' %}">
 
     {% if user.is_authenticated %}
@@ -22,7 +22,6 @@
             <a class="nav-link" href="{% url 'assessment:public_list' %}">Public Assessments</a>
             {% endif %}
         </li>
-
     </nav>
     {% endif %}
 </div>

--- a/hawc/templates/hawc/home.html
+++ b/hawc/templates/hawc/home.html
@@ -1,5 +1,7 @@
-{% extends "crumbless.html" %}
+{% extends 'base.html' %}
 
-{% block content %}
-{{ page|safe }}
-{% endblock content %}
+{% block content_outer %}
+<div class="col-xl-10 col-lg-12" >
+    {{page|safe}}
+</div>
+{% endblock content_outer %}

--- a/hawc/templates/includes/navigation.html
+++ b/hawc/templates/includes/navigation.html
@@ -2,41 +2,30 @@
 
 {% block navbar_outer %}
 {% if extra_branding and flavor == "EPA" %}
-<nav class="navbar navbar-expand-sm hawc-header">
-
-    <h2 class="d-inline-block">
-        <button class="navbar-toggler float-right" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
-            aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <i class="fa fa-bars fa-2x" aria-hidden="true"></i>
-        </button>
-        <a href="{% if user.is_authenticated %}{% url 'portal' %}{% else %}{% url 'home' %}{% endif %}">Health Assessment Workspace Collaborative (HAWC)</a>
+<nav class="navbar hawc-header justify-content-between">
+    <h2>
+        <a href="{% url 'home' %}">Health Assessment Workspace Collaborative (HAWC)</a>
     </h2>
-
-    <ul id="navbarSupportedContent" class="nav navbar-nav collapse navbar-collapse justify-content-end text-right">
+    <ul id="navbarSupportedContent" class="nav text-right">
         {% if user.is_authenticated %}
             {% include "includes/_navigation_links.html" with contact_only=False %}
         {% else %}
             {% include "includes/_navigation_links.html" with contact_only=True %}
         {% endif %}
     </ul>
-
 </nav>
 {% else %}
 <nav class="navbar navbar-expand-sm navbar-light bg-light hawc-header">
-
-    <a class="ml-3 navbar-brand" href="{% if user.is_authenticated %}{% url 'portal' %}{% else %}{% url 'home' %}{% endif %}">
+    <a class="ml-3 navbar-brand" href="{% url 'home' %}">
         <img alt="The website logo" src="{% static 'img/HAWC-40.png' %}">
     </a>
-
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
         aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
     </button>
-
     <ul id="navbarSupportedContent" class="nav navbar-nav collapse navbar-collapse justify-content-end" >
         {% include "includes/_navigation_links.html" with contact_only=False %}
     </ul>
-
 </nav>
 {% endif %}
 {% endblock navbar_outer %}


### PR DESCRIPTION
- when collapsing browser to minimum width, "Contact Us" is now still visible instead of hamburgered
- show sidebar on all pages except home
- dont show top border on first row of the sidebar 

<img width="1168" alt="Screen Shot 2021-06-30 at 7 02 34 PM" src="https://user-images.githubusercontent.com/999952/124041911-c0276200-d9d5-11eb-9207-e894e56fbad3.png">
<img width="1163" alt="Screen Shot 2021-06-30 at 7 02 17 PM" src="https://user-images.githubusercontent.com/999952/124041912-c0bff880-d9d5-11eb-8ec7-0d0c2535b9bd.png">
<img width="481" alt="Screen Shot 2021-06-30 at 7 04 39 PM" src="https://user-images.githubusercontent.com/999952/124042028-0aa8de80-d9d6-11eb-82f4-63687ed1fb12.png">
