### PR TITLE
Fix: Error on Visual create page

### DIFF
--- a/hawc/apps/summary/models.py
+++ b/hawc/apps/summary/models.py
@@ -918,7 +918,7 @@ class Prefilter:
     def setFiltersFromForm(filters, d, visual_type):
         evidence_type = d.get("evidence_type")
 
-        if visual_type == Visual.BIOASSAY_CROSSVIEW:
+        if visual_type == constants.VisualType.BIOASSAY_CROSSVIEW:
             evidence_type = constants.StudyType.BIOASSAY
 
         if d.get("prefilter_system"):


### PR DESCRIPTION
Fixed an error that was being thrown on the Visual create page. This was a regression from #543.

This should be the last regression that needs to be addressed; the following regex captures `Model.CONSTANT` and was used to search the code base for any other infractions, and none were found.

```
(?<!constants\.)(?<!\w)(Permission|Group|ContentType|Session|Site|LogEntry|Token|TokenProxy|Revision|Version|Tag|TaggedItem|HAWCUser|UserProfile|DSSTox|Assessment|Attachment|DoseUnits|Species|Strain|EffectTag|BaseEndpoint|TimeSpentEditing|Dataset|DatasetRevision|Job|Communication|Log|Blog|Content|Term|Entity|EntityTermRelation|LiteratureAssessment|Search|PubMedQuery|Identifiers|ReferenceFilterTag|ReferenceTags|Reference|RiskOfBiasDomain|RiskOfBiasMetric|RiskOfBias|RiskOfBiasScore|RiskOfBiasScoreOverrideObject|RiskOfBiasAssessment|Study|Attachment|Experiment|AnimalGroup|DosingRegime|DoseGroup|Endpoint|EndpointGroup|Criteria|Country|AdjustmentFactor|Ethnicity|StudyPopulationCriteria|StudyPopulation|Outcome|ComparisonSet|Group|Exposure|CentralTendency|GroupNumericalDescriptions|ResultMetric|ResultAdjustmentFactor|Result|GroupResult|MetaProtocol|MetaResult|SingleResult|IVChemical|IVCellType|IVExperiment|IVEndpointCategory|IVEndpoint|IVEndpointGroup|IVBenchmark|AssessmentSettings|LogicField|Session|Model|SelectedModel|SummaryText|SummaryTable|Visual|DataPivot|DataPivotUpload|DataPivotQuery|Task|FinalRiskOfBiasScore)\.(?!COPY_NAME)[A-Z]{2,}
```