### PR TITLE
fix display of inactive users; anonymize external_id

### DIFF
--- a/hawc/apps/assessment/templates/assessment/assessment_detail.html
+++ b/hawc/apps/assessment/templates/assessment/assessment_detail.html
@@ -151,7 +151,7 @@
         <td>
           <p><strong>Project manager{{ object.project_manager.all|pluralize }}</strong></p>
           <ul class="mb-0">
-            {% for m in object.project_manager.all %}
+            {% for m in object.project_manager.active %}
               <li>{{ m.get_full_name }}</li>
             {% endfor %}
           </ul>
@@ -159,7 +159,7 @@
         <td>
           <p><strong>Team member{{ object.team_members.all|pluralize }}</strong></p>
           <ul class="mb-0">
-            {% for m in object.team_members.all %}
+            {% for m in object.team_members.active %}
             <li>{{ m.get_full_name }}</li>
             {% empty %}
             <li><i>None assigned</i></li>
@@ -169,7 +169,7 @@
         <td>
           <p><strong>Reviewer{{ object.reviewers.all|pluralize }}</strong></p>
           <ul class="mb-0">
-            {% for m in object.reviewers.all %}
+            {% for m in object.reviewers.active %}
             <li>{{ m.get_full_name }}</li>
             {% empty %}
             <li><i>None assigned</i></li>

--- a/hawc/apps/myuser/lookups.py
+++ b/hawc/apps/myuser/lookups.py
@@ -19,6 +19,9 @@ class HAWCUserLookup(ModelLookup):
         "is_active": True,
     }
 
+    def get_item_value(self, obj):
+        return str(obj) if obj is not None else "&lt;inactive user&gt;"
+
 
 class AssessmentTeamMemberOrHigherLookup(HAWCUserLookup):
     def get_query(self, request, term):

--- a/hawc/apps/myuser/management/commands/scrub_db.py
+++ b/hawc/apps/myuser/management/commands/scrub_db.py
@@ -1,3 +1,4 @@
+from random import randint
 from textwrap import dedent
 
 from django.contrib.auth import get_user_model
@@ -43,6 +44,9 @@ class Command(BaseCommand):
             user.first_name = fake.first_name()
             user.last_name = fake.last_name()
             user.email = f"{user.first_name.lower()}.{user.last_name.lower()}@{fake.domain_name()}"
+            user.external_id = (
+                f"{user.first_name[0].lower()}{user.last_name.lower()}{randint(1,256)}"
+            )
             user.password = hash_password
             user.save()
 
@@ -56,6 +60,7 @@ class Command(BaseCommand):
         superuser.first_name = "Super"
         superuser.last_name = "Duper"
         superuser.email = "webmaster@hawcproject.org"
+        superuser.external_id = "sudo"
         user.password = hash_password
         superuser.save()
 
@@ -64,7 +69,7 @@ class Command(BaseCommand):
             f"""\
         Rewrite complete!
 
-        - All {num_users} users have randomly generated names and email-addresses.
+        - All {num_users} users have randomly generated names and email addresses.
         - All {num_users} users have passwords set to `password`
         - A superuser has the username `webmaster@hawcproject.org`
         - A superuser has the password `password`

--- a/hawc/apps/myuser/managers.py
+++ b/hawc/apps/myuser/managers.py
@@ -56,3 +56,6 @@ class HAWCMgr(BaseUserManager):
         u.is_superuser = True
         u.save()
         return u
+
+    def active(self):
+        return self.filter(is_active=True)


### PR DESCRIPTION
- Update assessment detail view so inactive users are no longer displayed
- Update assessment update view so that inactive users which have been selected now say `<inactive user>` instead of `None`; they are still not available via autocomplete
- Update the `scrub_db` mgmt command to anonymize the external id and generate a sensible default