### PR TITLE
add tag tree fetch/clone/update to API & client

### DIFF
--- a/client/hawc_client/__init__.py
+++ b/client/hawc_client/__init__.py
@@ -229,6 +229,51 @@ class LiteratureClient(BaseClient):
         response_json = self.session.get(url).json()
         return pd.DataFrame(response_json)
 
+    def get_tag_tree(self, assessment_id: int) -> pd.DataFrame:
+        """
+        Retrieves the nested tag tree for the given assessment.
+
+        Args:
+            assessment_id (int): Assessment ID
+
+        Returns:
+            Dict: JSON representation of the tag tree
+        """
+        url = f"{self.session.root_url}/lit/api/assessment/{assessment_id}/get_tag_tree/"
+        response_json = self.session.get(url).json()
+        return response_json
+
+    def clone_tag_tree(self, source_assessment_id: int, target_assessment_id: int) -> pd.DataFrame:
+        """
+        Copies the tag tree from one assessment to another.
+
+        Args:
+            source_assessment_id (int): Assessment ID to copy tag tree from
+            target_assessment_id (int): Assessment ID to copy tag tree to
+
+        Returns:
+            Dict: JSON representation of the new tag tree
+        """
+        url = f"{self.session.root_url}/lit/api/assessment/{target_assessment_id}/clone_tag_tree_from_assessment/?assessment_id={source_assessment_id}"
+        response_json = self.session.get(url).json()
+        return response_json
+
+    def update_tag_tree(self, assessment_id: int, tags: List[Dict]) -> pd.DataFrame:
+        """
+        Updates the tag tree.
+
+        Args:
+            assessment_id (int): Assessment ID to update
+            tags (List[Dict]): tag definitions. For each tag Dict element, "name" is required. "slug" is
+               optional. "children" is optional and should contain a recursive List containing valid tags.
+
+        Returns:
+            Dict: JSON representation of the new tag tree. If errors, a JSON list containing details.
+        """
+        url = f"{self.session.root_url}/lit/api/assessment/{assessment_id}/update_tag_tree/"
+        response_json = self.session.post(url, tags).json()
+        return response_json
+
     def reference_tags(self, assessment_id: int) -> pd.DataFrame:
         """
         Retrieves the literature references and their corresponding tags for a given assessment.

--- a/hawc/apps/lit/api.py
+++ b/hawc/apps/lit/api.py
@@ -1,3 +1,5 @@
+import json
+
 import pandas as pd
 import plotly.express as px
 from django.conf import settings
@@ -45,6 +47,119 @@ class LiteratureAssessmentViewset(LegacyAssessmentAdapterMixin, viewsets.Generic
         df = models.ReferenceFilterTag.as_dataframe(instance.id)
         export = FlatExport(df=df, filename=f"reference-tags-{self.assessment.id}")
         return Response(export)
+
+    @action(detail=True)
+    def get_tag_tree(self, request, pk):
+        """
+        Shows the (nested, tree structure) literature tags for entire assessment.
+        """
+        assessment = self.get_object()
+
+        if not assessment.user_can_view_object(request.user):
+            raise exceptions.PermissionDenied()
+
+        tags = models.ReferenceFilterTag.get_all_tags(assessment.id, json_encode=False)
+        return Response(tags, status=status.HTTP_200_OK)
+
+    @action(detail=True, methods=("get",))
+    def clone_tag_tree_from_assessment(self, request, pk, *args, **pkargs):
+        """
+        Copies the tag tree from one assessment to another. Removes existing reference/tag associations.
+
+        To be clear - the assessment_id in the URL pattern is the target; the ?assessment_id=X is the source and
+        will not be modified by this operation.
+        """
+        assessment = self.get_object()
+
+        # target assessment is only modifiable by assesssment admins / superusers
+        if not assessment.user_can_edit_object(request.user):
+            raise exceptions.PermissionDenied()
+
+        source_assessment_id = request.query_params.get("assessment_id")
+        source_assessment = Assessment.objects.get(id=source_assessment_id)
+
+        # source assessment must be viewable
+        if not assessment.user_can_view_object(request.user):
+            raise exceptions.PermissionDenied()
+
+        # don't let someone clone from the same assessment!
+        if assessment.id == source_assessment.id:
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+
+        # copy from one assessment to another
+        models.ReferenceFilterTag.copy_tags(assessment, source_assessment)
+
+        # and now fetch the updated tag tree and return it to the user
+        tags = models.ReferenceFilterTag.get_all_tags(assessment.id, json_encode=False)
+        return Response(tags, status=status.HTTP_200_OK)
+
+    @action(detail=True, methods=("post",))
+    def update_tag_tree(self, request, pk, *args, **pkargs):
+        """
+        Accepts a list of tags and replaces the tag structure in the assessment. This removes all existing reference/tag
+        associations.
+
+        The tags should be POST'ed as a list of tags in JSON format. A tag must have a "name" and can
+        optionally supply a "slug"; if this is supplied it must be valid (lowercase, only
+        alphanumeric/underscore/hyphen, etc.). A tag can optionally have a "children" list; each child
+        must be a valid tag. For example, the following is valid data to POST to this method:
+
+        [
+            { "name": "This is required" },
+            { "name": "Tag Name", "slug": "custom-slug" },
+            {
+                "name": "Grandparent Tag", "children": [
+                    { "name": "nested" },
+                    {
+                        "name": "Parent Tag", "children": [
+                            { "name": "deeply nested" }
+                        ]
+                    }
+                ]
+            }
+        ]
+
+        Note that this differs slightly from the dump_bulk format actually stored with Treebeard; we expect an input
+        like:
+
+        { "name": "foo", "slug": "bar", "children": [...] }
+
+        but this will be converted to be:
+
+        { "data": { "name": "foo", "slug": "bar" }, "children": [...] }
+
+        The simpler format makes things easier for API users.
+        """
+
+        assessment = self.get_object()
+
+        # only modifiable by assesssment admins / superusers
+        if not assessment.user_can_edit_object(request.user):
+            raise exceptions.PermissionDenied()
+
+        try:
+            proposed_tag_tree = json.loads(request.body)
+        except json.decoder.JSONDecodeError:
+            return Response(["invalid JSON supplied"], status=status.HTTP_400_BAD_REQUEST)
+
+        if type(proposed_tag_tree) is not list:
+            return Response(["JSON supplied is not a list"], status=status.HTTP_400_BAD_REQUEST)
+
+        tag_issues = []
+        models.ReferenceFilterTag.validate_and_transform_tag_tree(proposed_tag_tree, tag_issues)
+
+        if len(tag_issues) == 0:
+            # supplied tag tree looks good and we've added slugs, etc. as needed. Can proceed with
+            # replacing the tag tree for the assessment, wiping out tag associations, etc.
+
+            updated_tag_tree = models.ReferenceFilterTag.replace_tag_tree_in_assessment(
+                assessment, proposed_tag_tree
+            )
+
+            return Response(updated_tag_tree, status=status.HTTP_200_OK)
+        else:
+            # bad input; stop here
+            return Response(tag_issues, status=status.HTTP_400_BAD_REQUEST)
 
     @action(detail=True, pagination_class=PaginationWithCount)
     def references(self, request, pk):

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -495,6 +495,32 @@ class TestClient(LiveServerTestCase, TestCase):
         response = client.lit.tags(self.db_keys.assessment_client)
         assert isinstance(response, pd.DataFrame)
 
+    def test_lit_tag_tree(self):
+        client = HawcClient(self.live_server_url)
+        response = client.lit.get_tag_tree(self.db_keys.assessment_client)
+        assert isinstance(response, list)
+
+    def test_clone_tag_tree(self):
+        client = HawcClient(self.live_server_url)
+        client.authenticate("pm@hawcproject.org", "pw")
+        response = client.lit.clone_tag_tree(
+            self.db_keys.assessment_final, self.db_keys.assessment_client
+        )
+        assert isinstance(response, list)
+
+    def test_update_tag_tree(self):
+        client = HawcClient(self.live_server_url)
+        client.authenticate("pm@hawcproject.org", "pw")
+
+        updates = [
+            {"name": "set via client"},
+            {"name": "Client Slug", "slug": "sluggo"},
+            {"name": "tree", "children": [{"name": "child element"}]},
+        ]
+
+        response = client.lit.update_tag_tree(self.db_keys.assessment_client, updates)
+        assert isinstance(response, list)
+
     def test_lit_reference_tags(self):
         client = HawcClient(self.live_server_url)
         response = client.lit.reference_tags(self.db_keys.assessment_final)


### PR DESCRIPTION
@shapiromatron one thing to call out that is nagging me; the format returned by all of these is the native Treebeard format (so name/slug are wrapped in a "data" dictionary), whereas the format accepted by update_tag_tree just has name/slug at the top level, no "data" nesting those values (the API transforms it into the format Treebeard wants). I did it this way b/c it felt simpler for the client, but it is admittedly a little inconsistent and potentially confusing. If you'd prefer I just required API consumers to wrap it themselves, I can redo it that way easy enough.

-----

Adds three new API endpoints:
* /lit/api/assessment/<assessment_id>/get_tag_tree - fetches the tag tree for an assessment as a nested structure
* /lit/api/assessment/<target_assessment_id>/clone_tag_tree_from_assessment?assessment_id=<source_assessment_id> - clones tag
  tree from one assessment to another
* /lit/api/assessment/<assessment_id>/update_tag_tree - takes POSTed JSON data and replaces the existing tag tree

Also updates the Python HAWC client with methods matching the three new endpoints.

Addresses https://trello.com/c/g3rUWQMG/168-api-to-bulk-replace-tags