### PR TITLE
allow duplicate IDs when importing HERO references

### DIFF
--- a/hawc/apps/lit/forms.py
+++ b/hawc/apps/lit/forms.py
@@ -140,7 +140,7 @@ class ImportForm(SearchForm):
             )
 
         if len(ids) == 0 or any([el < 0 for el in ids]):
-            raise forms.ValidationError("At least one positive identifer must exist")
+            raise forms.ValidationError("At least one positive identifier must exist")
 
         return ids
 

--- a/hawc/apps/lit/forms.py
+++ b/hawc/apps/lit/forms.py
@@ -132,16 +132,15 @@ class ImportForm(SearchForm):
     @classmethod
     def validate_import_search_string(cls, search_string) -> List[int]:
         try:
-            ids = [int(el) for el in search_string.split(",")]
+            # convert to a set, then a list to remove duplicate ids
+            ids = list(set(int(el) for el in search_string.split(",")))
         except ValueError:
             raise forms.ValidationError(
                 "Must be a comma-separated list of positive integer identifiers"
             )
 
-        if len(ids) == 0 or len(ids) != len(set(ids)) or any([el < 0 for el in ids]):
-            raise forms.ValidationError(
-                "At least one positive identifer must exist and must be unique"
-            )
+        if len(ids) == 0 or any([el < 0 for el in ids]):
+            raise forms.ValidationError("At least one positive identifer must exist")
 
         return ids
 

--- a/hawc/apps/lit/managers.py
+++ b/hawc/apps/lit/managers.py
@@ -243,7 +243,7 @@ class ReferenceManager(BaseManager):
 
     def build_ref_ident_m2m(self, objs):
         # Bulk-create reference-search relationships
-        logger.debug("Starting bulk creation of reference-identifer values")
+        logger.debug("Starting bulk creation of reference-identifier values")
         m2m = self.model.identifiers.through
         objects = [m2m(reference_id=ref_id, identifiers_id=ident_id) for ref_id, ident_id in objs]
         m2m.objects.bulk_create(objects)

--- a/hawc/apps/lit/models.py
+++ b/hawc/apps/lit/models.py
@@ -284,7 +284,8 @@ class Search(models.Model):
 
     @property
     def import_ids(self):
-        return [v.strip() for v in self.search_string_text.split(",")]
+        # convert from string->set->list to remove repeat ids
+        return list(set(v.strip() for v in self.search_string_text.split(",")))
 
     @transaction.atomic
     def run_new_import(self):

--- a/hawc/apps/lit/serializers.py
+++ b/hawc/apps/lit/serializers.py
@@ -449,7 +449,7 @@ class ReferenceReplaceHeroIdSerializer(serializers.Serializer):
 
     def execute(self) -> ResultBase:
 
-        # import missing identifers
+        # import missing identifiers
         models.Identifiers.objects.bulk_create_hero_ids(self.fetched_content)
 
         # set hero ref

--- a/hawc/services/epa/dsstox.py
+++ b/hawc/services/epa/dsstox.py
@@ -19,7 +19,7 @@ class DssSubstance(NamedTuple):
         """Fetch a DssTox instance from the actor webservices using a DTXSID.
 
         Args:
-            dtxsid (str): a DTXSID identifer
+            dtxsid (str): a DTXSID identifier
 
         Raises:
             ValueError: if object could not be created

--- a/tests/hawc/apps/lit/test_api.py
+++ b/tests/hawc/apps/lit/test_api.py
@@ -321,12 +321,8 @@ class TestSearchViewset:
         assert resp.status_code == 201
 
         # search string with duplicates
-        new_payload = {
-            **payload,
-            **{"search_string": "5490558, 5490558"},
-            **{"title": "second demo"},
-        }
-        resp = c.post(url, new_payload, format="json")
+        payload.update(search_string="5490558, 5490558", title="second demo")
+        resp = c.post(url, payload, format="json")
         assert resp.status_code == 201
 
     def test_validation_failures(self, db_keys):
@@ -403,7 +399,9 @@ class TestSearchViewset:
             new_payload = {**payload, **{"search_string": bad_search_string}}
             resp = c.post(url, new_payload, format="json")
             assert resp.status_code == 400
-            assert resp.data == {"non_field_errors": ["At least one positive identifer must exist"]}
+            assert resp.data == {
+                "non_field_errors": ["At least one positive identifier must exist"]
+            }
 
     def test_missing_id_in_hero(self, db_keys):
         """

--- a/tests/hawc/apps/lit/test_api.py
+++ b/tests/hawc/apps/lit/test_api.py
@@ -320,6 +320,15 @@ class TestSearchViewset:
         resp = c.post(url, payload, format="json")
         assert resp.status_code == 201
 
+        # search string with duplicates
+        new_payload = {
+            **payload,
+            **{"search_string": "5490558, 5490558"},
+            **{"title": "second demo"},
+        }
+        resp = c.post(url, new_payload, format="json")
+        assert resp.status_code == 201
+
     def test_validation_failures(self, db_keys):
         url = reverse("lit:api:search-list")
         c = APIClient()
@@ -389,16 +398,12 @@ class TestSearchViewset:
             }
 
         # check bad id lists
-        bad_search_strings = ["-1", "123,123"]
+        bad_search_strings = ["-1"]
         for bad_search_string in bad_search_strings:
             new_payload = {**payload, **{"search_string": bad_search_string}}
             resp = c.post(url, new_payload, format="json")
             assert resp.status_code == 400
-            assert resp.data == {
-                "non_field_errors": [
-                    "At least one positive identifer must exist and must be unique"
-                ]
-            }
+            assert resp.data == {"non_field_errors": ["At least one positive identifer must exist"]}
 
     def test_missing_id_in_hero(self, db_keys):
         """

--- a/tests/hawc/apps/lit/test_forms.py
+++ b/tests/hawc/apps/lit/test_forms.py
@@ -110,7 +110,7 @@ class TestImportForm:
             new_payload = {**payload, **{"search_string": bad_search_string}}
             form = ImportForm(new_payload, parent=parent)
             assert not form.is_valid()
-            assert form.errors == {"search_string": ["At least one positive identifer must exist"]}
+            assert form.errors == {"search_string": ["At least one positive identifier must exist"]}
 
     def test_missing_id_in_hero(self, db_keys):
         """

--- a/tests/hawc/apps/lit/test_forms.py
+++ b/tests/hawc/apps/lit/test_forms.py
@@ -62,7 +62,7 @@ class TestImportForm:
                 "title": "demo title",
                 "slug": "demo-title",
                 "description": "",
-                "search_string": "5490558",
+                "search_string": "5490558, 5490558",
             },
             parent=Assessment.objects.get(id=db_keys.assessment_working),
         )
@@ -105,15 +105,12 @@ class TestImportForm:
         # check bad id lists
         bad_search_strings = [
             "-1",
-            "1,1",
         ]
         for bad_search_string in bad_search_strings:
             new_payload = {**payload, **{"search_string": bad_search_string}}
             form = ImportForm(new_payload, parent=parent)
             assert not form.is_valid()
-            assert form.errors == {
-                "search_string": ["At least one positive identifer must exist and must be unique"]
-            }
+            assert form.errors == {"search_string": ["At least one positive identifer must exist"]}
 
     def test_missing_id_in_hero(self, db_keys):
         """


### PR DESCRIPTION
Previously, attempting to import a list of HERO ids would create a server error if any duplicates were contained in the list. Now, duplicates are automatically removed from the list when validating the string