### PR TITLE
Add async task expirations for recurring tasks

### DIFF
--- a/hawc/main/celery.py
+++ b/hawc/main/celery.py
@@ -24,39 +24,39 @@ app.conf.beat_schedule = {
     "worker-healthcheck": {
         "task": "hawc.apps.common.tasks.worker_healthcheck",
         "schedule": timedelta(minutes=5),
-        "options": {"expires": timedelta(minutes=5)},
+        "options": {"expires": timedelta(minutes=5).total_seconds()},
     },
     "lit-schedule_topic_model_reruns-10-min": {
         "task": "hawc.apps.lit.tasks.schedule_topic_model_reruns",
         "schedule": timedelta(minutes=10),
-        "options": {"expires": timedelta(minutes=10)},
+        "options": {"expires": timedelta(minutes=10).total_seconds()},
     },
     "lit-update_pubmed_content-1-day": {
         "task": "hawc.apps.lit.tasks.update_pubmed_content",
         "schedule": timedelta(days=1),
-        "options": {"expires": timedelta(days=1)},
+        "options": {"expires": timedelta(days=1).total_seconds()},
     },
     "assessment-delete_old_jobs-1-day": {
         "task": "hawc.apps.assessment.tasks.delete_old_jobs",
         "schedule": timedelta(days=1),
-        "options": {"expires": timedelta(days=1)},
+        "options": {"expires": timedelta(days=1).total_seconds()},
     },
     "delete-orphan-relations": {
         "task": "hawc.apps.assessment.tasks.delete_orphan_relations",
         "schedule": timedelta(hours=6),
         "kwargs": dict(delete=False),
-        "options": {"expires": timedelta(hours=6)},
+        "options": {"expires": timedelta(hours=6).total_seconds()},
     },
     "check-refresh-mvs": {
         "task": "hawc.apps.materialized.tasks.refresh_all_mvs",
         "schedule": timedelta(minutes=5),
-        "options": {"expires": timedelta(minutes=5)},
+        "options": {"expires": timedelta(minutes=5).total_seconds()},
     },
     "refresh-mvs": {
         "task": "hawc.apps.materialized.tasks.refresh_all_mvs",
         "schedule": timedelta(days=1),
         "kwargs": dict(force=True),
-        "options": {"expires": timedelta(days=1)},
+        "options": {"expires": timedelta(days=1).total_seconds()},
     },
 }
 
@@ -66,5 +66,5 @@ if has_bmds_service_url:
     app.conf.beat_schedule["bmds2-healthcheck"] = {
         "task": "hawc.apps.bmd.tasks.bmds2_healthcheck",
         "schedule": timedelta(hours=12),
-        "options": {"expires": timedelta(hours=12)},
+        "options": {"expires": timedelta(hours=12).total_seconds()},
     }

--- a/hawc/main/celery.py
+++ b/hawc/main/celery.py
@@ -24,39 +24,39 @@ app.conf.beat_schedule = {
     "worker-healthcheck": {
         "task": "hawc.apps.common.tasks.worker_healthcheck",
         "schedule": timedelta(minutes=5),
-        "options": {"expires": timedelta(minutes=5) / 2},
+        "options": {"expires": timedelta(minutes=5)},
     },
     "lit-schedule_topic_model_reruns-10-min": {
         "task": "hawc.apps.lit.tasks.schedule_topic_model_reruns",
         "schedule": timedelta(minutes=10),
-        "options": {"expires": timedelta(minutes=10) / 2},
+        "options": {"expires": timedelta(minutes=10)},
     },
     "lit-update_pubmed_content-1-day": {
         "task": "hawc.apps.lit.tasks.update_pubmed_content",
         "schedule": timedelta(days=1),
-        "options": {"expires": timedelta(days=1) / 2},
+        "options": {"expires": timedelta(days=1)},
     },
     "assessment-delete_old_jobs-1-day": {
         "task": "hawc.apps.assessment.tasks.delete_old_jobs",
         "schedule": timedelta(days=1),
-        "options": {"expires": timedelta(days=1) / 2},
+        "options": {"expires": timedelta(days=1)},
     },
     "delete-orphan-relations": {
         "task": "hawc.apps.assessment.tasks.delete_orphan_relations",
         "schedule": timedelta(hours=6),
         "kwargs": dict(delete=False),
-        "options": {"expires": timedelta(hours=6) / 2},
+        "options": {"expires": timedelta(hours=6)},
     },
     "check-refresh-mvs": {
         "task": "hawc.apps.materialized.tasks.refresh_all_mvs",
         "schedule": timedelta(minutes=5),
-        "options": {"expires": timedelta(minutes=5) / 2},
+        "options": {"expires": timedelta(minutes=5)},
     },
     "refresh-mvs": {
         "task": "hawc.apps.materialized.tasks.refresh_all_mvs",
         "schedule": timedelta(days=1),
         "kwargs": dict(force=True),
-        "options": {"expires": timedelta(days=1) / 2},
+        "options": {"expires": timedelta(days=1)},
     },
 }
 
@@ -66,5 +66,5 @@ if has_bmds_service_url:
     app.conf.beat_schedule["bmds2-healthcheck"] = {
         "task": "hawc.apps.bmd.tasks.bmds2_healthcheck",
         "schedule": timedelta(hours=12),
-        "options": {"expires": timedelta(hours=12) / 2},
+        "options": {"expires": timedelta(hours=12)},
     }

--- a/hawc/main/celery.py
+++ b/hawc/main/celery.py
@@ -24,32 +24,39 @@ app.conf.beat_schedule = {
     "worker-healthcheck": {
         "task": "hawc.apps.common.tasks.worker_healthcheck",
         "schedule": timedelta(minutes=5),
+        "options": {"expires": timedelta(minutes=5) / 2},
     },
     "lit-schedule_topic_model_reruns-10-min": {
         "task": "hawc.apps.lit.tasks.schedule_topic_model_reruns",
         "schedule": timedelta(minutes=10),
+        "options": {"expires": timedelta(minutes=10) / 2},
     },
     "lit-update_pubmed_content-1-day": {
         "task": "hawc.apps.lit.tasks.update_pubmed_content",
         "schedule": timedelta(days=1),
+        "options": {"expires": timedelta(days=1) / 2},
     },
     "assessment-delete_old_jobs-1-day": {
         "task": "hawc.apps.assessment.tasks.delete_old_jobs",
         "schedule": timedelta(days=1),
+        "options": {"expires": timedelta(days=1) / 2},
     },
     "delete-orphan-relations": {
         "task": "hawc.apps.assessment.tasks.delete_orphan_relations",
         "schedule": timedelta(hours=6),
         "kwargs": dict(delete=False),
+        "options": {"expires": timedelta(hours=6) / 2},
     },
     "check-refresh-mvs": {
         "task": "hawc.apps.materialized.tasks.refresh_all_mvs",
         "schedule": timedelta(minutes=5),
+        "options": {"expires": timedelta(minutes=5) / 2},
     },
     "refresh-mvs": {
         "task": "hawc.apps.materialized.tasks.refresh_all_mvs",
         "schedule": timedelta(days=1),
         "kwargs": dict(force=True),
+        "options": {"expires": timedelta(days=1) / 2},
     },
 }
 
@@ -59,4 +66,5 @@ if has_bmds_service_url:
     app.conf.beat_schedule["bmds2-healthcheck"] = {
         "task": "hawc.apps.bmd.tasks.bmds2_healthcheck",
         "schedule": timedelta(hours=12),
+        "options": {"expires": timedelta(hours=12) / 2},
     }


### PR DESCRIPTION
Added expirations to celery beat, so that scheduled tasks don't queue up multiple times if a service is down.

Inspired by [Caktus](https://www.caktusgroup.com/) blogpost: https://www.caktusgroup.com/blog/2021/08/11/using-celery-scheduling-tasks/