### PR TITLE
test fixture improvements; api tweaks

### DIFF
--- a/hawc/apps/animal/serializers.py
+++ b/hawc/apps/animal/serializers.py
@@ -329,12 +329,6 @@ class EndpointSerializer(serializers.ModelSerializer):
                 {term_field: f"Got term type '{term.type}', expected type '{term_type}'."}
             )
 
-        # Term overrides its non-term counterpart, so non-term cannot be set at the same time
-        if term and text:
-            raise serializers.ValidationError(
-                {term_field: f"'{text_field}' and '{text_field}_term' are mutually exclusive."}
-            )
-
         # Save the non-term equivalent
         data[text_field] = term.name
 

--- a/hawc/apps/animal/serializers.py
+++ b/hawc/apps/animal/serializers.py
@@ -310,7 +310,6 @@ class EndpointSerializer(serializers.ModelSerializer):
         """
 
         term = data.get(term_field)
-        text = data.get(text_field)
         if term is None:
             return
 

--- a/hawc/apps/assessment/actions/media.py
+++ b/hawc/apps/assessment/actions/media.py
@@ -50,8 +50,9 @@ def media_metadata_report(root_uri: str) -> pd.DataFrame:
         df.size_mb = df.size_mb / (1024 * 1024)
         df.created = pd.to_datetime(df.created, unit="s")
         df.modified = pd.to_datetime(df.modified, unit="s")
+        df.full_path = df.full_path.astype(str)
 
         # sort in descending order
-        df = df.sort_values("created", ascending=False)
+        df = df.convert_dtypes().sort_values("created", ascending=False)
 
     return df

--- a/hawc/apps/assessment/admin.py
+++ b/hawc/apps/assessment/admin.py
@@ -166,6 +166,7 @@ class DatasetAdmin(admin.ModelAdmin):
 
 @admin.register(models.DoseUnits)
 class DoseUnitsAdmin(admin.ModelAdmin):
+    search_fields = ("name",)
     list_display = (
         "name",
         "animal_dose_group_count",

--- a/hawc/apps/lit/api.py
+++ b/hawc/apps/lit/api.py
@@ -169,8 +169,11 @@ class LiteratureAssessmentViewset(LegacyAssessmentAdapterMixin, viewsets.Generic
     @action(detail=True, url_path="topic-model")
     def topic_model(self, request, pk):
         assessment = self.get_object()
-        fig_dict = assessment.literature_settings.get_topic_tsne_fig_dict()
-        return Response(fig_dict)
+        if assessment.literature_settings.has_topic_model:
+            data = assessment.literature_settings.get_topic_tsne_fig_dict()
+        else:
+            data = {"status": "No topic model available"}
+        return Response(data)
 
     @action(detail=True, methods=("post",), url_path="topic-model-request-refresh")
     def topic_model_request_refresh(self, request, pk):

--- a/hawc/apps/lit/models.py
+++ b/hawc/apps/lit/models.py
@@ -140,7 +140,7 @@ class LiteratureAssessment(models.Model):
 
         data = dict(df=f1.getvalue(), topics=f2.getvalue())
 
-        if self.has_topic_model():
+        if self.has_topic_model:
             self.topic_tsne_data.delete(save=False)
         self.topic_tsne_refresh_requested = None
         self.topic_tsne_last_refresh = timezone.now()
@@ -148,7 +148,7 @@ class LiteratureAssessment(models.Model):
         cache.delete(self.topic_tsne_fig_dict_cache_key)
 
     def get_topic_tsne_data(self) -> Dict:
-        if not self.has_topic_model():
+        if not self.has_topic_model:
             raise ValueError("No data available.")
         data = pickle.load(self.topic_tsne_data.file.file)
         data["df"] = pd.read_parquet(BytesIO(data["df"]), engine="pyarrow")
@@ -164,8 +164,10 @@ class LiteratureAssessment(models.Model):
             cache.set(self.topic_tsne_fig_dict_cache_key, fig_dict, 60 * 60)  # cache for 1 hour
         return fig_dict
 
+    @property
     def has_topic_model(self) -> bool:
-        return self.topic_tsne_data.name is not None and self.topic_tsne_data.name != ""
+        name = self.topic_tsne_data.name
+        return name is not None and name != ""
 
     def can_topic_model(self) -> bool:
         return self.assessment.references.count() >= self.TOPIC_MODEL_MIN_REFERENCES

--- a/tests/data/fixtures/db.yaml
+++ b/tests/data/fixtures/db.yaml
@@ -477,6 +477,12 @@
     date_joined: 2020-01-25 14:23:16.175169+00:00
     groups: []
     user_permissions: []
+- model: authtoken.token
+  pk: cef32b9abcbe1a6e9c8460099403e9cd77e12c79
+  fields:
+    user:
+    - admin@hawcproject.org
+    created: 2045-01-01 12:00:00.123456+00:00
 - model: myuser.userprofile
   pk: 1
   fields:

--- a/tests/hawc/apps/animal/test_animal_serializer.py
+++ b/tests/hawc/apps/animal/test_animal_serializer.py
@@ -189,22 +189,6 @@ class TestEndpointSerializer:
         assert serializer.is_valid() is False
         assert serializer.errors == {"name": ["'name' or 'name_term' is required."]}
 
-        # term_field and text_field are mutually exclusive
-        data = {
-            "name": "Endpoint name",
-            "animal_group_id": 1,
-            "data_type": "C",
-            "variance_type": 1,
-            "response_units": "μg/dL",
-            "system": "Cardio",
-            "system_term": 1,
-        }
-        serializer = EndpointSerializer(data=data, context={"request": request})
-        assert serializer.is_valid() is False
-        assert serializer.errors == {
-            "system_term": ["'system' and 'system_term' are mutually exclusive."]
-        }
-
         # term types must match field
         data = {
             "name": "Endpoint name",

--- a/tests/hawc/apps/lit/test_lit_api.py
+++ b/tests/hawc/apps/lit/test_lit_api.py
@@ -52,11 +52,10 @@ class TestLiteratureAssessmentViewset:
             assert anon_client.get(url).status_code == 403
             assert rev_client.get(url).status_code == 200
 
-        # check permissions for this one; raises an error
+        # topic model permissions
         url = reverse("lit:api:assessment-topic-model", args=(db_keys.assessment_working,))
         assert anon_client.get(url).status_code == 403
-        with pytest.raises(ValueError):
-            assert rev_client.get(url).status_code == 200
+        assert rev_client.get(url).status_code == 200
 
         tagtree_url = reverse("lit:api:assessment-tagtree", args=(db_keys.assessment_working,))
         # only reviewers and up can GET


### PR DESCRIPTION
- create iris dataset files with `load_test_db` command
- fix media preview admin api w/ json recursion on filesystem paths
- fix lit topic model api when not enough references
- add 30-yr auth token for test fixture
- add name to dose-units search field
- for animal endpoint API creation, relax mutual exclusion in api; not enforced in form view, so this makes the API and form consistent