### PR TITLE
Reorganize visual selector page

### DIFF
--- a/hawc/apps/summary/templates/summary/visual_selector.html
+++ b/hawc/apps/summary/templates/summary/visual_selector.html
@@ -10,24 +10,24 @@
   <div class="row">
     <div class="col-md-9">
       <select id="vis_selector" class="form-control col-md-12">
+        <option value="4" data-url="{% url 'summary:visualization_create' assessment.id 4 %}">Literature
+          tagtree</option>
+        <option value="6" data-url="{% url 'summary:visualization_create' assessment.id 6 %}">Exploratory
+          heatmap</option>
+        <option value="5" data-url="{% url 'summary:visualization_create' assessment.id 5 %}">Embedded
+          external website</option>
+        <option value="2" data-url="{% url 'summary:visualization_create' assessment.id 2 %}">
+          {{assessment.get_rob_name_display}} heatmap</option>
+        <option value="3" data-url="{% url 'summary:visualization_create' assessment.id 3 %}">
+          {{assessment.get_rob_name_display}} barchart</option>
         <option value="100" data-url="{% url 'summary:dp_new-prompt' assessment.id %}">Data pivot</option>
+        <option value="1" data-url="{% url 'summary:visualization_create' assessment.id 1 %}">Bioassay
+          endpoint crossview</option>
         {% comment %}
         <!-- deprecate; let's see if anyone requests it..  -->
         <option value="0" data-url="{% url 'summary:visualization_create' assessment.id 0 %}">Bioassay
           endpoint aggregation</option>
         {% endcomment %}
-        <option value="1" data-url="{% url 'summary:visualization_create' assessment.id 1 %}">Bioassay
-          endpoint crossview</option>
-        <option value="2" data-url="{% url 'summary:visualization_create' assessment.id 2 %}">
-          {{assessment.get_rob_name_display}} heatmap</option>
-        <option value="3" data-url="{% url 'summary:visualization_create' assessment.id 3 %}">
-          {{assessment.get_rob_name_display}} barchart</option>
-        <option value="4" data-url="{% url 'summary:visualization_create' assessment.id 4 %}">Literature
-          tagtree</option>
-        <option value="5" data-url="{% url 'summary:visualization_create' assessment.id 5 %}">Embedded
-          external website</option>
-        <option value="6" data-url="{% url 'summary:visualization_create' assessment.id 6 %}">Exploratory
-          heatmap</option>
       </select>
     </div>
     <div class="col-md-3">


### PR DESCRIPTION
Reorganized the visual selector page to be more intuitive by mapping to the "steps" in a systematic review.
![image](https://user-images.githubusercontent.com/46504563/132536327-90c68e7c-d202-4cc6-8312-956a07a1d16f.png)
