### PR TITLE
add swagger API user interface 

### DIFF
--- a/frontend/summary/dataPivot/ConditionalFormat.js
+++ b/frontend/summary/dataPivot/ConditionalFormat.js
@@ -293,7 +293,7 @@ class _DataPivot_settings_conditional {
                         .add_select(parent.settings.type, hash.get(v), true)
                         .data("key", v);
                     self.discrete_styles.push(style);
-                    add_input_row(discrete, `Style for <code>${v}</code>:`, style);
+                    add_input_row(discrete, `Style for <kbd>${v}</kbd>:`, style);
                 });
 
                 if (vals.unique.length === 0) {

--- a/hawc/apps/assessment/views.py
+++ b/hawc/apps/assessment/views.py
@@ -283,6 +283,11 @@ class Error401(TemplateView):
     template_name = "401.html"
 
 
+@method_decorator(staff_member_required, name="dispatch")
+class Swagger(TemplateView):
+    template_name = "swagger.html"
+
+
 # Assessment Object
 class AssessmentList(LoginRequiredMixin, ListView):
     model = models.Assessment

--- a/hawc/apps/lit/templates/lit/ris_export_instructions.html
+++ b/hawc/apps/lit/templates/lit/ris_export_instructions.html
@@ -55,21 +55,21 @@
 
 <h3 id="pubmed">PubMed:</h3>
 
-<p>For PubMed import into EndNote, use the Medline format and save the text file. Import using PubMed filter customized for HAWC imports (<code>HAWC_PubMed</code>). “NLM” will appear in Database Name field.</p>
+<p>For PubMed import into EndNote, use the Medline format and save the text file. Import using PubMed filter customized for HAWC imports (<kbd>HAWC_PubMed</kbd>). “NLM” will appear in Database Name field.</p>
 
 
 
 <h4 id="copying-the-pmid-into-the-custom-8-field">Copying the PMID into the Custom 8 field</h4>
 
 <ul>
-<li>Select all PubMed references (<code>ctrl-A</code> selects all showing references) </li>
-<li>Select <code>Change Move and Copy Fields</code> from the <code>Tools</code> dropdown on the top menu. A pop-up window will appear: <br>
-<ul><li>Select: <code>Move or Copy</code> tab </li>
-<li>Select: <code>Copy</code></li>
-<li>From field: <code>Accession Number</code></li>
-<li>To Field: <code>Custom 8</code> (if your Custom 8 is already assigned you will need to identify a new custom field to use.)</li>
-<li>Select <code>Insert after field’s text</code> (field should be empty)</li>
-<li>Click <code>OK</code></li></ul></li>
+<li>Select all PubMed references (<kbd>ctrl-A</kbd> selects all showing references) </li>
+<li>Select <kbd>Change Move and Copy Fields</kbd> from the <kbd>Tools</kbd> dropdown on the top menu. A pop-up window will appear: <br>
+<ul><li>Select: <kbd>Move or Copy</kbd> tab </li>
+<li>Select: <kbd>Copy</kbd></li>
+<li>From field: <kbd>Accession Number</kbd></li>
+<li>To Field: <kbd>Custom 8</kbd> (if your Custom 8 is already assigned you will need to identify a new custom field to use.)</li>
+<li>Select <kbd>Insert after field’s text</kbd> (field should be empty)</li>
+<li>Click <kbd>OK</kbd></li></ul></li>
 </ul>
 
 <p>The PMID will now appear in both the Accession Number field and in the Custom Field identified as PMID. </p>
@@ -78,7 +78,7 @@
 
 <h3 id="web-of-science">Web of Science</h3>
 
-<p>For Web of Science import into EndNote, search the Core Collection, save to “Endnote Desktop” and select “Full Record” for the record content. Import records using ICI filter customized for HAWC imports (<code>HAWC_WOS</code>).</p>
+<p>For Web of Science import into EndNote, search the Core Collection, save to “Endnote Desktop” and select “Full Record” for the record content. Import records using ICI filter customized for HAWC imports (<kbd>HAWC_WOS</kbd>).</p>
 
 
 
@@ -87,21 +87,21 @@
 <p>Select all references which were imported from Web of Science. Add the text “WOS” to the Name of Database Field as follows:</p>
 
 <ul>
-<li><p>Select <code>Change Move and Copy Fields</code> from the <code>Tools</code> dropdown on the top menu. In the pop-up window</p>
+<li><p>Select <kbd>Change Move and Copy Fields</kbd> from the <kbd>Tools</kbd> dropdown on the top menu. In the pop-up window</p>
 
-<ul><li>Select: <code>Change Fields</code> tab</li>
-<li>Select <code>Name of Database</code> in the fields</li>
-<li>Check <code>Insert after field’s text</code></li>
+<ul><li>Select: <kbd>Change Fields</kbd> tab</li>
+<li>Select <kbd>Name of Database</kbd> in the fields</li>
+<li>Check <kbd>Insert after field’s text</kbd></li>
 <li>In the text-box type “WOS”</li>
-<li>Uncheck the box to <code>Include a space before new text</code></li>
-<li>Click <code>OK</code></li></ul></li>
+<li>Uncheck the box to <kbd>Include a space before new text</kbd></li>
+<li>Click <kbd>OK</kbd></li></ul></li>
 </ul>
 
 
 
 <h3 id="scopus">Scopus:</h3>
 
-<p>For exporting Scopus results into EndNote, use the RIS format and be sure to <code>Specify fields to be exported</code> including the Citation information, DOI, PMID, Abstract etc. Import into EndNote using Scopus filter customized for HAWC imports (<code>HAWC_Scopus_RIS</code>).</p>
+<p>For exporting Scopus results into EndNote, use the RIS format and be sure to Specify fields to be exported including the Citation information, DOI, PMID, Abstract etc. Import into EndNote using Scopus filter customized for HAWC imports (<kbd>HAWC_Scopus_RIS</kbd>).</p>
 
 <p>No additional modifications are required.</p>
 
@@ -109,7 +109,7 @@
 
 <h3 id="embase">Embase:</h3>
 
-<p>For importing Embase into EndNote, use the export format “Plain Text” and choose “Full Record” Output.  Import into EndNote using the <code>HAWC_Embase_TEXT</code> filter.</p>
+<p>For importing Embase into EndNote, use the export format “Plain Text” and choose “Full Record” Output.  Import into EndNote using the <kbd>HAWC_Embase_TEXT</kbd> filter.</p>
 
 
 
@@ -129,12 +129,12 @@
 
 <ol>
 <li>Use the same process as described above for PubMed for copying the PMID field into the Custom 8 field, excepting using the URL field as the source and the DOI field as the destination.</li>
-<li>Run a <code>find and replace</code> on the DOI field to remove the text “<a href="http://dx.doi.org/">http://dx.doi.org/</a>.”  <br>
-<ul><li>Select <code>Find and Replace</code> from the <code>Edit</code> dropdown on the top menu. A pop-up window will appear: <br>
-<ul><li>Select <code>In</code> field: DOI</li>
-<li>In <code>Search For</code> box paste “<a href="http://dx.doi.org/">http://dx.doi.org/</a>”</li>
-<li>Keep the input-textbox <code>Change the text to</code> empty</li>
-<li>Click <code>Change</code></li></ul></li></ul></li>
+<li>Run a <kbd>find and replace</kbd> on the DOI field to remove the text “<a href="http://dx.doi.org/">http://dx.doi.org/</a>.”  <br>
+<ul><li>Select <kbd>Find and Replace</kbd> from the <kbd>Edit</kbd> dropdown on the top menu. A pop-up window will appear: <br>
+<ul><li>Select <kbd>In</kbd> field: DOI</li>
+<li>In <kbd>Search For</kbd> box paste “<a href="http://dx.doi.org/">http://dx.doi.org/</a>”</li>
+<li>Keep the input-textbox <kbd>Change the text to</kbd> empty</li>
+<li>Click <kbd>Change</kbd></li></ul></li></ul></li>
 </ol>
 
 <hr>
@@ -147,13 +147,13 @@ Also remove duplicates of items already in your HAWC project.</p>
 <p>If you need to merge multiple EndNote libraries to create single, unified file for upload into HAWC: </p>
 
 <ul>
-<li>Use the customized <code>HAWC_EndNote_Export</code> style to export your references from their library.</li>
+<li>Use the customized <kbd>HAWC_EndNote_Export</kbd> style to export your references from their library.</li>
 <li>In your Library of the references already held in your HAWC project, (or a copy of that library), create a group folder for the “old” set, and move all the references into the group folder.  Label it to differentiate it from the new import.</li>
-<li>Use the customized <code>HAWC_EndNote_Import</code> filter to import your new references into your library of existing HAWC references. <br>
+<li>Use the customized <kbd>HAWC_EndNote_Import</kbd> filter to import your new references into your library of existing HAWC references. <br>
 <ul><li><em>Remember to set your duplicate recognition preferences as you see fit before the import.</em></li></ul></li>
 </ul>
 
-<p>Your new set of references should be in the <code>Unfiled</code> grouping in your left hand <code>Library</code> pane.  You may make a new group folder for them or leave them unfiled. </p>
+<p>Your new set of references should be in the <kbd>Unfiled</kbd> grouping in your left hand <kbd>Library</kbd> pane.  You may make a new group folder for them or leave them unfiled. </p>
 
 <p>Use your preferred method of ensuring there are no duplicates within your list. <br>
  </p>
@@ -162,7 +162,7 @@ Also remove duplicates of items already in your HAWC project.</p>
 
 <h2 id="exporting-from-endnote-for-hawc-import">Exporting from EndNote for HAWC import</h2>
 
-<p>Select references to be exported. Export using customized <code>HAWC_Export_RIS</code> style. <br>
+<p>Select references to be exported. Export using customized <kbd>HAWC_Export_RIS</kbd> style. <br>
  </p>
 
 <hr>
@@ -170,28 +170,28 @@ Also remove duplicates of items already in your HAWC project.</p>
 <h2 id="endnote-tutorial-adding-filters-and-styles">(EndNote tutorial) Adding filters and styles</h2>
 
 <ol>
-<li>Locate your Endnote folder on your computer (probably under <code>My Documents</code>).  Inside it you will see a <code>Styles</code> folder and a <code>Filters</code> folder. </li>
+<li>Locate your Endnote folder on your computer (probably under <kbd>My Documents</kbd>).  Inside it you will see a <kbd>Styles</kbd> folder and a <kbd>Filters</kbd> folder. </li>
 <li>Copy or drag the required filters from the source location (whether attached to an email or stored in a shared folder) to the correct folder on your computer. <br>
-<ul><li><strong>Input filters</strong>: Place the new files in your <code>Filters</code> folder</li>
-<li><strong>Output styles</strong>: Place the new files in your <code>Styles</code> folder</li></ul></li>
-<li>In EndNote, go to your library and select <code>Import Filters</code> from the <code>Edit</code> menu <br>
-<ul><li>Chose <code>Open Filter Manager</code> </li>
+<ul><li><strong>Input filters</strong>: Place the new files in your <kbd>Filters</kbd> folder</li>
+<li><strong>Output styles</strong>: Place the new files in your <kbd>Styles</kbd> folder</li></ul></li>
+<li>In EndNote, go to your library and select <kbd>Import Filters</kbd> from the <kbd>Edit</kbd> menu <br>
+<ul><li>Chose <kbd>Open Filter Manager</kbd> </li>
 <li>A new window will pop up.</li>
 <li>Scroll through the list of choices in the new menu to select the filter you saved.</li>
 <li>Click the box to the left of the filter you would like to make available in your library.  Anything with a blue check in the box will be available in your choices for the import process.</li>
 <li>Close the box when you finish, and return to your library to use the filter.</li></ul></li>
-<li>For new output styles, use the same process but choose <code>Output Styles</code> from the Edit menu instead.</li>
+<li>For new output styles, use the same process but choose <kbd>Output Styles</kbd> from the Edit menu instead.</li>
 </ol>
 
 <hr>
 
 <h2 id="endnote-tutorial-changing-reference-list-display-fields">(EndNote tutorial) Changing reference list-display fields</h2>
 
-<p>You may display 10 fields at a time in your library view window. You may change them in the library screen (one at a time) or go to the <code>Preferences</code> window to make multiple changes at once.  To change which fields are showing within the library window, right-click in the header bar where you would like to add a column. A list of fields will open showing the fields in use in black text with a check, and fields not displayed grayed out.</p>
+<p>You may display 10 fields at a time in your library view window. You may change them in the library screen (one at a time) or go to the <kbd>Preferences</kbd> window to make multiple changes at once.  To change which fields are showing within the library window, right-click in the header bar where you would like to add a column. A list of fields will open showing the fields in use in black text with a check, and fields not displayed grayed out.</p>
 
 <p>If you don’t have 10 fields showing already, you may simply check an additional field and it will be added. (You will have to add them one at a time, as the choice list closes after each selection). If you already have 10 displayed, you will need to click one of the checked fields to remove it, then re-open the choice list to add the new field.</p>
 
-<p>If you have several fields to add or remove it may be easier to open the utility and assign the fields there. Go to <code>Endnote</code> in the top menu and select <code>Preferences</code>. In the window that pops up, choose <code>Display Fields</code>.</p>
+<p>If you have several fields to add or remove it may be easier to open the utility and assign the fields there. Go to <kbd>Endnote</kbd> in the top menu and select <kbd>Preferences</kbd>. In the window that pops up, choose <kbd>Display Fields</kbd>.</p>
 
 <p>Select the fields by their systematic fields name in the left column. In the right column you have the option to edit the way the field is displayed in your library.  You may chose to change the heading for Custom 8 to “PMID”. You may set the order here with the top (Column 1) representing the first column on the left, proceeding to the right as you go down.  You may also drag and drop the headings in your library window to change the order.</p>
 

--- a/hawc/apps/lit/templates/lit/ris_export_instructions.html
+++ b/hawc/apps/lit/templates/lit/ris_export_instructions.html
@@ -2,6 +2,8 @@
 
 {% load static %}
 
+{% block title %}RIS formatting instructions |{{block.super}}{% endblock %}
+
 {% block content %}
 <div class="col-md-8 col-md-offset-2">
 

--- a/hawc/apps/myuser/templates/myuser/welcome_email.html
+++ b/hawc/apps/myuser/templates/myuser/welcome_email.html
@@ -15,7 +15,7 @@ In order to use the site, you'll need to set your password. To set your
 password, click this link:<br>
 <a href="https://{{domain}}/user/password-reset/" >Set your password</a><br><br>
 
-Enter your email address <code>{{user.email}}</code>, and a link will be emailed to you to
+Enter your email address, {{user.email}}, and a link will be emailed to you to
 reset your password.<br><br>
 
 Thank you for joining HAWC; we hope this is helpful in your health assessment!<br><br>

--- a/hawc/main/urls.py
+++ b/hawc/main/urls.py
@@ -72,7 +72,7 @@ if settings.INCLUDE_ADMIN:
     admin_url = f"admin/{settings.ADMIN_URL_PREFIX}" if settings.ADMIN_URL_PREFIX else "admin"
     urlpatterns += [
         path(
-            "api/openapi/",
+            f"{admin_url}/api/openapi/",
             get_schema_view(
                 title="HAWC",
                 version=__version__,
@@ -81,7 +81,7 @@ if settings.INCLUDE_ADMIN:
             ),
             name="openapi",
         ),
-        path("api/swagger/", views.Swagger.as_view(), name="swagger"),
+        path(f"{admin_url}/api/swagger/", views.Swagger.as_view(), name="swagger"),
         path(f"{admin_url}/dashboard/", views.AdminDashboard.as_view(), name="admin_dashboard",),
         path(
             f"{admin_url}/assessment-size/",

--- a/hawc/main/urls.py
+++ b/hawc/main/urls.py
@@ -65,22 +65,23 @@ urlpatterns = [
     path("500/", views.Error500.as_view(), name="500"),
     path("update-session/", views.UpdateSession.as_view(), name="update_session"),
     path("selectable/", include("selectable.urls")),
-    path(
-        "openapi/",
-        get_schema_view(
-            title="HAWC",
-            version=__version__,
-            patterns=open_api_patterns,
-            permission_classes=(permissions.IsAdminUser,),
-        ),
-        name="openapi",
-    ),
 ]
 
 
 if settings.INCLUDE_ADMIN:
     admin_url = f"admin/{settings.ADMIN_URL_PREFIX}" if settings.ADMIN_URL_PREFIX else "admin"
     urlpatterns += [
+        path(
+            "api/openapi/",
+            get_schema_view(
+                title="HAWC",
+                version=__version__,
+                patterns=open_api_patterns,
+                permission_classes=(permissions.IsAdminUser,),
+            ),
+            name="openapi",
+        ),
+        path("api/swagger/", views.Swagger.as_view(), name="swagger"),
         path(f"{admin_url}/dashboard/", views.AdminDashboard.as_view(), name="admin_dashboard",),
         path(
             f"{admin_url}/assessment-size/",

--- a/hawc/static/css/hawc.css
+++ b/hawc/static/css/hawc.css
@@ -49,15 +49,6 @@ tfoot > tr > td {
     font-size: 80%;
     border-top: none;
 }
-code {
-    margin: 0 2px;
-    padding: 0px 5px;
-    border: 1px solid #ddd;
-    background-color: #f8f8f8;
-    border-radius: 2px;
-    font-size: 0.95em;
-    color: #444;
-}
 .hidden {
     display: none;
 }

--- a/hawc/templates/admin/base.html
+++ b/hawc/templates/admin/base.html
@@ -11,6 +11,7 @@
     {% if site_url %}
         <a href="{{ site_url }}">{% trans 'View site' %}</a> /
     {% endif %}
+    <a href="{% url 'swagger' %}">{% translate 'Swagger UI' %}</a> /
     {% if user.is_active and user.is_staff %}
         {% url 'django-admindocs-docroot' as docsroot %}
         {% if docsroot %}

--- a/hawc/templates/swagger.html
+++ b/hawc/templates/swagger.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+{% block title %}{{block.super}} | Swagger UI{% endblock title %}
+
+{% block extrahead %}
+<link rel="stylesheet" type="text/css" href="//unpkg.com/swagger-ui-dist@3/swagger-ui.css" />
+<script src="//unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
+{% endblock extrahead %}
+
+{% block content_row_outer %}
+<div id="swagger-ui"></div>
+{% endblock content_row_outer %}
+
+{% block extrajs %}
+<script>
+    const ui = SwaggerUIBundle({
+        url: "{% url 'openapi' %}",
+        dom_id: '#swagger-ui',
+        presets: [
+            SwaggerUIBundle.presets.apis,
+            SwaggerUIBundle.SwaggerUIStandalonePreset
+        ],
+        layout: "BaseLayout",
+        requestInterceptor: (request) => {
+            request.headers['X-CSRFToken'] = "{{ csrf_token }}"
+            return request;
+        }
+    })
+</script>
+{% endblock extrajs %}


### PR DESCRIPTION
Add a browsable swagger user interface `{{admin}}/api/swagger/` (staff only):

<img width="1057" alt="Screen Shot 2021-11-22 at 10 52 30 PM" src="https://user-images.githubusercontent.com/999952/142968976-b1d532a9-4cd7-44b3-9b9c-2838cf2fcf92.png">

To fix styling:

- removed custom code styling in css
- switch to [kbd](https://getbootstrap.com/docs/4.5/content/code/#user-input) for a few commands previously using code 
    -  conditional formatting options on data pivots
    - RIS instructions (`/lit/ris-export-instructions/`)
<img width="212" alt="Screen Shot 2021-12-01 at 8 18 29 PM" src="https://user-images.githubusercontent.com/999952/144340290-c16febb5-a460-4422-b1d2-c6a1a5f0ac48.png">

