### PR TITLE
Update 500 error page

### DIFF
--- a/hawc/templates/500.html
+++ b/hawc/templates/500.html
@@ -1,10 +1,38 @@
-{% extends "crumbless.html" %}
+<!DOCTYPE html>
+<html class="js" lang="en-us">
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="NONE,NOARCHIVE" />
+    <title>Server Error - HAWC</title>
 
-{% block title %}500 | HAWC{% endblock %}
-
-{% block content %}
-  <div class="jumbotron">
-    <h1>Error 500.</h1>
-    <p>Ohh goodness, something went wrong on HAWC server-side. An administrator has already been emailed what went wrong, but please <a href="{% url 'contact' %}">contact us</a> if urgent.</p>
-  </div>
-{% endblock content %}
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+  
+  </head>
+  <body class="html">
+    <nav class="navbar navbar-expand-sm bg-light">
+      <a class="ml-3 navbar-brand" href="{% url 'home' %}"><img alt="The website logo" src="/static/img/HAWC-40.png"></a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <ul class="nav navbar-nav collapse navbar-collapse justify-content-end" id="navbarSupportedContent">
+        <li class="nav-item">
+          <a class="nav-link" href="{% url 'contact' %}">Contact Us</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{% url 'about' %}">About</a>
+        </li>
+      </ul>
+    </nav>
+    <div class="container">
+      <div class="jumbotron">
+        <h1>Error 500.</h1>
+        <p>Ohh goodness, something went wrong on HAWC server-side. An administrator has already been emailed what went wrong, but please <a href="{% url 'contact' %}">contact us</a> if urgent.</p>
+      </div>
+    </div>
+    
+    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+  </body>
+</html>

--- a/hawc/templates/500.html
+++ b/hawc/templates/500.html
@@ -17,7 +17,7 @@
   </head>
   <body class="html">
     <nav class="navbar navbar-expand-sm navbar-light bg-light">
-      <a class="ml-3 navbar-brand" href="{% url 'home' %}"><img alt="The website logo" src="{% static 'img/HAWC-40.png' %}"></a>
+      <a class="ml-3 navbar-brand" href="{% url 'home' %}"><img alt="The website logo" src="/static/img/HAWC-40.png"></a>
       <ul class="navbar-nav navbar-collapse justify-content-end">
         <li class="nav-item">
           <a class="nav-link" href="{% url 'contact' %}">Contact Us</a>
@@ -31,23 +31,12 @@
       <div class="row">
         <div class="col-8 offset-2">
           <div class="jumbotron mt-5">
-            <div id="observablehq-graphic-24aaae82"></div>
             <h1>Error 500.</h1>
             <p>Ohh goodness, something went wrong on HAWC server-side. An administrator has already been emailed what went wrong, but please <a href="{% url 'contact' %}">contact us</a> if it's urgent.</p>
-            <p class="font-italic">Credit for graphic: <a href="https://observablehq.com/@mbostock/epicyclic-gearing">Epicyclic Gearing by Mike Bostock</a></p>
           </div>
         </div>
       </div>
       </div>
     </div>
-  <script type="module">
-    import { Runtime, Inspector } from "https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js";
-    import define from "https://api.observablehq.com/@munnsmunns/epicyclic-gearing.js?v=3";
-    new Runtime().module(define, name => {
-      if (name === "graphic") return new Inspector(document.querySelector("#observablehq-graphic-24aaae82"));
-      return ["update"].includes(name);
-    });
-  </script>
   </body>
 </html>
-

--- a/hawc/templates/500.html
+++ b/hawc/templates/500.html
@@ -1,4 +1,5 @@
 {% load static %}
+
 <!DOCTYPE html>
 <html class="js" lang="en-us">
   <head>
@@ -7,25 +8,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="NONE,NOARCHIVE" />
     <title>500 | HAWC</title>
-
     <link id="favicon" href="{% static 'img/favicon-256.png' %}" rel="shortcut icon" sizes="256x256" />
     <link id="favicon" href="{% static 'img/favicon-128.png' %}" rel="shortcut icon" sizes="128x128" />
     <link id="favicon" href="{% static 'img/favicon-64.png' %}" rel="shortcut icon" sizes="64x64" />
     <link id="favicon" href="{% static 'img/favicon-32.png' %}" rel="shortcut icon" sizes="32x32" />
-    <link rel="stylesheet" type="text/css" href="{% static 'vendor/font-awesome/4.7.0/css/font-awesome.min.css' %}" />
     <link rel="stylesheet" type="text/css" href="{% static 'vendor/bootstrap/4.5.3/css/bootstrap.min.css' %}" />
-    <link rel="stylesheet" type="text/css" href="{% static 'vendor/jqueryui/1.10.3/css/jquery-ui.min.css' %}" />
     <link rel="stylesheet" type="text/css" href="{% static 'css/hawc.css' %}" />
-    <link rel="stylesheet" type="text/css" href="{% static 'css/d3.css' %}" />
-
   </head>
   <body class="html">
-    <nav class="navbar navbar-expand-sm bg-light">
+    <nav class="navbar navbar-expand-sm navbar-light bg-light">
       <a class="ml-3 navbar-brand" href="{% url 'home' %}"><img alt="The website logo" src="/static/img/HAWC-40.png"></a>
-      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <ul class="nav navbar-nav collapse navbar-collapse justify-content-end" id="navbarSupportedContent">
+      <ul class="navbar-nav navbar-collapse justify-content-end">
         <li class="nav-item">
           <a class="nav-link" href="{% url 'contact' %}">Contact Us</a>
         </li>
@@ -34,17 +27,16 @@
         </li>
       </ul>
     </nav>
-    <div class="container">
-      <div class="jumbotron">
-        <h1>Error 500.</h1>
-        <p>Ohh goodness, something went wrong on HAWC server-side. An administrator has already been emailed what went wrong, but please <a href="{% url 'contact' %}">contact us</a> if urgent.</p>
+    <div class="container-fluid">
+      <div class="row">
+        <div class="col-8 offset-2">
+          <div class="jumbotron mt-5">
+            <h1>Error 500.</h1>
+            <p>Ohh goodness, something went wrong on HAWC server-side. An administrator has already been emailed what went wrong, but please <a href="{% url 'contact' %}">contact us</a> if it's urgent.</p>
+          </div>
+        </div>
+      </div>
       </div>
     </div>
-
-    <script type="text/javascript" src="{% static 'vendor/jquery/3.5.1/jquery.min.js' %}"></script>
-    <script type="text/javascript" src="{% static 'vendor/jquery-migrate/3.3.1/jquery-migrate.min.js' %}"></script>
-    <script type="text/javascript" src="{% static 'vendor/popper.js/1.16.1/umd/popper.min.js' %}"></script>
-    <script type="text/javascript" src="{% static 'vendor/bootstrap/4.5.3/js/bootstrap.min.js' %}"></script>
-    <script type="text/javascript" src="{% static 'vendor/jqueryui/1.10.3/jquery-ui.min.js' %}"></script>
   </body>
 </html>

--- a/hawc/templates/500.html
+++ b/hawc/templates/500.html
@@ -1,3 +1,4 @@
+{% load static %}
 <!DOCTYPE html>
 <html class="js" lang="en-us">
   <head>
@@ -5,10 +6,18 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="NONE,NOARCHIVE" />
-    <title>Server Error - HAWC</title>
+    <title>500 | HAWC</title>
 
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
-  
+    <link id="favicon" href="{% static 'img/favicon-256.png' %}" rel="shortcut icon" sizes="256x256" />
+    <link id="favicon" href="{% static 'img/favicon-128.png' %}" rel="shortcut icon" sizes="128x128" />
+    <link id="favicon" href="{% static 'img/favicon-64.png' %}" rel="shortcut icon" sizes="64x64" />
+    <link id="favicon" href="{% static 'img/favicon-32.png' %}" rel="shortcut icon" sizes="32x32" />
+    <link rel="stylesheet" type="text/css" href="{% static 'vendor/font-awesome/4.7.0/css/font-awesome.min.css' %}" />
+    <link rel="stylesheet" type="text/css" href="{% static 'vendor/bootstrap/4.5.3/css/bootstrap.min.css' %}" />
+    <link rel="stylesheet" type="text/css" href="{% static 'vendor/jqueryui/1.10.3/css/jquery-ui.min.css' %}" />
+    <link rel="stylesheet" type="text/css" href="{% static 'css/hawc.css' %}" />
+    <link rel="stylesheet" type="text/css" href="{% static 'css/d3.css' %}" />
+
   </head>
   <body class="html">
     <nav class="navbar navbar-expand-sm bg-light">
@@ -31,8 +40,11 @@
         <p>Ohh goodness, something went wrong on HAWC server-side. An administrator has already been emailed what went wrong, but please <a href="{% url 'contact' %}">contact us</a> if urgent.</p>
       </div>
     </div>
-    
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+
+    <script type="text/javascript" src="{% static 'vendor/jquery/3.5.1/jquery.min.js' %}"></script>
+    <script type="text/javascript" src="{% static 'vendor/jquery-migrate/3.3.1/jquery-migrate.min.js' %}"></script>
+    <script type="text/javascript" src="{% static 'vendor/popper.js/1.16.1/umd/popper.min.js' %}"></script>
+    <script type="text/javascript" src="{% static 'vendor/bootstrap/4.5.3/js/bootstrap.min.js' %}"></script>
+    <script type="text/javascript" src="{% static 'vendor/jqueryui/1.10.3/jquery-ui.min.js' %}"></script>
   </body>
 </html>

--- a/hawc/templates/500.html
+++ b/hawc/templates/500.html
@@ -17,7 +17,7 @@
   </head>
   <body class="html">
     <nav class="navbar navbar-expand-sm navbar-light bg-light">
-      <a class="ml-3 navbar-brand" href="{% url 'home' %}"><img alt="The website logo" src="/static/img/HAWC-40.png"></a>
+      <a class="ml-3 navbar-brand" href="{% url 'home' %}"><img alt="The website logo" src="{% static 'img/HAWC-40.png' %}"></a>
       <ul class="navbar-nav navbar-collapse justify-content-end">
         <li class="nav-item">
           <a class="nav-link" href="{% url 'contact' %}">Contact Us</a>
@@ -31,12 +31,23 @@
       <div class="row">
         <div class="col-8 offset-2">
           <div class="jumbotron mt-5">
+            <div id="observablehq-graphic-24aaae82"></div>
             <h1>Error 500.</h1>
             <p>Ohh goodness, something went wrong on HAWC server-side. An administrator has already been emailed what went wrong, but please <a href="{% url 'contact' %}">contact us</a> if it's urgent.</p>
+            <p class="font-italic">Credit for graphic: <a href="https://observablehq.com/@mbostock/epicyclic-gearing">Epicyclic Gearing by Mike Bostock</a></p>
           </div>
         </div>
       </div>
       </div>
     </div>
+  <script type="module">
+    import { Runtime, Inspector } from "https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js";
+    import define from "https://api.observablehq.com/@munnsmunns/epicyclic-gearing.js?v=3";
+    new Runtime().module(define, name => {
+      if (name === "graphic") return new Inspector(document.querySelector("#observablehq-graphic-24aaae82"));
+      return ["update"].includes(name);
+    });
+  </script>
   </body>
 </html>
+


### PR DESCRIPTION
The previous 500 error page displayed improperly when a error occurs because no context is passed, causing layout errors:

> The default 500 view passes no variables to the 500.html template and is rendered with an empty Context to lessen the chance of additional errors.

https://docs.djangoproject.com/en/3.2/ref/views/#the-500-server-error-view

500 error page no longer inherits the base.html template. Now it is a simple page with the Error message and links to Home, About, and Contact Us

<img width="605" alt="Screen Shot 2022-02-08 at 12 56 20 PM" src="https://user-images.githubusercontent.com/999952/153047245-54e17849-bed4-44c4-8206-67d5e105ad7f.png">

Note that this view doesn't attempt to apply any specific "HAWC flavor" or skin on the page, since they require context variables. An alternative approach may have been to override the 500 response handler to pass in those settings, but since this page isn't not hopefully ever viewed, but it goes against the philosophy of keeping things simple on the server side.
