### PR TITLE
Fix: Include missing endpoints in generated OpenAPI schema

### DIFF
--- a/hawc/main/openapi.py
+++ b/hawc/main/openapi.py
@@ -1,0 +1,64 @@
+import warnings
+from urllib.parse import urljoin
+
+from rest_framework.schemas.openapi import SchemaGenerator
+
+
+class OpenAPIGenerator(SchemaGenerator):
+    """
+    This subclass removes permission checks during endpoint determination, since we want all endpoints to be shown and some permission checks will fail without additional query params (AssessmentLevelPermissions)
+    """
+
+    def get_schema(self, request=None, public=False):
+        """
+        Generate a OpenAPI schema.
+        """
+        self._initialise_endpoints()
+        components_schemas = {}
+
+        # Iterate endpoints generating per method path operations.
+        paths = {}
+        _, view_endpoints = self._get_paths_and_endpoints(None if public else request)
+        for path, method, view in view_endpoints:
+
+            """
+            Permission checks are removed here:
+
+            if not self.has_view_permissions(path, method, view):
+                continue
+            """
+
+            operation = view.schema.get_operation(path, method)
+            components = view.schema.get_components(path, method)
+            for k in components.keys():
+                if k not in components_schemas:
+                    continue
+                if components_schemas[k] == components[k]:
+                    continue
+                warnings.warn(
+                    'Schema component "{}" has been overriden with a different value.'.format(k)
+                )
+
+            components_schemas.update(components)
+
+            # Normalise path for any provided mount url.
+            if path.startswith("/"):
+                path = path[1:]
+            path = urljoin(self.url or "/", path)
+
+            paths.setdefault(path, {})
+            paths[path][method.lower()] = operation
+
+        self.check_duplicate_operation_id(paths)
+
+        # Compile final schema.
+        schema = {
+            "openapi": "3.0.2",
+            "info": self.get_info(),
+            "paths": paths,
+        }
+
+        if len(components_schemas) > 0:
+            schema["components"] = {"schemas": components_schemas}
+
+        return schema

--- a/hawc/main/urls.py
+++ b/hawc/main/urls.py
@@ -16,8 +16,11 @@ import hawc.apps.mgmt.urls
 import hawc.apps.riskofbias.urls
 import hawc.apps.study.urls
 import hawc.apps.summary.urls
+import hawc.apps.vocab.urls
 from hawc import __version__
 from hawc.apps.assessment import views
+
+from .openapi import OpenAPIGenerator
 
 open_api_patterns = [
     path("ani/api/", include(hawc.apps.animal.urls.router.urls)),
@@ -31,6 +34,7 @@ open_api_patterns = [
     path("rob/api/", include(hawc.apps.riskofbias.urls.router.urls)),
     path("study/api/", include(hawc.apps.study.urls.router.urls)),
     path("summary/api/", include(hawc.apps.summary.urls.router.urls)),
+    path("vocab/api", include(hawc.apps.vocab.urls.router.urls)),
 ]
 
 urlpatterns = [
@@ -78,6 +82,7 @@ if settings.INCLUDE_ADMIN:
                 version=__version__,
                 patterns=open_api_patterns,
                 permission_classes=(permissions.IsAdminUser,),
+                generator_class=OpenAPIGenerator,
             ),
             name="openapi",
         ),


### PR DESCRIPTION
Some endpoints were being left out of the OpenAPI schema, namely those using `AssessmentLevelPermissions` where it was expecting an `assessment_id` query param to be passed through. This PR includes a subclass of the default OpenAPI generator that ignores permission checks during endpoint determination, which allows for it to capture all endpoints.