### PR TITLE
Fix Actions dropdown button on endpoint detail page

### DIFF
--- a/hawc/apps/animal/templates/animal/endpoint_detail.html
+++ b/hawc/apps/animal/templates/animal/endpoint_detail.html
@@ -2,7 +2,6 @@
 
 {% block content %}
 
-  <h1 class="d-inline-block">{{object}}</h1>
   {% if crud == "Read" %}
     {% if obj_perms.edit %}
     <div class="dropdown btn-group float-right">
@@ -13,33 +12,28 @@
         <a class="dropdown-item" href="{% url 'animal:endpoint_delete' object.pk %}">Delete endpoint</a>
         {% if assessment.enable_bmd and object.bmd_modeling_possible %}
           <div class="dropdown-divider"></div>
+          <span class="dropdown-header">BMD Modeling</span>
           {% if bmd_session %}
-          <span class="dropdown-header">BMD Modeling</span>
-          <a class="dropdown-item" href="{{bmd_session.get_absolute_url}}">View session</a>
-          <a class="dropdown-item" href="{% url 'bmd:session_list' object.pk %}">Other options</a>
+            <a class="dropdown-item" href="{{bmd_session.get_absolute_url}}">View session</a>
+            <a class="dropdown-item" href="{% url 'bmd:session_list' object.pk %}">Other options</a>
           {% else %}
-          <span class="dropdown-header">BMD Modeling</span>
-          <a class="dropdown-item" href="{% url 'bmd:session_create' object.pk %}">Create</a>
+            <a class="dropdown-item" href="{% url 'bmd:session_create' object.pk %}">Create</a>
           {% endif %}
         {% endif %}
       </div>
     </div>
-    {% elif assessment.enable_bmd and object.bmd_modeling_possible %}
+    {% elif assessment.enable_bmd and object.bmd_modeling_possible and bmd_session %}
     <div class="dropdown btn-group float-right">
       <a class="btn btn-primary dropdown-toggle" data-toggle="dropdown">Actions</a>
       <div class="dropdown-menu dropdown-menu-right">
-        {% if bmd_session %}
         <span class="dropdown-header">BMD Modeling</span>
         <a class="dropdown-item" href="{{bmd_session.get_absolute_url}}">View session</a>
         <a class="dropdown-item" href="{% url 'bmd:session_list' object.pk %}">Other options</a>
-        {% else %}
-        <span class="dropdown-header">BMD Modeling</span>
-        <a class="dropdown-item" href="{% url 'bmd:session_create' object.pk %}">Create</a>
-        {% endif %}
       </div>
     </div>
     {% endif %}
   {% endif %}
+  <h1 class="d-inline-block">{{object}}</h1>
 
   <!-- Endpoint details -->
   <div class="row">

--- a/hawc/apps/animal/templates/animal/endpoint_detail.html
+++ b/hawc/apps/animal/templates/animal/endpoint_detail.html
@@ -4,30 +4,41 @@
 
   <h1 class="d-inline-block">{{object}}</h1>
   {% if crud == "Read" %}
+    {% if obj_perms.edit %}
     <div class="dropdown btn-group float-right">
       <a class="btn btn-primary dropdown-toggle" data-toggle="dropdown">Actions</a>
       <div class="dropdown-menu dropdown-menu-right">
-          {% if obj_perms.edit %}
-          <span class="dropdown-header">Endpoint Editing</span>
-          <a class="dropdown-item" href="{{ object.get_update_url }}">Update endpoint</a>
-          <a class="dropdown-item" href="{% url 'animal:endpoint_delete' object.pk %}">Delete endpoint</a>
+        <span class="dropdown-header">Endpoint Editing</span>
+        <a class="dropdown-item" href="{{ object.get_update_url }}">Update endpoint</a>
+        <a class="dropdown-item" href="{% url 'animal:endpoint_delete' object.pk %}">Delete endpoint</a>
+        {% if assessment.enable_bmd and object.bmd_modeling_possible %}
           <div class="dropdown-divider"></div>
+          {% if bmd_session %}
+          <span class="dropdown-header">BMD Modeling</span>
+          <a class="dropdown-item" href="{{bmd_session.get_absolute_url}}">View session</a>
+          <a class="dropdown-item" href="{% url 'bmd:session_list' object.pk %}">Other options</a>
+          {% else %}
+          <span class="dropdown-header">BMD Modeling</span>
+          <a class="dropdown-item" href="{% url 'bmd:session_create' object.pk %}">Create</a>
           {% endif %}
-
-          {% if assessment.enable_bmd and object.bmd_modeling_possible %}
-            {% if bmd_session %}
-              <span class="dropdown-header">BMD Modeling</span>
-              <a class="dropdown-item" href="{{bmd_session.get_absolute_url}}">View session</a>
-              <a class="dropdown-item" href="{% url 'bmd:session_list' object.pk %}">Other options</a>
-            {% else %}
-              {% if obj_perms.edit %}
-                <span class="dropdown-header">BMD Modeling</span>
-                <a class="dropdown-item" href="{% url 'bmd:session_create' object.pk %}">Create</a>
-              {% endif %}
-            {% endif %}
-          {% endif %}
+        {% endif %}
       </div>
     </div>
+    {% elif assessment.enable_bmd and object.bmd_modeling_possible %}
+    <div class="dropdown btn-group float-right">
+      <a class="btn btn-primary dropdown-toggle" data-toggle="dropdown">Actions</a>
+      <div class="dropdown-menu dropdown-menu-right">
+        {% if bmd_session %}
+        <span class="dropdown-header">BMD Modeling</span>
+        <a class="dropdown-item" href="{{bmd_session.get_absolute_url}}">View session</a>
+        <a class="dropdown-item" href="{% url 'bmd:session_list' object.pk %}">Other options</a>
+        {% else %}
+        <span class="dropdown-header">BMD Modeling</span>
+        <a class="dropdown-item" href="{% url 'bmd:session_create' object.pk %}">Create</a>
+        {% endif %}
+      </div>
+    </div>
+    {% endif %}
   {% endif %}
 
   <!-- Endpoint details -->


### PR DESCRIPTION
The Actions dropdown button now only renders when there are items to display.

Logic is confusion: many possible states:
1. if not in detail mode, no action button
1. if user cannot edit and no bmd model, no action button
1. if user cannot edit and bmd model, action button w/ session 
1. if user can edit, show action with endpoint editing, and ....
    1. if no bmd and bmd is possible, add create bmd buton
    1. if bmd user can edit and bmd, add views session button
    1. if bmd not enabled, no bmd model section under actions