### PR TITLE
update rob legend on visuals

### DIFF
--- a/frontend/summary/summary/RoBLegend.js
+++ b/frontend/summary/summary/RoBLegend.js
@@ -24,11 +24,12 @@ class RoBLegend {
     }
 
     get_data() {
-        const {show_na_legend, show_nr_legend} = this.settings,
+        const {included_metrics, show_na_legend, show_nr_legend} = this.settings,
             {collapseNR} = this.options,
             includedItems = new Set(_.keys(SCORE_TEXT_DESCRIPTION_LEGEND).map(d => parseInt(d)));
 
         let response_values = _.chain(this.rob_settings.metrics)
+            .filter(d => _.includes(included_metrics, d.id))
             .map(d => d.response_values)
             .flatten()
             .uniq()


### PR DESCRIPTION
Only show the legend options which are in the metrics selected for a given visualization

Only one score set shown: 
<img width="405" alt="Screen Shot 2021-11-27 at 9 56 34 PM" src="https://user-images.githubusercontent.com/999952/143727123-4b78285e-52b2-49e5-b4e2-ba88b32a9ead.png">

Multiple score sets shown:
<img width="471" alt="Screen Shot 2021-11-27 at 9 55 18 PM" src="https://user-images.githubusercontent.com/999952/143727124-e0d94674-4e8d-4b48-9c85-8d0841a7fdaf.png">
