### PR TITLE
tag actions on custom visuals and tables

### DIFF
--- a/frontend/lit/NestedTag.js
+++ b/frontend/lit/NestedTag.js
@@ -55,14 +55,14 @@ class NestedTag {
         }
     }
 
-    renderPaginatedReferenceList(el) {
+    renderPaginatedReferenceList(el, canEdit) {
         const settings = {
             assessment_id: this.assessment_id,
             tag_id: this.data.pk,
             search_id: this.search_id,
             tag: this,
         };
-        ReactDOM.render(<PaginatedReferenceList settings={settings} />, el);
+        ReactDOM.render(<PaginatedReferenceList settings={settings} canEdit={canEdit} />, el);
     }
 
     renderReferenceList(el) {

--- a/frontend/lit/ReferenceTreeBrowse/Main.js
+++ b/frontend/lit/ReferenceTreeBrowse/Main.js
@@ -4,12 +4,12 @@ import PropTypes from "prop-types";
 import {inject, observer} from "mobx-react";
 import {toJS} from "mobx";
 
-import {ActionLink, ActionsButton} from "shared/components/ActionsButton";
 import Loading from "shared/components/Loading";
 import TextInput from "shared/components/TextInput";
 import TagTree from "../components/TagTree";
 import YearHistogram from "./YearHistogram";
 import ReferenceTableMain from "./ReferenceTableMain";
+import TagActions from "lit/components/TagActions";
 
 const referenceListItem = ref => {
     return (
@@ -54,20 +54,18 @@ class ReferenceTreeMain extends Component {
     }
     render() {
         const {store} = this.props,
-            actions = store.getActionLinks,
             {selectedReferences, selectedReferencesLoading, filteredReferences, yearFilter} = store,
             yearText = yearFilter ? ` (${yearFilter.min}-${yearFilter.max})` : "";
 
         return (
             <div className="row">
                 <div className="col-md-12 pb-2">
-                    {actions.length > 0 ? (
-                        <ActionsButton
-                            items={actions.map((action, index) => (
-                                <ActionLink key={index} label={action[1]} href={action[0]} />
-                            ))}
-                        />
-                    ) : null}
+                    <TagActions
+                        assessmentId={store.config.assessment_id}
+                        tagId={store.selectedTag ? store.selectedTag.data.pk : undefined}
+                        untagged={store.untaggedReferencesSelected}
+                        canEdit={store.config.canEdit}
+                    />
                     {store.untaggedReferencesSelected === true ? (
                         <h4>Untagged references</h4>
                     ) : store.selectedTag === null ? (

--- a/frontend/lit/ReferenceTreeBrowse/store.js
+++ b/frontend/lit/ReferenceTreeBrowse/store.js
@@ -91,34 +91,6 @@ class Store {
         return refs;
     }
 
-    @computed get getActionLinks() {
-        let links = [];
-        if (this.untaggedReferencesSelected === true && this.config.canEdit) {
-            links.push([
-                `/lit/assessment/${this.config.assessment_id}/tag/untagged/`,
-                "Tag untagged references",
-            ]);
-        } else if (this.selectedTag !== null) {
-            links = [
-                [
-                    `/lit/api/tags/${this.selectedTag.data.pk}/references/?format=xlsx`,
-                    "Download references",
-                ],
-                [
-                    `/lit/api/tags/${this.selectedTag.data.pk}/references-table-builder/?format=xlsx`,
-                    "Download references (table-builder format)",
-                ],
-            ];
-            if (this.config.canEdit) {
-                links.push([
-                    `/lit/tag/${this.selectedTag.data.pk}/tag/`,
-                    "Tag references with this tag (but not descendants)",
-                ]);
-            }
-        }
-        return links;
-    }
-
     // year filter
     @observable yearFilter = null;
     @action.bound updateYearFilter(filter) {

--- a/frontend/lit/TagTreeViz.js
+++ b/frontend/lit/TagTreeViz.js
@@ -160,7 +160,7 @@ class TagTreeViz extends D3Plot {
                     .addFooter("")
                     .show({maxWidth: 1200});
 
-                tag.renderPaginatedReferenceList(div.get(0));
+                tag.renderPaginatedReferenceList(div.get(0), self.stateStore.options.can_edit);
             },
             update = function(event, source) {
                 var duration = event && event.altKey ? 5000 : 500,

--- a/frontend/lit/TagTreeViz.js
+++ b/frontend/lit/TagTreeViz.js
@@ -152,7 +152,7 @@ class TagTreeViz extends D3Plot {
             },
             fetch_references = function(tag) {
                 var title = `<h4>${tag.data.name}</h4>`,
-                    div = $('<div id="references_div"></div');
+                    div = $("<div>");
 
                 self.modal
                     .addHeader(title)

--- a/frontend/lit/components/PaginatedReferenceList.js
+++ b/frontend/lit/components/PaginatedReferenceList.js
@@ -56,11 +56,10 @@ class PaginatedReferenceList extends Component {
     }
     render() {
         const {hasPage, formattedReferences, currentPage, fetchPage} = this.store,
-            {settings} = this.props;
+            {settings, canEdit} = this.props;
         if (!hasPage) {
             return <Loading />;
         }
-
         return (
             <>
                 <div>
@@ -68,7 +67,7 @@ class PaginatedReferenceList extends Component {
                     <TagActions
                         assessmentId={settings.assessment_id}
                         tagId={settings.tag_id}
-                        canEdit={true} // FIX THIS
+                        canEdit={canEdit}
                     />
                 </div>
                 {formattedReferences ? (
@@ -87,6 +86,10 @@ PaginatedReferenceList.propTypes = {
         search_id: PropTypes.number,
         tag: PropTypes.object.isRequired,
     }),
+    canEdit: PropTypes.bool,
+};
+PaginatedReferenceList.defaultProps = {
+    canEdit: false,
 };
 
 export default PaginatedReferenceList;

--- a/frontend/lit/components/PaginatedReferenceList.js
+++ b/frontend/lit/components/PaginatedReferenceList.js
@@ -9,6 +9,7 @@ import Paginator from "shared/components/Paginator";
 
 import Reference from "../Reference";
 import ReferenceTable from "./ReferenceTable";
+import TagActions from "./TagActions";
 
 class ReferenceListStore {
     @observable currentPage = null;
@@ -54,13 +55,22 @@ class PaginatedReferenceList extends Component {
         this.store.fetchFirstPage();
     }
     render() {
-        const {hasPage, formattedReferences, currentPage, fetchPage} = this.store;
+        const {hasPage, formattedReferences, currentPage, fetchPage} = this.store,
+            {settings} = this.props;
         if (!hasPage) {
             return <Loading />;
         }
 
         return (
             <>
+                <div>
+                    &nbsp;
+                    <TagActions
+                        assessmentId={settings.assessment_id}
+                        tagId={settings.tag_id}
+                        canEdit={true} // FIX THIS
+                    />
+                </div>
                 {formattedReferences ? (
                     <ReferenceTable references={formattedReferences} showActions={false} />
                 ) : null}

--- a/frontend/lit/components/TagActions.js
+++ b/frontend/lit/components/TagActions.js
@@ -1,0 +1,65 @@
+import React, {Component} from "react";
+import PropTypes from "prop-types";
+
+import {ActionLink, ActionsButton} from "shared/components/ActionsButton";
+
+const getActionLinks = function(assessmentId, tagId, untagged, canEdit) {
+    let links = [];
+    if (untagged && canEdit) {
+        links.push(
+            <ActionLink
+                key={0}
+                label="Tag untagged references"
+                href={`/lit/assessment/${assessmentId}/tag/untagged/`}
+            />
+        );
+    }
+    if (tagId) {
+        links = [
+            <ActionLink
+                key={1}
+                label="Download references"
+                href={`/lit/api/tags/${tagId}/references/?format=xlsx`}
+            />,
+            <ActionLink
+                key={2}
+                label="Download references (table-builder format)"
+                href={`/lit/api/tags/${tagId}/references-table-builder/?format=xlsx`}
+            />,
+        ];
+        if (canEdit) {
+            links.push(
+                <ActionLink
+                    key={3}
+                    label="Tag references with this tag (but not descendants)"
+                    href={`/lit/tag/${tagId}/tag/`}
+                />
+            );
+        }
+    }
+    return links;
+};
+
+class TagActions extends Component {
+    render() {
+        const {assessmentId, tagId, untagged, canEdit} = this.props,
+            links = getActionLinks(assessmentId, tagId, untagged, canEdit);
+        if (links.length == 0) {
+            return null;
+        }
+        return <ActionsButton containerClasses="btn-primary" items={links} />;
+    }
+}
+
+TagActions.propTypes = {
+    assessmentId: PropTypes.number.isRequired,
+    tagId: PropTypes.number,
+    untagged: PropTypes.bool.isRequired,
+    canEdit: PropTypes.bool.isRequired,
+};
+TagActions.defaultProps = {
+    untagged: false,
+    canEdit: false,
+};
+
+export default TagActions;

--- a/frontend/summary/summary/LiteratureTagtree.js
+++ b/frontend/summary/summary/LiteratureTagtree.js
@@ -1,3 +1,5 @@
+import _ from "lodash";
+
 import SmartTagContainer from "shared/smartTags/SmartTagContainer";
 import BaseVisual from "./BaseVisual";
 import TagTree from "lit/TagTree";
@@ -48,6 +50,8 @@ class LiteratureTagtree extends BaseVisual {
 
         // change root node
         tagtree.reset_root_node(this.data.settings.root_node);
+
+        _.extend(this.data.settings, {can_edit: window.isEditable});
 
         new TagTreeViz(tagtree, $plotDiv, title, url, this.data.settings);
     }

--- a/frontend/summary/summary/Visual.js
+++ b/frontend/summary/summary/Visual.js
@@ -46,15 +46,11 @@ class Visual {
 
     static displayAsPage(id, $el) {
         $el.html(HAWCUtils.loading());
-        Visual.get_object(id, function(d) {
-            d.displayAsPage($el);
-        });
+        Visual.get_object(id, d => d.displayAsPage($el));
     }
 
     static displayAsModal(id, options) {
-        Visual.get_object(id, function(d) {
-            d.displayAsModal(options);
-        });
+        Visual.get_object(id, d => d.displayAsModal(options));
     }
 
     static displayInline(id, setTitle, setBody) {

--- a/hawc/apps/lit/templates/lit/reference_visual.html
+++ b/hawc/apps/lit/templates/lit/reference_visual.html
@@ -25,6 +25,7 @@
         hide_empty_tag_nodes: false,
         width: 1280,
         height: 800,
+        can_edit: {{ obj_perms.edit | lower }}
       });
     });
   </script>

--- a/tests/data/api/api-visual-tagtree.json
+++ b/tests/data/api/api-visual-tagtree.json
@@ -10,9 +10,12 @@
   "prefilters": "{}",
   "published": true,
   "settings": {
+    "height": 500,
+    "hide_empty_tag_nodes": false,
     "pruned_tags": [],
     "required_tags": [],
-    "root_node": 11
+    "root_node": 11,
+    "width": 1280
   },
   "slug": "tagtree",
   "sort_order": "short_citation",

--- a/tests/data/fixtures/db.yaml
+++ b/tests/data/fixtures/db.yaml
@@ -5283,7 +5283,7 @@
     visual_type: 4
     dose_units: null
     prefilters: '{}'
-    settings: '{"root_node": 11, "required_tags": [], "pruned_tags": []}'
+    settings: '{"root_node": 11, "required_tags": [], "pruned_tags": [], "hide_empty_tag_nodes": false, "height": 500, "width": 1280}'
     caption: <p>caption</p>
     published: true
     sort_order: short_citation


### PR DESCRIPTION
Create a new `TagActions` component and use for both tagtree visualizations (restoring old functionality that was removed), as well as replacing the existing tag-actions button the the reference tag browsing page

- `/lit/assessment/:id/references/visualization/` (new; restoring old feature removed)
- `/lit/assessment/:id/references/` (replace with new component)
- `/summary/visual/assessment/:id/:slug/` (new; custom visualization tagtrees)