### PR TITLE
Customizable reference ordering

### DIFF
--- a/frontend/lit/Reference.js
+++ b/frontend/lit/Reference.js
@@ -2,6 +2,8 @@ import _ from "lodash";
 
 import Hero from "shared/utils/Hero";
 
+import {sortReferences} from "./constants";
+
 class Reference {
     constructor(data, tagtree) {
         this.data = data;
@@ -22,10 +24,8 @@ class Reference {
     }
 
     static sortedArray(data, tagtree) {
-        return _.chain(data)
-            .map(d => new Reference(d, tagtree))
-            .orderBy([d => d.data.year, d => d.data.authors_short], ["desc", "asc"])
-            .value();
+        const refs = _.map(data, d => new Reference(d, tagtree));
+        return sortReferences(refs);
     }
 
     get_edit_url() {

--- a/frontend/lit/ReferenceSearch/Main.js
+++ b/frontend/lit/ReferenceSearch/Main.js
@@ -7,13 +7,28 @@ import Alert from "shared/components/Alert";
 import Loading from "shared/components/Loading";
 import ReferenceTable from "../components/ReferenceTable";
 import SearchForm from "./SearchForm";
+import ReferenceSortSelector from "../components/ReferenceSortSelector";
 
 @inject("store")
 @observer
 class ReferenceSearchMain extends Component {
     render() {
         const {store} = this.props,
-            {isSearching, searchError, references, hasReferences, numReferences} = store;
+            {
+                isSearching,
+                searchError,
+                references,
+                sortReferences,
+                hasReferences,
+                numReferences,
+            } = store,
+            nRefText =
+                numReferences === store.MAX_REFERENCES ? (
+                    <b>Showing the first {numReferences} references.</b>
+                ) : (
+                    <b>{numReferences} references found.</b>
+                );
+
         return (
             <div className="container-fluid">
                 <div className="card">
@@ -41,15 +56,10 @@ class ReferenceSearchMain extends Component {
                         />
                     ) : null}
                     {numReferences > 0 ? (
-                        numReferences === store.MAX_REFERENCES ? (
-                            <p>
-                                <b>Showing the first {numReferences} references.</b>
-                            </p>
-                        ) : (
-                            <p>
-                                <b>{numReferences} references found.</b>
-                            </p>
-                        )
+                        <>
+                            <ReferenceSortSelector onChange={sortReferences} />
+                            <p>{nRefText}</p>
+                        </>
                     ) : null}
                     {hasReferences && numReferences > 0 ? (
                         <ReferenceTable references={toJS(references)} showActions={false} />

--- a/frontend/lit/ReferenceSearch/SearchForm.js
+++ b/frontend/lit/ReferenceSearch/SearchForm.js
@@ -26,15 +26,12 @@ class SearchForm extends Component {
                         />
                     </div>
                     <div className="form-group col-lg-3">
-                        <IntegerInput
-                            minimum={1}
+                        <TextInput
                             name="id_db"
                             label="External identifier"
-                            helpText="Pubmed ID, HERO ID, etc."
+                            helpText="Pubmed ID, DOI, HERO ID, etc."
                             value={searchForm.db_id}
-                            onChange={e =>
-                                changeSearchTerm("db_id", parseInt(e.target.value) || "")
-                            }
+                            onChange={e => changeSearchTerm("db_id", e.target.value)}
                         />
                     </div>
                     <div className="form-group col-lg-3">

--- a/frontend/lit/ReferenceSearch/store.js
+++ b/frontend/lit/ReferenceSearch/store.js
@@ -4,6 +4,7 @@ import {action, computed, toJS, observable} from "mobx";
 import h from "shared/utils/helpers";
 import Reference from "../Reference";
 import TagTree from "../TagTree";
+import {sortReferences} from "../constants";
 
 class Store {
     config = null;
@@ -65,6 +66,10 @@ class Store {
             tags: [],
         };
         this.references = null;
+    }
+
+    @action.bound sortReferences(sortBy) {
+        this.references = sortReferences(this.references, sortBy);
     }
 
     @computed get hasReferences() {

--- a/frontend/lit/ReferenceTreeBrowse/Main.js
+++ b/frontend/lit/ReferenceTreeBrowse/Main.js
@@ -6,6 +6,7 @@ import {toJS} from "mobx";
 
 import Loading from "shared/components/Loading";
 import TextInput from "shared/components/TextInput";
+import ReferenceSortSelector from "../components/ReferenceSortSelector";
 import TagTree from "../components/TagTree";
 import YearHistogram from "./YearHistogram";
 import ReferenceTableMain from "./ReferenceTableMain";
@@ -91,6 +92,7 @@ class ReferenceTreeMain extends Component {
                                 yearFilter={store.yearFilter}
                                 onFilter={store.updateYearFilter}
                             />
+                            <ReferenceSortSelector onChange={store.sortReferences} />
                             <QuickSearch
                                 updateQuickFilter={text => store.changeQuickFilterText(text)}
                             />

--- a/frontend/lit/ReferenceTreeBrowse/store.js
+++ b/frontend/lit/ReferenceTreeBrowse/store.js
@@ -5,6 +5,7 @@ import h from "shared/utils/helpers";
 
 import Reference from "../Reference";
 import TagTree from "../TagTree";
+import {sortReferences} from "../constants";
 
 class Store {
     constructor(config) {
@@ -89,6 +90,10 @@ class Store {
             refs = refs.filter(d => d.data.year >= filter.min && d.data.year <= filter.max);
         }
         return refs;
+    }
+
+    @action.bound sortReferences(sortBy) {
+        this.selectedReferences = sortReferences(this.selectedReferences, sortBy);
     }
 
     // year filter

--- a/frontend/lit/components/ReferenceSortSelector.js
+++ b/frontend/lit/components/ReferenceSortSelector.js
@@ -1,0 +1,55 @@
+import _ from "lodash";
+import React, {Component} from "react";
+import PropTypes from "prop-types";
+import {observer} from "mobx-react";
+import SelectInput from "shared/components/SelectInput";
+
+import {ReferenceStorageKey, SortBy} from "../constants";
+
+@observer
+class ReferenceSortSelector extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: window.localStorage.getItem(ReferenceStorageKey) || SortBy.YEAR_DESC[0],
+        };
+    }
+    render() {
+        const choices = _.map(SortBy, (v, k) => {
+            return {id: v[0], label: v[1]};
+        });
+        return (
+            <div className="dropdown float-right">
+                <button
+                    className="btn btn-sm btn-light"
+                    title="Reference ordering"
+                    type="button"
+                    data-toggle="dropdown"
+                    aria-haspopup="true"
+                    aria-expanded="false">
+                    <i className="fa fa-fw fa-sort"></i>
+                </button>
+                <form className="dropdown-menu dropdown-menu-right p-3">
+                    <div className="form-group">
+                        <SelectInput
+                            name="sortReferencesBy"
+                            label="Ordering"
+                            value={this.state.value}
+                            choices={choices}
+                            handleSelect={value => {
+                                window.localStorage.setItem(ReferenceStorageKey, value);
+                                this.setState({value});
+                                this.props.onChange(value);
+                            }}
+                        />
+                    </div>
+                </form>
+            </div>
+        );
+    }
+}
+ReferenceSortSelector.propTypes = {
+    onChange: PropTypes.func.isRequired,
+};
+
+export default ReferenceSortSelector;

--- a/frontend/lit/constants.js
+++ b/frontend/lit/constants.js
@@ -1,0 +1,35 @@
+import _ from "lodash";
+
+export const ReferenceStorageKey = "sortReferencesBy",
+    SortBy = {
+        // {value, label, sort method}
+        AUTH_ASC: [
+            "AUTH_ASC",
+            "author ↑",
+            [d => d.data.authors_short, d => d.data.year],
+            ["asc", "asc"],
+        ],
+        AUTH_DESC: [
+            "AUTH_DESC",
+            "author ↓",
+            [d => d.data.authors_short, d => d.data.year],
+            ["desc", "asc"],
+        ],
+        YEAR_ASC: [
+            "YEAR_ASC",
+            "year ↑",
+            [d => d.data.year, d => d.data.authors_short],
+            ["asc", "asc"],
+        ],
+        YEAR_DESC: [
+            "YEAR_DESC",
+            "year ↓",
+            [d => d.data.year, d => d.data.authors_short],
+            ["desc", "asc"],
+        ],
+    },
+    sortReferences = function(refs, sortByKey) {
+        const key =
+            sortByKey || window.localStorage.getItem(ReferenceStorageKey) || SortBy.YEAR_DESC[0];
+        return _.orderBy(refs, SortBy[key][2], SortBy[key][3]);
+    };

--- a/hawc/apps/lit/serializers.py
+++ b/hawc/apps/lit/serializers.py
@@ -99,7 +99,7 @@ class IdentifiersSerializer(serializers.ModelSerializer):
 
 class ReferenceQuerySerializer(serializers.Serializer):
     id = serializers.IntegerField(required=False, allow_null=True)
-    db_id = serializers.IntegerField(required=False, allow_null=True)
+    db_id = serializers.CharField(required=False, allow_blank=True)
     year = serializers.IntegerField(required=False, allow_null=True)
     title = serializers.CharField(required=False, allow_blank=True)
     authors = serializers.CharField(required=False, allow_blank=True)
@@ -127,8 +127,8 @@ class ReferenceQuerySerializer(serializers.Serializer):
         query = Q()
         if "id" in self.data and self.data["id"] is not None:
             query &= Q(id=self.data["id"])
-        if "db_id" in self.data and self.data["db_id"] is not None:
-            query &= Q(identifiers__unique_id=self.data["db_id"])
+        if db_id := self.data.get("db_id", ""):
+            query &= Q(identifiers__unique_id__icontains=db_id)
         if "year" in self.data and self.data["year"] is not None:
             query &= Q(year=self.data["year"])
         if "title" in self.data:


### PR DESCRIPTION
Make reference ordering persistent and customizable on literature views:
<img width="861" alt="Screen Shot 2022-01-11 at 3 36 58 PM" src="https://user-images.githubusercontent.com/999952/149017659-6e03c110-aa8d-4560-ad1b-c348f5618a0c.png">

Currently applied to two views:

1. lit overview: `/lit/assessment/:id/references/`
2. lit search: `/lit/assessment/:id/search/`

Currently four different orderings:

 1. author ↑:  author alphabetical ascending, year ascending
 2. author ↓:  author alphabetical descending, year ascending
 3. year ↑: year ascending, author alphabetical ascending
 4. year  ↓: year descending, author alphabetical ascending

The sort orders are persistent are applied in all locations, including literature tagging.