### PR TITLE
wrap token in a html ID

### DIFF
--- a/hawc/apps/myuser/templates/myuser/userprofile_detail.html
+++ b/hawc/apps/myuser/templates/myuser/userprofile_detail.html
@@ -49,7 +49,7 @@
     <tr>
       <th>API token</th>
       <td colspan="2">
-        {{token.key}}
+        <span id="api_token">{{token.key}}</span>
         <p class="text-muted mb-0">Token is only valid during the current login session.</p>
     </td>
     </tr>


### PR DESCRIPTION
Wrap the API token in an ID so automation can easily grab it.

Using javascript:

```javascript
const token = document.getElementById("api_token").innerText
```

Using python:

```python
from lxml import html
html_text = """<div><div id="api_token">asdf123</div></div>"""
dom = html.fromstring(html_text)
print(dom.get_element_by_id('api_token').text)
```