### PR TITLE
use django form for rasterizer download

### DIFF
--- a/hawc/apps/assessment/tasks.py
+++ b/hawc/apps/assessment/tasks.py
@@ -5,7 +5,6 @@ from celery.utils.log import get_task_logger
 from django.apps import apps
 from django.utils import timezone
 
-from ..common.svg import SVGConverter
 from . import models
 
 logger = get_task_logger(__name__)
@@ -37,34 +36,6 @@ def run_job(self):
     except Exception as exc:
         job.set_failure(exc)
     job.save()
-
-
-@shared_task
-def convert_to_svg(svg, url, width, height):
-    logger.info("Converting svg -> [css]+svg")
-    conv = SVGConverter(svg, url, width, height)
-    return conv.to_svg()
-
-
-@shared_task
-def convert_to_png(svg, url, width, height):
-    logger.info("Converting svg -> html -> png")
-    conv = SVGConverter(svg, url, width, height)
-    return conv.to_png()
-
-
-@shared_task
-def convert_to_pdf(svg, url, width, height):
-    logger.info("Converting svg -> html -> pdf")
-    conv = SVGConverter(svg, url, width, height)
-    return conv.to_pdf()
-
-
-@shared_task
-def convert_to_pptx(svg, url, width, height):
-    logger.info("Converting svg -> html -> png -> pptx")
-    conv = SVGConverter(svg, url, width, height)
-    return conv.to_pptx()
 
 
 @shared_task

--- a/hawc/apps/common/forms.py
+++ b/hawc/apps/common/forms.py
@@ -9,6 +9,7 @@ from django.http import HttpResponse
 from django.template.loader import render_to_string
 
 from . import selectable, tasks, validators
+from .svg import SVGConverter
 
 ASSESSMENT_UNIQUE_MESSAGE = "Must be unique for assessment (current value already exists)."
 
@@ -225,6 +226,14 @@ class DownloadPlotForm(forms.Form):
     svg = forms.CharField()
     width = forms.FloatField()
     height = forms.FloatField()
+
+    def clean_svg(self):
+        data = self.cleaned_data["svg"]
+        try:
+            SVGConverter.decode_svg(data)
+        except ValueError as err:
+            raise forms.ValidationError(str(err))
+        return data
 
     def process(self, url: str) -> HttpResponse:
         extension = self.cleaned_data["output"]

--- a/hawc/apps/common/forms.py
+++ b/hawc/apps/common/forms.py
@@ -5,9 +5,10 @@ from crispy_forms import helper as cf
 from crispy_forms import layout as cfl
 from crispy_forms.utils import TEMPLATE_PACK, flatatt
 from django import forms
+from django.http import HttpResponse
 from django.template.loader import render_to_string
 
-from . import selectable, validators
+from . import selectable, tasks, validators
 
 ASSESSMENT_UNIQUE_MESSAGE = "Must be unique for assessment (current value already exists)."
 
@@ -205,3 +206,38 @@ class AdderLayout(cfl.Field):
 
 class CustomURLField(forms.URLField):
     default_validators = [validators.CustomURLValidator()]
+
+
+class DownloadPlotForm(forms.Form):
+    CROSSWALK = {
+        "svg": (tasks.convert_to_svg, "image/svg+xml"),
+        "png": (tasks.convert_to_png, "application/png"),
+        "pdf": (tasks.convert_to_pdf, "application/pdf"),
+        "pptx": (
+            tasks.convert_to_pptx,
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        ),
+    }
+
+    output = forms.ChoiceField(
+        choices=(("svg", "svg"), ("png", "png"), ("pdf", "pdf"), ("pptx", "pptx"))
+    )
+    svg = forms.CharField()
+    width = forms.FloatField()
+    height = forms.FloatField()
+
+    def process(self, url: str) -> HttpResponse:
+        extension = self.cleaned_data["output"]
+        handler, content_type = self.CROSSWALK[extension]
+        task = handler.delay(
+            self.cleaned_data["svg"],
+            url,
+            int(self.cleaned_data["width"] * 5),
+            int(self.cleaned_data["height"] * 5),
+        )
+        response = HttpResponse("<p>An error in processing occurred.</p>")
+        output = task.get(timeout=90)
+        if output:
+            response = HttpResponse(output, content_type=content_type)
+            response["Content-Disposition"] = f'attachment; filename="download.{extension}"'
+        return response

--- a/hawc/apps/common/svg.py
+++ b/hawc/apps/common/svg.py
@@ -1,4 +1,5 @@
 import base64
+import binascii
 import logging
 import os
 import re
@@ -69,20 +70,34 @@ Styles = HawcStyles()
 
 
 class SVGConverter:
-    def __init__(self, svg, url, width, height):
+    def __init__(self, svg, url: str, width: int, height: int):
         self.url = url
         self.width = width
         self.height = height
         self.tempfns = []
-
-        svg = (
-            base64.b64decode(svg)
-            .decode("utf8")
-            .replace("%u", "\\u")
-            .encode()
-            .decode("unicode-escape")
-        )
+        svg = self.decode_svg(svg)
         self.svg = parse.unquote(svg, encoding="ISO-8859-1")
+
+    @classmethod
+    def decode_svg(cls, svg) -> str:
+        """Decode base64 encoded svg data
+
+        Args:
+            svg: base64 encoded svg
+
+        Raises:
+            ValueError: If data cannot be decoded
+        """
+        try:
+            return (
+                base64.b64decode(svg)
+                .decode("utf8")
+                .replace("%u", "\\u")
+                .encode()
+                .decode("unicode-escape")
+            )
+        except (binascii.Error, ValueError, UnicodeDecodeError):
+            raise ValueError("Invalid base64 encoded SVG")
 
     def to_svg(self):
         svg = self.svg

--- a/hawc/apps/common/tasks.py
+++ b/hawc/apps/common/tasks.py
@@ -7,6 +7,8 @@ from django.contrib.auth import get_user_model
 from django.utils.timezone import now
 from rest_framework.authtoken.models import Token
 
+from .svg import SVGConverter
+
 logger = get_task_logger(__name__)
 
 
@@ -30,3 +32,31 @@ def destroy_old_api_tokens():
     qs = Token.objects.filter(created__lt=deletion_date)
     logger.info(f"Destroying {qs.count()} old tokens")
     qs.delete()
+
+
+@shared_task
+def convert_to_svg(svg, url, width, height):
+    logger.info("Converting svg -> [css]+svg")
+    conv = SVGConverter(svg, url, width, height)
+    return conv.to_svg()
+
+
+@shared_task
+def convert_to_png(svg, url, width, height):
+    logger.info("Converting svg -> html -> png")
+    conv = SVGConverter(svg, url, width, height)
+    return conv.to_png()
+
+
+@shared_task
+def convert_to_pdf(svg, url, width, height):
+    logger.info("Converting svg -> html -> pdf")
+    conv = SVGConverter(svg, url, width, height)
+    return conv.to_pdf()
+
+
+@shared_task
+def convert_to_pptx(svg, url, width, height):
+    logger.info("Converting svg -> html -> png -> pptx")
+    conv = SVGConverter(svg, url, width, height)
+    return conv.to_pptx()

--- a/hawc/apps/myuser/signals.py
+++ b/hawc/apps/myuser/signals.py
@@ -10,4 +10,5 @@ logger = logging.getLogger(__name__)
 
 @receiver(user_logged_out)
 def invalidate_tokens(sender, request, user: HAWCUser, **kw):
-    user.destroy_api_token()
+    if user and user.is_authenticated:
+        user.destroy_api_token()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import base64
 import logging
 import os
 from pathlib import Path
@@ -191,3 +192,11 @@ def set_chrome_driver(request, chrome_driver):
 @pytest.fixture
 def set_firefox_driver(request, firefox_driver):
     request.cls.driver = firefox_driver
+
+
+@pytest.fixture
+def svg_data():
+    svg = """<svg width="100" height="100" version="1.1" xmlns="http://www.w3.org/2000/svg">
+            <rect x="10" y="10" width="80" height="80" style="fill:red;stroke-width:3;stroke:blue" />
+        </svg>"""
+    return (base64.encodebytes(svg.encode()), "/test/", 240, 240)

--- a/tests/hawc/apps/assessment/test_assessment_views.py
+++ b/tests/hawc/apps/assessment/test_assessment_views.py
@@ -195,6 +195,13 @@ class TestDownloadPlot:
         assert resp.status_code == 400
         assert resp.json() == {"valid": False}
 
+        # test incorrect svg encoding
+        data = self._get_valid_payload(svg_data)
+        data["svg"] = "💥"
+        resp = client.post(url, data)
+        assert resp.status_code == 400
+        assert resp.json() == {"valid": False}
+
     def test_valid(self, svg_data):
         client = Client()
         url = reverse("assessment:download_plot")

--- a/tests/hawc/apps/common/test_svg.py
+++ b/tests/hawc/apps/common/test_svg.py
@@ -49,3 +49,13 @@ class TestSvgConverter:
         resp = conv.to_pptx()
         assert isinstance(resp, BytesIO)
         # can't compare file; timestamp metadata information pptx
+
+    def test_decode_svg(self, svg_data):
+        # success
+        data = SVGConverter.decode_svg(svg_data[0])
+        assert data.startswith("<svg")
+
+        # failures
+        for value in ["💥", "�", "/../../WEB-INF/web.xml"]:
+            with pytest.raises(ValueError):
+                SVGConverter.decode_svg(value)

--- a/tests/hawc/apps/common/test_svg.py
+++ b/tests/hawc/apps/common/test_svg.py
@@ -1,4 +1,3 @@
-import base64
 import xml.etree.ElementTree as ET
 from io import BytesIO
 from pathlib import Path
@@ -9,14 +8,6 @@ import pytest
 from hawc.apps.common.svg import SVGConverter
 
 DATA_PATH = Path(__file__).parent.absolute() / "data"
-
-
-@pytest.fixture
-def svg_data():
-    svg = """<svg width="100" height="100" version="1.1" xmlns="http://www.w3.org/2000/svg">
-            <rect x="10" y="10" width="80" height="80" style="fill:red;stroke-width:3;stroke:blue" />
-        </svg>"""
-    return (base64.encodebytes(svg.encode()), "/test/", 240, 240)
 
 
 @pytest.mark.skipif(which("phantomjs") is None, reason="requires phantomjs on path to run")


### PR DESCRIPTION
Minor updates to improve data validation to handle errors during validation instead of processing.

- Used a django form for the `DownloadPlot` view to handle type checks 
- Added validation check to ensure base64-encoded svg can be properly decoded
- (unrelated) prevent error if unauthenticated user attempts to logout


