### PR TITLE
allow duplicate rows when bulk data tagging

### DIFF
--- a/hawc/apps/lit/serializers.py
+++ b/hawc/apps/lit/serializers.py
@@ -234,7 +234,7 @@ class BulkReferenceTagSerializer(serializers.Serializer):
 
     def validate_csv(self, value):
         try:
-            df = pd.read_csv(StringIO(value))
+            df = pd.read_csv(StringIO(value)).drop_duplicates()
         except pd.errors.ParserError:
             raise serializers.ValidationError("CSV could not be parsed")
         except pd.errors.EmptyDataError:
@@ -281,10 +281,7 @@ class BulkReferenceTagSerializer(serializers.Serializer):
         if missing:
             raise serializers.ValidationError(f"Reference(s) not found: {missing}")
 
-        # remove duplicate rows
-        df = df.drop_duplicates()
-
-        # success! save dataframe
+        # success! cache dataframe
         self.assessment = self.context["assessment"]
         self.df = df
 

--- a/hawc/apps/lit/serializers.py
+++ b/hawc/apps/lit/serializers.py
@@ -281,13 +281,8 @@ class BulkReferenceTagSerializer(serializers.Serializer):
         if missing:
             raise serializers.ValidationError(f"Reference(s) not found: {missing}")
 
-        # check to make sure we have no duplicates
-        df_nrows = df.shape[0]
+        # remove duplicate rows
         df = df.drop_duplicates()
-        if df.shape[0] != df_nrows:
-            raise serializers.ValidationError(
-                "CSV contained duplicates; please remove before importing"
-            )
 
         # success! save dataframe
         self.assessment = self.context["assessment"]

--- a/tests/hawc/apps/lit/test_serializers.py
+++ b/tests/hawc/apps/lit/test_serializers.py
@@ -94,8 +94,11 @@ def test_BulkReferenceTagSerializer(db_keys):
     # check duplicates
     data = {"operation": "replace", "csv": "reference_id,tag_id\n1,3\n1,3"}
     serializer = BulkReferenceTagSerializer(data=data, context=context)
-    assert serializer.is_valid() is False
-    assert serializer.errors["csv"][0] == "CSV contained duplicates; please remove before importing"
+    assert serializer.is_valid() is True
+    serializer.bulk_create_tags()
+
+    reference.refresh_from_db()
+    assert reference.tags.count() == 1
 
     # check that a 2x2 table works
     csv = "reference_id,tag_id\n1,3\n1,4\n3,3\n3,4\n"

--- a/tests/hawc/apps/lit/test_serializers.py
+++ b/tests/hawc/apps/lit/test_serializers.py
@@ -87,9 +87,10 @@ def test_BulkReferenceTagSerializer(db_keys):
     serializer = BulkReferenceTagSerializer(data=data, context=context)
     assert serializer.is_valid() is True
     serializer.bulk_create_tags()
-    reference.refresh_from_db()
-    assert reference.tags.count() == 1
-    assert reference.tags.all()[0].id == 4
+    resp = ReferenceTags.objects.as_dataframe(db_keys.assessment_working).to_csv(
+        index=False, line_terminator="\n"
+    )
+    assert resp == "reference_id,tag_id\n1,4\n"
 
     # check duplicates
     data = {"operation": "replace", "csv": "reference_id,tag_id\n1,3\n1,3"}
@@ -98,7 +99,10 @@ def test_BulkReferenceTagSerializer(db_keys):
     serializer.bulk_create_tags()
 
     reference.refresh_from_db()
-    assert reference.tags.count() == 1
+    resp = ReferenceTags.objects.as_dataframe(db_keys.assessment_working).to_csv(
+        index=False, line_terminator="\n"
+    )
+    assert resp == "reference_id,tag_id\n1,3\n"
 
     # check that a 2x2 table works
     csv = "reference_id,tag_id\n1,3\n1,4\n3,3\n3,4\n"
@@ -106,12 +110,10 @@ def test_BulkReferenceTagSerializer(db_keys):
     serializer = BulkReferenceTagSerializer(data=data, context=context)
     assert serializer.is_valid() is True
     serializer.bulk_create_tags()
-    assert (
-        ReferenceTags.objects.as_dataframe(db_keys.assessment_working).to_csv(
-            index=False, line_terminator="\n"
-        )
-        == csv
+    resp = ReferenceTags.objects.as_dataframe(db_keys.assessment_working).to_csv(
+        index=False, line_terminator="\n"
     )
+    assert resp == csv
 
 
 @pytest.mark.vcr


### PR DESCRIPTION
When uploading a CSV for bulk data tags, duplicate rows are now deleted instead of raising an error