### PR TITLE
WIP: Software stability and reproducibility 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,6 @@
 hawc/static/vendor/* linguist-vendored
 vendor/* linguist-vendored
 scripts/* linguist-vendored
+
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -270,12 +270,21 @@ When using the recommended settings below, your python and javascript code shoul
 More settings
 -------------
 
+Local settings
+~~~~~~~~~~~~
+
+Additional settings or overrides can be set at ``hawc/main/settings/local.py``.
+
+This file is not available by default, but can be copied from ``hawc/main/settings/local.example.py`` as a starting point.
+The settings from ``local.py`` will be added automatically to the default settings (``hawc.main.settings.dev``), or can be
+used solely by setting the environment variable ``DJANGO_SETTINGS_MODULE`` to ``hawc.main.settings.local``.
+
 HAWC flavors
 ~~~~~~~~~~~~
 
 Currently HAWC has two possible application "flavors", where the application is slightly
 different depending on which flavor is selected. To change, modify the ``HAWC_FLAVOR``
-variable ``hawc/main/settings/local.py``. Possible values include:
+variable at ``hawc/main/settings/local.py``. Possible values include:
 
 - PRIME (default application; as hosted at https://hawcproject.org)
 - EPA (EPA application; as hosted at EPA)

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -51,6 +51,7 @@ Instructions below have been written for bash, so should work out of the box for
 
     # install requirements
     ./venv/bin/pip install -r ./requirements/dev.txt
+    python -m nltk.downloader punkt
 
     # create a PostgreSQL database and superuser
     createuser --superuser --no-password hawc
@@ -80,6 +81,7 @@ Windows requires using anaconda or miniconda to get requirements.
     cd %HOMEPATH%\dev\hawc
     python -m pip install --upgrade pip
     pip install -r requirements\dev.txt
+    python -m nltk.downloader punkt
 
     :: setup and start PostgreSQL; in this example we'll put it in dev
     cd %HOMEPATH%\dev

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -421,7 +421,7 @@ Then, create the example docker container and start a celery worker instance:
     # stop redis when you're done
     docker-compose -f compose/dc-build.yml --project-directory . down
 
-Asynchronous tasks will no be executed by celery workers instead of the main thread.
+Asynchronous tasks will not be executed by celery workers instead of the main thread.
 
 Integration tests
 ~~~~~~~~~~~~~~~~~

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -394,6 +394,8 @@ To run tests without using the cassettes and making the network requests, use:
 Testing celery application
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+The following requires ``redis-cli`` and ``docker-compose``.
+
 To test asynchronous functionality in development, modify your ``hawc/main/settings/local.py``:
 
 .. code-block:: python

--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -1,10 +1,7 @@
 {
     "rules": {
         "generator-star-spacing": 1,
-        "linebreak-style": [
-            2,
-            "unix"
-        ],
+        "linebreak-style": 0,
         "no-await-in-loop": 1,
         "no-console": [
             2,

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,6 +1,6 @@
 arrowParens: "avoid"
 bracketSpacing: false
-endOfLine: "lf"
+endOfLine: "auto"
 jsxBracketSameLine: true
 parser: "babel"
 printWidth: 100


### PR DESCRIPTION
Recommend adding a note at the begining about windows VSCode config. When formatting (i.e., make format), line endings will be updated to windows line endings and registered as changes.
Fixed by removing linebreaks from linting/formatting and relying solely on git conversions (added autoclfr to gitattributes to be safe)


The naming convention for the test databases is confusing: hawc-fixture-test vs test_hawc-fixture-test. Recommend changing to something less repetitive. 
Rename test_hawc-fixture-test to hawc-test?


Line 390 For this section, clarify requirements needed to test this, e.g., clarify redis-cli is a requirement for this step
Done


Line 420 should read "Asynchronous tasks will not be executed by celery workers instead of the main thread."
Done


Line 422: This section section only has examples with Mac/Linux. Clarify why windows examples are not provided.
The only Linux specific lines is setting the environment variables, do we need another section for windows?


Entire document: local.py doesn't exist, only local.example.py. Clarify whether local.py needs to be created from local.example.py.
Done


Potential bug: I needed to download the punkt corpors from NLTK to pass a number of tests. The corpus was not included by default when following the documenation as is.
Done