### PR TITLE
add notification error for 500 error on data cleanup

### DIFF
--- a/frontend/shared/textCleanup/GroupedObjectList.js
+++ b/frontend/shared/textCleanup/GroupedObjectList.js
@@ -14,11 +14,18 @@ class GroupedObjectList extends Component {
         return (
             <div className="container-fluid">
                 {store.hasTermMapping ? (
-                    <div className="row">
+                    <div className="row-fluid">
                         <p className="alert alert-info">
                             <i className="fa fa-exclamation-triangle"></i> Controlled vocabulary may
                             exist for this assessment. This list is filtered to only display terms
                             which are not being used with controlled vocabulary.
+                        </p>
+                    </div>
+                ) : null}
+                {store.bulkUpdateError ? (
+                    <div className="row-fluid">
+                        <p className="alert alert-danger">
+                            <i className="fa fa-exclamation-triangle"></i> {store.bulkUpdateError}
                         </p>
                     </div>
                 ) : null}

--- a/frontend/shared/textCleanup/stores.js
+++ b/frontend/shared/textCleanup/stores.js
@@ -11,6 +11,7 @@ class TextCleanupStore {
     @observable termFieldMapping = null;
     @observable selectedField = null;
 
+    @observable bulkUpdateError = null;
     @observable isLoadingObjects = false;
     @observable objects = null;
 
@@ -76,8 +77,13 @@ class TextCleanupStore {
         fetch(url, opts)
             .then(response => {
                 if (response.ok) {
+                    this.bulkUpdateError = null;
                     groupStore.reset();
                     this.updateObjects(ids, payload);
+                } else {
+                    response.json().then(d => {
+                        this.bulkUpdateError = d.detail;
+                    });
                 }
             })
             .catch(ex => console.error("Patch failed", ex));

--- a/hawc/apps/common/api/mixins.py
+++ b/hawc/apps/common/api/mixins.py
@@ -55,10 +55,7 @@ class ListUpdateModelMixin:
             self.pre_save_bulk(queryset, update_bulk_dict)
             try:
                 queryset.update(**update_bulk_dict)
-            except ValueError as e:
-                errors = {"detail": force_str(e)}
-                return Response(errors, status=status.HTTP_400_BAD_REQUEST)
-            except DataError as e:
+            except (DataError, ValueError) as e:
                 errors = {"detail": force_str(e)}
                 return Response(errors, status=status.HTTP_400_BAD_REQUEST)
             self.post_save_bulk(queryset, update_bulk_dict)

--- a/hawc/apps/common/api/mixins.py
+++ b/hawc/apps/common/api/mixins.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.db import DataError
 from django.shortcuts import get_object_or_404
 from django.utils.encoding import force_str
 from rest_framework import status
@@ -55,6 +56,9 @@ class ListUpdateModelMixin:
             try:
                 queryset.update(**update_bulk_dict)
             except ValueError as e:
+                errors = {"detail": force_str(e)}
+                return Response(errors, status=status.HTTP_400_BAD_REQUEST)
+            except DataError as e:
                 errors = {"detail": force_str(e)}
                 return Response(errors, status=status.HTTP_400_BAD_REQUEST)
             self.post_save_bulk(queryset, update_bulk_dict)

--- a/hawc/apps/common/api/viewsets.py
+++ b/hawc/apps/common/api/viewsets.py
@@ -37,6 +37,7 @@ class CleanupFieldsBaseViewSet(
     def get_queryset(self):
         return self.model.objects.all()
 
+    # should we catch the error here?
     @action(detail=False, methods=["get"])
     def fields(self, request, format=None):
         """

--- a/hawc/apps/common/api/viewsets.py
+++ b/hawc/apps/common/api/viewsets.py
@@ -37,7 +37,6 @@ class CleanupFieldsBaseViewSet(
     def get_queryset(self):
         return self.model.objects.all()
 
-    # should we catch the error here?
     @action(detail=False, methods=["get"])
     def fields(self, request, format=None):
         """

--- a/tests/hawc/apps/common/test_api.py
+++ b/tests/hawc/apps/common/test_api.py
@@ -126,6 +126,17 @@ class TestCleanupFieldsBaseViewSet:
         assert resp.status_code == 403
         assert Study.objects.get(id=study_id).short_citation != new_short_citation
 
+        # check too long
+        study_id = db_keys.study_working
+        resp = client.patch(
+            url + f"?assessment_id={db_keys.assessment_working}&ids={study_id}",
+            json.dumps({"short_citation": "a" * 500}),
+            content_type="application/json",
+            **{"HTTP_X_CUSTOM_BULK_OPERATION": "true"},
+        )
+        assert resp.status_code == 400
+        assert "value too long" in resp.json()["detail"]
+
         # finally, check success
         study_id = db_keys.study_working
         assert Study.objects.get(id=study_id).short_citation != new_short_citation


### PR DESCRIPTION
Add an error modal on the data cleanup page if an error occurs:

<img width="609" alt="Screen Shot 2022-01-20 at 12 15 34 PM" src="https://user-images.githubusercontent.com/999952/150388683-4cc418a4-6305-4b01-b788-3b686db6da06.png">



To test the user interface,  I put a really long string into the study short citation on this page using the text fixture: http://127.0.0.1:8000/assessment/1/clean-extracted-data/#