### PR TITLE
improve accession number parsing in RIS

### DIFF
--- a/hawc/services/utils/ris.py
+++ b/hawc/services/utils/ris.py
@@ -161,11 +161,16 @@ class ReferenceParser:
     def _get_accession_number(self):
         number = self.content.get("accession_number", None)
 
-        # extract the Scopus EID
-        if number and isinstance(number, str) and "eid=" in number:
-            m = self.re_scopus_eid.findall(number)
-            if len(m) > 0:
-                number = m[0]
+        if number and isinstance(number, str):
+            number = number.strip()
+            if "eid=" in number:
+                # extract the Scopus EID
+                m = self.re_scopus_eid.findall(number)
+                if len(m) > 0:
+                    number = m[0]
+            elif number.lower() == "null":
+                # sometimes a "null" is returned
+                return None
 
         return number
 

--- a/tests/hawc/services/utils/data/accession-numbers.txt
+++ b/tests/hawc/services/utils/data/accession-numbers.txt
@@ -1,0 +1,23 @@
+TY  - JOUR
+ID  - 1
+AN  - 1234
+ER  -
+
+TY  - JOUR
+ID  - 2
+AN  - abc
+ER  -
+
+TY  - JOUR
+ID  - 3
+AN  - eid=123
+ER  -
+
+TY  - JOUR
+ID  - 4
+ER  -
+
+TY  - JOUR
+ID  - 5
+AN  - null
+ER  -

--- a/tests/hawc/services/utils/test_ris.py
+++ b/tests/hawc/services/utils/test_ris.py
@@ -78,3 +78,13 @@ def test_parsing():
     ref = refs[4]
     ref_json = ref.pop("json")
     assert ref_json["unknown_tag"] == {"JP": ["CRISPR"], "DC": ["Direct Current"]}
+
+
+def test_accession_nuber():
+    fn = DATA_ROOT / "accession-numbers.txt"
+    importer = RisImporter(str(fn))
+    refs = importer.references
+
+    # accession numbers
+    ans = {ref["id"]: ref["accession_number"] for ref in refs}
+    assert ans == {1: "1234", 2: "abc", 3: "123", 4: None, 5: None}


### PR DESCRIPTION
Improve accession number parsing. Values equal to a string of "null" converted to None. Also added tests.

Users reported cases where multiple references were imported and unintentionally merged together. This was determined that the RIS file had a null value `AN  - null`. Since accession numbers are treated as strings, the null value was determined to be an identical number, and therefore references were merged together.