### PR TITLE
Setting to disallow users from making assessment public

### DIFF
--- a/hawc/apps/assessment/forms.py
+++ b/hawc/apps/assessment/forms.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from textwrap import dedent
 
 from django import forms
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.mail import mail_admins
 from django.db import transaction
@@ -42,6 +43,14 @@ class AssessmentForm(forms.ModelForm):
         self.fields["reviewers"].widget = AutoCompleteSelectMultipleWidget(
             lookup_class=HAWCUserLookup
         )
+        if not settings.PM_CAN_MAKE_PUBLIC:
+            if self.instance.public:
+                self.fields[
+                    "public"
+                ].help_text += " If made private, the HAWC team will need to be contacted to make public again."
+            else:
+                self.fields["public"].disabled = True
+                self.fields["public"].help_text = "Contact the HAWC team to make public."
 
     @property
     def helper(self):

--- a/hawc/main/settings/base.py
+++ b/hawc/main/settings/base.py
@@ -310,6 +310,7 @@ WEBPACK_LOADER = {
 }
 
 ANYONE_CAN_CREATE_ASSESSMENTS = True
+PM_CAN_MAKE_PUBLIC = os.getenv("PM_CAN_MAKE_PUBLIC", "True") == "True"
 EXTRA_BRANDING = True
 
 MODIFY_HELP_TEXT = "makemigrations" not in sys.argv


### PR DESCRIPTION
If `PM_CAN_MAKE_PUBLIC` is set to `False`, the following updates are made to the assessment form:

If the assessment is already public, it can be made private and hidden from public page. The help text is updated to inform the user that if made private, only an admin can make it public again.
![image](https://user-images.githubusercontent.com/46504563/128707980-1ec37849-eefa-40e0-b7e0-36be09767c83.png)

If the assessment is private, the input will be [disabled](https://docs.djangoproject.com/en/3.2/ref/forms/fields/#disabled), with help text instructing the user to contact an admin.
![image](https://user-images.githubusercontent.com/46504563/128708183-ce7b7da3-3a94-45a2-a592-76e772080e2e.png)
