### PR TITLE
add goto page number selector

### DIFF
--- a/hawc/templates/includes/paginator.html
+++ b/hawc/templates/includes/paginator.html
@@ -26,5 +26,16 @@
         <a class="page-link" href="#">&gt;&gt;</a>
     </li>
     {% endif %}
+
+    <li class="ml-3 page-item">
+        <label class="page-link font-weight-normal text-muted" for="quickPageSelector">Go to page:&nbsp;</label>
+    </li>
+    <li class="page-item from-group">
+        <select id="quickPageSelector" class="form-control" onchange="location=this.value;">
+            {% for n in page_obj.paginator.page_range %}
+            <option {% ifequal page_obj.number n %}selected{% endifequal %} value="?{% url_replace request 'page' n %}">{{ n }}</option>
+            {% endfor %}
+        </select>
+    </li>
 </ul>
 {% endif %}


### PR DESCRIPTION
Previously, our default paginator allowed a user to go left or right one page at a time. This may be problematic for the user as well as unnecessary server load if there are many pages and you want to go to the end, or the middle. 

Therefore, we add a goto page where a user can select any page and they are redirected there

Old:
![image](https://user-images.githubusercontent.com/999952/134723454-d7c87969-562c-435b-ad85-d3167d0ef636.png)

New:
![image](https://user-images.githubusercontent.com/999952/134723464-cffe6f66-6a76-4c73-a832-6a17dcf80cfb.png)
