### PR TITLE
add new email provider - sendgrid

### DIFF
--- a/hawc/main/settings/staging.py
+++ b/hawc/main/settings/staging.py
@@ -38,6 +38,12 @@ elif email_backend == "MAILGUN":
         MAILGUN_API_KEY=os.environ["MAILGUN_ACCESS_KEY"],
         MAILGUN_SENDER_DOMAIN=os.environ["MAILGUN_SERVER_NAME"],
     )
+elif email_backend == "SENDGRID":
+    INSTALLED_APPS += ("anymail",)
+    EMAIL_BACKEND = "anymail.backends.sendgrid.EmailBackend"
+    ANYMAIL = dict(
+        SENDGRID_API_KEY=os.environ["SENDGRID_API_KEY"],
+   )
 elif email_backend == "CONSOLE":
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 else:

--- a/hawc/main/settings/staging.py
+++ b/hawc/main/settings/staging.py
@@ -41,9 +41,7 @@ elif email_backend == "MAILGUN":
 elif email_backend == "SENDGRID":
     INSTALLED_APPS += ("anymail",)
     EMAIL_BACKEND = "anymail.backends.sendgrid.EmailBackend"
-    ANYMAIL = dict(
-        SENDGRID_API_KEY=os.environ["SENDGRID_API_KEY"],
-   )
+    ANYMAIL = dict(SENDGRID_API_KEY=os.environ["SENDGRID_API_KEY"],)
 elif email_backend == "CONSOLE":
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 else:


### PR DESCRIPTION
This permits the use of the sendgrid smtp api for emails within HAWC.
I have tested this using the sendgrid settings provided to me by IARC tech support. 