### PR TITLE
audit change logs

### DIFF
--- a/compose/app/web.sh
+++ b/compose/app/web.sh
@@ -10,4 +10,5 @@ set -xe
     --log-level info \
     --log-file - \
     --max-requests 750 \
-    --max-requests-jitter 250
+    --max-requests-jitter 250 \
+    --capture-output

--- a/hawc/apps/common/views.py
+++ b/hawc/apps/common/views.py
@@ -23,6 +23,7 @@ from .crumbs import Breadcrumb
 from .helper import tryParseInt
 
 logger = logging.getLogger(__name__)
+audit_logger = logging.getLogger("hawc.audit.change")
 
 
 def beta_tester_required(function=None, redirect_field_name=REDIRECT_FIELD_NAME, login_url=None):
@@ -95,6 +96,7 @@ def create_object_log(verb: str, obj, assessment_id: int, user_id: int):
     comment = (
         f"{reversion.get_comment()}, Log {log.id}" if reversion.get_comment() else f"Log {log.id}"
     )
+    audit_logger.info(f"[{log.id}] assessment-{assessment_id} user-{user_id} {log_message}")
     reversion.set_comment(comment)
 
 

--- a/hawc/main/settings/staging.py
+++ b/hawc/main/settings/staging.py
@@ -43,9 +43,9 @@ elif email_backend == "CONSOLE":
 else:
     raise ValueError(f"Unknown email backend: {email_backend}")
 
-LOGGING["loggers"]["django"]["handlers"] = ["file"]
-LOGGING["loggers"]["hawc"]["handlers"] = ["file"]
-LOGGING["loggers"]["hawc.request"]["handlers"] = ["hawc-request"]
+LOGGING["loggers"]["django"]["handlers"] = ["console", "file"]
+LOGGING["loggers"]["hawc"]["handlers"] = ["console", "file"]
+LOGGING["loggers"]["hawc.request"]["handlers"] = ["console", "hawc-request"]
 
 ANYONE_CAN_CREATE_ASSESSMENTS = os.getenv("HAWC_ANYONE_CAN_CREATE_ASSESSMENTS", "True") == "True"
 PM_CAN_MAKE_PUBLIC = os.getenv("HAWC_PM_CAN_MAKE_PUBLIC", "True") == "True"


### PR DESCRIPTION
This PR adds a level of redundancy to where audit changes are reported. Previously (see #496); changes to content with resulted in the creation of a new db change record. 

This PR does two things:
1. Adds an application log to `hawc.audit.change` that mirrors the change record in the database
2. Captures all django application logs and serves them through gunicorn in the container environment; these are further piped into the docker logs. (`django > gunicorn > docker`)