### PR TITLE
fix literature reports downloads to include child tags

### DIFF
--- a/frontend/lit/components/TagActions.js
+++ b/frontend/lit/components/TagActions.js
@@ -24,7 +24,7 @@ const getActionLinks = function(assessmentId, tagId, untagged, canEdit) {
             <ActionLink
                 key={2}
                 label="Download references (table-builder format)"
-                href={`/lit/api/tags/${tagId}/references-table-builder/?format=xlsx`}
+                href={`/lit/api/tags/${tagId}/references/?format=xlsx&exporter=table-builder`}
             />,
         ];
         if (canEdit) {

--- a/hawc/apps/lit/api.py
+++ b/hawc/apps/lit/api.py
@@ -331,11 +331,12 @@ class ReferenceFilterTagViewset(AssessmentRootedTagTreeViewset):
     @action(detail=True, renderer_classes=PandasRenderers)
     def references(self, request, pk):
         """
-        Return all references for a selected tag; does not include tag-descendants.
+        Return all references for a selected tag, including tag-descendants.
         """
         tag = self.get_object()
+        qs = models.Reference.objects.get_references_with_tag(tag=tag, descendants=True)
         exporter = exports.ReferenceFlatComplete(
-            queryset=models.Reference.objects.filter(tags=tag).order_by("id"),
+            queryset=qs.order_by("id"),
             filename=f"{self.assessment}-{tag.slug}",
             assessment=self.assessment,
             tags=self.model.get_all_tags(self.assessment.id, json_encode=False),
@@ -346,12 +347,12 @@ class ReferenceFilterTagViewset(AssessmentRootedTagTreeViewset):
     @action(detail=True, url_path="references-table-builder", renderer_classes=PandasRenderers)
     def references_table_builder(self, request, pk):
         """
-        Return all references for a selected tag in table-builder import format; does not include
-        tag-descendants.
+        Return all references in table-builder format for a selected tag, including tag-descendants.
         """
         tag = self.get_object()
+        qs = models.Reference.objects.get_references_with_tag(tag=tag, descendants=True)
         exporter = exports.TableBuilderFormat(
-            queryset=models.Reference.objects.filter(tags=tag).order_by("id"),
+            queryset=qs.order_by("id"),
             filename=f"{self.assessment}-{tag.slug}",
             assessment=self.assessment,
         )

--- a/hawc/apps/lit/serializers.py
+++ b/hawc/apps/lit/serializers.py
@@ -19,7 +19,7 @@ from ..assessment.serializers import AssessmentRootedSerializer
 from ..common.api import DynamicFieldsMixin
 from ..common.forms import ASSESSMENT_UNIQUE_MESSAGE
 from ..common.serializers import validate_jsonschema
-from . import constants, forms, models, tasks
+from . import constants, exports, forms, models, tasks
 
 logger = logging.getLogger(__name__)
 
@@ -463,3 +463,20 @@ class ReferenceReplaceHeroIdSerializer(serializers.Serializer):
 
         # run chained tasks
         return chain(t1, t2, t3)()
+
+
+class ReferenceTagExportSerializer(serializers.Serializer):
+    nested = serializers.ChoiceField(choices=[("t", "true"), ("f", "false")], default="t")
+    exporter = serializers.ChoiceField(
+        choices=[("base", "base"), ("table-builder", "table builder")], default="base"
+    )
+    _exporters = {
+        "base": exports.ReferenceFlatComplete,
+        "table-builder": exports.TableBuilderFormat,
+    }
+
+    def get_exporter(self):
+        return self._exporters[self.validated_data["exporter"]]
+
+    def include_descendants(self):
+        return self.validated_data["nested"] == "t"

--- a/tests/hawc/apps/lit/test_api.py
+++ b/tests/hawc/apps/lit/test_api.py
@@ -279,22 +279,26 @@ class TestLiteratureAssessmentViewset:
 @pytest.mark.django_db
 class TestReferenceFilterTagViewset:
     def test_references(self):
-        # ensure we get a valid json return
         url = reverse("lit:api:tags-references", args=(12,))
         c = APIClient()
         assert c.login(email="pm@hawcproject.org", password="pw") is True
+
+        # base report; reference metadata plus columns for each tag
         resp = c.get(url).json()
         assert len(resp) == 2
+        assert len(resp[0]) > 20
         assert resp[0]["Inclusion"] is True
 
-    def test_references_table_builder(self):
-        # ensure we get the expected return
-        url = reverse("lit:api:tags-references-table-builder", args=(12,))
-        c = APIClient()
-        assert c.login(email="pm@hawcproject.org", password="pw") is True
-        resp = c.get(url).json()
+        # table builder format
+        resp = c.get(url, {"exporter": "table-builder"}).json()
         assert len(resp) == 2
+        assert len(resp[0]) == 5
         assert resp[0]["Name"] == "Kawana N, Ishimatsu S, and Kanda K 2001"
+
+        # invalid exporter format
+        resp = c.get(url, {"exporter": "not-a-format"})
+        assert resp.status_code == 400
+        assert resp.json() == {"exporter": ['"not-a-format" is not a valid choice.']}
 
 
 @pytest.mark.vcr


### PR DESCRIPTION
Fix a regression where literature report downloads only included current tag, and not child tags. 

This PR changes the default behavior of GET `/lit/api/tags/:id/references/` to include nested tags.

We also add a few options to this API endpoint:

- nested: {t or f} - if t (default), will include descendants
- exporter: {base or table-builder} - which export format to use

With this change, we removed the GET `/lit/api/tags/:id/references-table-builder/` and allow this as a different export format.
