### PR TITLE
Allow SvgRenderer to handle permission errors

### DIFF
--- a/hawc/apps/common/renderers.py
+++ b/hawc/apps/common/renderers.py
@@ -44,6 +44,8 @@ class SvgRenderer(BaseRenderer):
     format = "svg"
 
     def render(self, ax: Axes, accepted_media_type=None, renderer_context=None):
+        if isinstance(ax, dict):
+            return f"<svg><text>{json.dumps(ax)}</text></svg>"
         f = StringIO()
         ax.figure.savefig(f, format="svg")
         plt.close(ax.figure)

--- a/hawc/apps/common/renderers.py
+++ b/hawc/apps/common/renderers.py
@@ -45,7 +45,7 @@ class SvgRenderer(BaseRenderer):
 
     def render(self, ax: Axes, accepted_media_type=None, renderer_context=None):
         if isinstance(ax, dict):
-            return f"<svg><text>{json.dumps(ax)}</text></svg>"
+            return f'<svg xmlns="http://www.w3.org/2000/svg"><text y="15">{json.dumps(ax)}</text></svg>'
         f = StringIO()
         ax.figure.savefig(f, format="svg")
         plt.close(ax.figure)

--- a/tests/hawc/apps/assessment/test_assessment_api.py
+++ b/tests/hawc/apps/assessment/test_assessment_api.py
@@ -327,6 +327,23 @@ class TestHealthcheckViewset:
         assert resp.status_code == 200
         assert resp.json()["healthy"] is True
 
+    @pytest.mark.skipif(not has_redis(), reason="skip; redis cache required")
+    def test_worker_plot(self):
+        client = APIClient()
+        url = reverse("assessment:api:healthcheck-worker-plot")
+
+        # failure - not admin
+        resp = client.get(url)
+        assert resp.status_code == 403
+        assert client.login(username="pm@hawcproject.org", password="pw") is True
+        resp = client.get(url)
+        assert resp.status_code == 403
+
+        # success - admin
+        assert client.login(username="admin@hawcproject.org", password="pw") is True
+        resp = client.get(url)
+        assert resp.status_code == 200
+
 
 @pytest.mark.django_db
 class TestAdminDashboardViewset:


### PR DESCRIPTION
When a `SvgRenderer` rendered request faces a permission error, it now returns an SVG of the error with the correct status code, instead of raising a server error.