### PR TITLE
Study from identifier

### DIFF
--- a/client/hawc_client/literature.py
+++ b/client/hawc_client/literature.py
@@ -10,6 +10,33 @@ class LiteratureClient(BaseClient):
     Client class for literature requests.
     """
 
+    def _import(
+        self, source: int, assessment_id: int, title: str, description: str, ids: List[int]
+    ) -> Dict:
+        """
+        Imports a list of IDs as literature references for the given assessment.
+
+        Args:
+            source (int): Database source (1 for PubMed, 2 for HERO)
+            assessment_id (int): Assessment ID
+            title (str): Title of import
+            description (str): Description of import
+            ids (List[int]): IDs
+
+        Returns:
+            Dict: JSON response
+        """
+        payload = {
+            "assessment": assessment_id,
+            "search_type": "i",
+            "source": source,
+            "title": title,
+            "description": description,
+            "search_string": ",".join(str(id_) for id_ in ids),
+        }
+        url = f"{self.session.root_url}/lit/api/search/"
+        return self.session.post(url, payload).json()
+
     def import_hero(self, assessment_id: int, title: str, description: str, ids: List[int]) -> Dict:
         """
         Imports a list of HERO IDs as literature references for the given assessment.
@@ -23,16 +50,24 @@ class LiteratureClient(BaseClient):
         Returns:
             Dict: JSON response
         """
-        payload = {
-            "assessment": assessment_id,
-            "search_type": "i",
-            "source": 2,
-            "title": title,
-            "description": description,
-            "search_string": ",".join(str(id_) for id_ in ids),
-        }
-        url = f"{self.session.root_url}/lit/api/search/"
-        return self.session.post(url, payload).json()
+        return self._import(2, assessment_id, title, description, ids)
+
+    def import_pubmed(
+        self, assessment_id: int, title: str, description: str, ids: List[int]
+    ) -> Dict:
+        """
+        Imports a list of PubMed IDs as literature references for the given assessment.
+
+        Args:
+            assessment_id (int): Assessment ID
+            title (str): Title of import
+            description (str): Description of import
+            ids (List[int]): PubMed IDs
+
+        Returns:
+            Dict: JSON response
+        """
+        return self._import(1, assessment_id, title, description, ids)
 
     def tags(self, assessment_id: int) -> pd.DataFrame:
         """

--- a/client/hawc_client/study.py
+++ b/client/hawc_client/study.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 from .client import BaseClient
 
@@ -44,3 +44,22 @@ class StudyClient(BaseClient):
 
         url = f"{self.session.root_url}/study/api/study/"
         return self.session.post(url, data).json()
+
+    def create_from_identifier(
+        self, db_type: str, db_id: Union[str, int], assessment_id: int, **kwargs
+    ) -> Dict:
+        """
+        Creates a study using the given identifier.
+        The identifier and reference are also created as needed.
+
+        Args:
+            db_type (str): Database type (HERO, PUBMED, DOI)
+            db_id (Union[str,int]): Database ID
+            assessment_id (int): Assessment ID to create the study under
+
+        Returns:
+            Dict: JSON of the created study
+        """
+        payload = {"db_type": db_type, "db_id": db_id, "assessment_id": assessment_id, **kwargs}
+        url = f"{self.session.root_url}/study/api/study/create-from-identifier/"
+        return self.session.post(url, payload).json()

--- a/hawc/apps/lit/forms.py
+++ b/hawc/apps/lit/forms.py
@@ -354,9 +354,9 @@ def create_external_id(db_type: int, content=None) -> models.Identifiers:
         raise ValueError("Content needed to create external ID")
 
     if db_type == constants.ReferenceDatabase.PUBMED:
-        return models.Identifiers.objects.bulk_create_hero_ids(content)[0]
-    elif db_type == constants.ReferenceDatabase.HERO:
         return models.Identifiers.objects.bulk_create_pubmed_ids(content)[0]
+    elif db_type == constants.ReferenceDatabase.HERO:
+        return models.Identifiers.objects.bulk_create_hero_ids(content)[0]
     elif db_type == constants.ReferenceDatabase.DOI:
         return models.Identifiers.objects.create(**content)
 

--- a/hawc/apps/lit/forms.py
+++ b/hawc/apps/lit/forms.py
@@ -1,6 +1,6 @@
 import logging
 from io import StringIO
-from typing import List, Union
+from typing import Dict, List, Tuple, Union
 
 import numpy as np
 from django import forms
@@ -150,7 +150,10 @@ class ImportForm(SearchForm):
         ids = self.validate_import_search_string(search_string)
 
         if self.cleaned_data["source"] == constants.ReferenceDatabase.HERO:
-            _, _, content = models.Identifiers.objects.validate_valid_hero_ids(ids)
+            content = models.Identifiers.objects.validate_hero_ids(ids)
+            self._import_data = dict(ids=ids, content=content)
+        elif self.cleaned_data["source"] == constants.ReferenceDatabase.PUBMED:
+            content = models.Identifiers.objects.validate_pubmed_ids(ids)
             self._import_data = dict(ids=ids, content=content)
 
         return search_string
@@ -160,15 +163,7 @@ class ImportForm(SearchForm):
         is_create = self.instance.id is None
         search = super().save(commit=commit)
         if is_create:
-            if search.source == constants.ReferenceDatabase.HERO:
-                # create missing identifiers from import
-                models.Identifiers.objects.bulk_create_hero_ids(self._import_data["content"])
-                # get hero identifiers
-                identifiers = models.Identifiers.objects.hero(self._import_data["ids"])
-                # get or create  reference objects from identifiers
-                models.Reference.objects.get_hero_references(search, identifiers)
-            else:
-                search.run_new_import()
+            search.run_new_import(self._import_data["content"])
         return search
 
 
@@ -329,59 +324,44 @@ class SearchSelectorForm(forms.Form):
         )
 
 
-def check_external_id(
-    assessment: Assessment, db_type: int, id_: Union[str, int]
-) -> models.Identifiers:
-    """Validate that the external ID can be used for a reference in this assessment.
+def validate_external_id(
+    db_type: int, db_id: Union[str, int]
+) -> Tuple[Union[models.Identifiers, None], Union[List, Dict, None]]:
+    identifier = models.Identifiers.objects.filter(database=db_type, unique_id=str(db_id)).first()
 
-    This method has a side effect which may create a new identifier; however this identifier object
-    will not be associated with other objects.
-
-    Args:
-        assessment (Assessment): Assessment instance
-        db_type (int): external reference type
-        id_ (int): candidate external ID
-
-    Raises:
-        forms.ValidationError: If the external ID cannot be used
-        ValueError: If we cannot handle this external ID type
-
-    Returns:
-        Identifier: Returns the identifier object which can be used
-    """
-    identifier = models.Identifiers.objects.filter(database=db_type, unique_id=str(id_)).first()
     if identifier:
-        # make sure ID doesn't already exist for this assessment
-        existing_reference = identifier.references.filter(assessment=assessment).first()
-        if existing_reference:
+        return identifier, None
+
+    if db_type == constants.ReferenceDatabase.PUBMED:
+        content = models.Identifiers.objects.validate_pubmed_ids([db_id])
+        return None, content
+    elif db_type == constants.ReferenceDatabase.HERO:
+        content = models.Identifiers.objects.validate_hero_ids([db_id])
+        return None, content
+    elif db_type == constants.ReferenceDatabase.DOI:
+        if not constants.DOI_EXACT.fullmatch(db_id):
             raise forms.ValidationError(
-                f"Existing HAWC reference with this ID already exists in this assessment: {existing_reference.id}"
+                f'Invalid DOI; should be in format "{constants.DOI_EXAMPLE}"'
             )
+        return None, {"database": db_type, "unique_id": str(db_id)}
 
     else:
-        # try to make an identifier; if it cannot be made an exception is thrown.
-        if db_type == constants.ReferenceDatabase.PUBMED:
-            identifiers = models.Identifiers.objects.get_pubmed_identifiers([id_])
-            if len(identifiers) == 0:
-                raise forms.ValidationError(f"Invalid PubMed ID: {id_}")
-            identifier = identifiers[0]
+        raise ValueError(f"Unknown database type {db_type}.")
 
-        elif db_type == constants.ReferenceDatabase.HERO:
-            _, _, content = models.Identifiers.objects.validate_valid_hero_ids([id_])
-            models.Identifiers.objects.bulk_create_hero_ids(content)
-            identifier = models.Identifiers.objects.get(database=db_type, unique_id=str(id_))
 
-        elif db_type == constants.ReferenceDatabase.DOI:
-            if not constants.DOI_EXACT.fullmatch(id_):
-                raise forms.ValidationError(
-                    f'Invalid DOI; should be in format "{constants.DOI_EXAMPLE}"'
-                )
-            identifier = models.Identifiers.objects.create(database=db_type, unique_id=str(id_))
+def create_external_id(db_type: int, content=None) -> models.Identifiers:
+    if content is None:
+        raise ValueError("Content needed to create external ID")
 
-        else:
-            raise ValueError(f"Unknown database type {db_type}.")
+    if db_type == constants.ReferenceDatabase.PUBMED:
+        return models.Identifiers.objects.bulk_create_hero_ids(content)[0]
+    elif db_type == constants.ReferenceDatabase.HERO:
+        return models.Identifiers.objects.bulk_create_pubmed_ids(content)[0]
+    elif db_type == constants.ReferenceDatabase.DOI:
+        return models.Identifiers.objects.create(**content)
 
-    return identifier
+    else:
+        raise ValueError(f"Unknown database type {db_type}.")
 
 
 class ReferenceForm(forms.ModelForm):
@@ -445,7 +425,17 @@ class ReferenceForm(forms.ModelForm):
         value = self.cleaned_data[field]
         if self.fields[field].initial != value:
             if value:
-                ident = check_external_id(self.instance.assessment, db_type, value)
+                ident, content = validate_external_id(db_type, value)
+                if ident is None:
+                    ident = create_external_id(db_type, content)
+                else:
+                    existing_ref = ident.references.filter(
+                        assessment=self.instance.assessment
+                    ).first()
+                    if existing_ref:
+                        raise forms.ValidationError(
+                            f"Existing HAWC reference with this ID already exists in this assessment: {existing_ref.id}"
+                        )
                 self._ident_additions.append(ident)
             existing = self.instance.identifiers.filter(database=db_type)
             self._ident_removals.extend(list(existing))

--- a/hawc/apps/study/api.py
+++ b/hawc/apps/study/api.py
@@ -1,5 +1,6 @@
+from django.shortcuts import get_object_or_404
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework import mixins, viewsets
+from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
@@ -10,6 +11,7 @@ from ..assessment.api import (
     InAssessmentFilter,
     get_assessment_id_param,
 )
+from ..assessment.models import Assessment
 from ..common.api import CleanupFieldsBaseViewSet
 from ..common.helper import re_digits
 from ..riskofbias.serializers import RiskOfBiasSerializer
@@ -28,7 +30,9 @@ class Study(
     lookup_value_regex = re_digits
 
     def get_serializer_class(self):
-        if self.action in ["list", "create"]:
+        if self.action == "create_from_identifier":
+            return serializers.StudyFromIdentifierSerializer
+        elif self.action in ["list", "create"]:
             return serializers.SimpleStudySerializer
         else:
             return serializers.VerboseStudySerializer
@@ -65,6 +69,18 @@ class Study(
             raise PermissionDenied("You must be part of the team to view unpublished data")
         serializer = RiskOfBiasSerializer(study.get_active_robs(), many=True)
         return Response(serializer.data)
+
+    @action(detail=False, methods=("post",), url_path="create-from-identifier")
+    def create_from_identifier(self, request):
+        # check permissions
+        assessment = get_object_or_404(Assessment, id=request.data.get("assessment_id", -1))
+        if not assessment.user_can_edit_object(request.user):
+            raise PermissionDenied()
+        # validate and create
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
 class StudyCleanupFieldsView(CleanupFieldsBaseViewSet):

--- a/hawc/apps/study/forms.py
+++ b/hawc/apps/study/forms.py
@@ -154,18 +154,17 @@ class IdentifierStudyForm(forms.Form):
         required=True,
         choices=[
             (choice.value, choice.label)
-            for choice in [ReferenceDatabase.PUBMED, ReferenceDatabase.HERO, ReferenceDatabase.DOI]
+            for choice in [ReferenceDatabase.PUBMED, ReferenceDatabase.HERO]
         ],
-        help_text="Select which database to use.",
     )
-    db_id = forms.CharField(label="Database ID", required=True, help_text="Give database ID.",)
+    db_id = forms.CharField(label="Database ID", required=True,)
 
     def __init__(self, *args, **kwargs):
         self.assessment = kwargs.pop("assessment")
         super().__init__(*args, **kwargs)
         inputs = {
-            "legend_text": "Create a new study",
-            "help_text": "This is help text",
+            "legend_text": "Create a new study from identifier",
+            "help_text": "Create a new study from a given database and ID.",
             "cancel_url": reverse("study:list", args=[self.assessment.id]),
         }
 

--- a/hawc/apps/study/serializers.py
+++ b/hawc/apps/study/serializers.py
@@ -1,11 +1,14 @@
 from django.core.exceptions import ObjectDoesNotExist
+from django.db import transaction
 from rest_framework import exceptions, serializers
 
+from ..assessment.models import Assessment
 from ..assessment.serializers import AssessmentMiniSerializer
 from ..common.api import DynamicFieldsMixin
 from ..common.helper import SerializerHelper
 from ..common.serializers import IdLookupMixin
-from ..lit.models import Reference
+from ..lit.constants import DOI_EXACT, DOI_EXAMPLE, ReferenceDatabase
+from ..lit.models import Identifiers, Reference
 from ..lit.serializers import IdentifiersSerializer, ReferenceTagsSerializer
 from ..riskofbias.serializers import AssessmentRiskOfBiasSerializer, FinalRiskOfBiasSerializer
 from . import models
@@ -85,6 +88,85 @@ class VerboseStudySerializer(StudySerializer):
     class Meta:
         model = models.Study
         fields = "__all__"
+
+
+class StudyFromIdentifierSerializer(serializers.ModelSerializer):
+    db_type = serializers.ChoiceField(choices=["PUBMED", "HERO", "DOI"], write_only=True)
+    db_id = serializers.CharField(write_only=True)
+    assessment_id = serializers.PrimaryKeyRelatedField(
+        queryset=Assessment.objects.all(), source="assessment"
+    )
+
+    def validate(self, data):
+        data["db_type"] = ReferenceDatabase[data["db_type"]]
+        # study should be creatable; ie. does not exist
+        if (
+            study := models.Study.objects.filter(
+                assessment_id=data["assessment"],
+                identifiers__database=data["db_type"],
+                identifiers__unique_id=str(data["db_id"]),
+            ).first()
+        ) is not None:
+            raise serializers.ValidationError(
+                f"Study for this assessment and identifier already exists (study {study.id})"
+            )
+        # if identifier does not exist, it must be validated
+        data["identifier"] = Identifiers.objects.filter(
+            database=data["db_type"], unique_id=str(data["db_id"])
+        ).first()
+        if data["identifier"] is None:
+            try:
+                if data["db_type"] == ReferenceDatabase.PUBMED:
+                    _, _, self._identifier_content = Identifiers.objects.validate_pubmed_ids(
+                        [int(data["db_id"])]
+                    )
+                elif data["db_type"] == ReferenceDatabase.HERO:
+                    _, _, self._identifier_content = Identifiers.objects.validate_valid_hero_ids(
+                        [int(data["db_id"])]
+                    )
+                elif data["db_type"] == ReferenceDatabase.DOI:
+                    if not DOI_EXACT.fullmatch(data["db_id"]):
+                        raise Exception(f'Invalid DOI; should be in format "{DOI_EXAMPLE}"')
+            except Exception:
+                raise serializers.ValidationError(
+                    f'Unable to import {data["db_type"].label} ID {data["db_id"]}.'
+                )
+        return data
+
+    @transaction.atomic
+    def create(self, validated_data):
+        assessment = validated_data.pop("assessment")
+        db_type = validated_data.pop("db_type")
+        db_id = validated_data.pop("db_id")
+
+        if (ident := validated_data.pop("identifier")) is None:
+            if db_type == ReferenceDatabase.PUBMED:
+                ident = Identifiers.objects.bulk_create_pubmed_ids(self._identifier_content)[0]
+            elif db_type == ReferenceDatabase.HERO:
+                ident = Identifiers.objects.bulk_create_hero_ids(self._identifier_content)[0]
+            elif db_type == ReferenceDatabase.DOI:
+                ident = Identifiers.objects.create(database=db_type, unique_id=db_id)
+
+        if (
+            ref := Reference.objects.filter(assessment=assessment, identifiers=ident).first()
+        ) is None:
+            ref = ident.create_reference(assessment)
+            ref.save()
+            ref.identifiers.add(ident)
+
+        return models.Study.save_new_from_reference(ref, validated_data)
+
+    class Meta:
+        model = models.Study
+        exclude = (
+            "assessment",
+            "searches",
+            "identifiers",
+        )
+        extra_kwargs = {
+            "full_citation": {"required": False},
+            "short_citation": {"required": False},
+        }
 
 
 class StudyCleanupFieldsSerializer(DynamicFieldsMixin, serializers.ModelSerializer):

--- a/hawc/apps/study/serializers.py
+++ b/hawc/apps/study/serializers.py
@@ -92,7 +92,7 @@ class VerboseStudySerializer(StudySerializer):
 
 
 class StudyFromIdentifierSerializer(serializers.ModelSerializer):
-    db_type = serializers.ChoiceField(choices=["PUBMED", "HERO", "DOI"], write_only=True)
+    db_type = serializers.ChoiceField(choices=["PUBMED", "HERO"], write_only=True)
     db_id = serializers.CharField(write_only=True)
     assessment_id = serializers.PrimaryKeyRelatedField(
         queryset=Assessment.objects.all(), source="assessment"

--- a/hawc/apps/study/urls.py
+++ b/hawc/apps/study/urls.py
@@ -14,6 +14,11 @@ urlpatterns = [
     path("assessment/<int:pk>/", views.StudyList.as_view(), name="list"),
     path("<int:pk>/add-details/", views.StudyCreateFromReference.as_view(), name="new_study"),
     path("assessment/<int:pk>/new-study/", views.ReferenceStudyCreate.as_view(), name="new_ref"),
+    path(
+        "assessment/<int:pk>/new-study-ident/",
+        views.IdentifierStudyCreate.as_view(),
+        name="new_ident",
+    ),
     path("assessment/<int:pk>/copy-studies/", views.StudiesCopy.as_view(), name="studies_copy"),
     path("<int:pk>/", views.StudyRead.as_view(), name="detail"),
     path("<int:pk>/toggle-lock/", views.StudyToggleLock.as_view(), name="toggle-lock"),

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -484,9 +484,28 @@ class TestClient(LiveServerTestCase, TestCase):
         ]
         response = client.lit.import_hero(
             assessment_id=self.db_keys.assessment_client,
-            title="Title",
+            title="HERO import",
             description="Description",
             ids=hero_ids,
+        )
+        assert isinstance(response, dict)
+
+    @pytest.mark.vcr
+    def test_lit_import_pubmed(self):
+        client = HawcClient(self.live_server_url)
+        client.authenticate("pm@hawcproject.org", "pw")
+        pubmed_ids = [
+            10357793,
+            20358181,
+            6355494,
+            8998951,
+            3383337,
+        ]
+        response = client.lit.import_pubmed(
+            assessment_id=self.db_keys.assessment_client,
+            title="PubMed import",
+            description="Description",
+            ids=pubmed_ids,
         )
         assert isinstance(response, dict)
 

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -693,3 +693,11 @@ class TestClient(LiveServerTestCase, TestCase):
         client.authenticate("pm@hawcproject.org", "pw")
         response = client.study.create(self.db_keys.reference_unlinked)
         assert isinstance(response, dict)
+
+    def test_study_create_from_identifier(self):
+        client = HawcClient(self.live_server_url)
+        client.authenticate("pm@hawcproject.org", "pw")
+        response = client.study.create_from_identifier(
+            db_type="HERO", db_id=2199697, assessment_id=self.db_keys.assessment_client
+        )
+        assert isinstance(response, dict)

--- a/tests/data/cassettes/apps.lit.test_api/TestSearchViewset.test_success.yaml
+++ b/tests/data/cassettes/apps.lit.test_api/TestSearchViewset.test_success.yaml
@@ -14,7 +14,7 @@ interactions:
     uri: https://hero.epa.gov/hero/ws/index.cfm/api/1.0/search/criteria/5490558/recordsperpage/100.json
   response:
     body:
-      string: "{\"results\":[{\"REFERENCE_ID\":5490558,\"usage_path_key\":[\"5881|3822|2284\",\"5550|4477|4544\",\"12073|15272|30833|20032|20239\",\"30833|20032|20240\",\"30833|20032|20034\",\"30833|34386|34388\",\"30833|34386|34394\",\"30944|30948|31065|20037|20209\",\"31065|20037|20210\",\"31065|20037|20039\",\"31101|31230|17338|17341\"],\"ABSTRACT\":\"Butylbenzylphthalate
+      string: "{\"results\":[{\"REFERENCE_ID\":5490558,\"ABSTRACT\":\"Butylbenzylphthalate
         (BBP) has been assessed as a Priority Substance under the Canadian Environmental
         Protection Act. Effects that occur at lowest concentrations in rats are increases
         in organ to body weight ratios, primarily for the liver and kidney, and histological
@@ -27,7 +27,7 @@ interactions:
         \u03BCg/kg body weight per day has been derived, based upon the lower 95%
         confidence limit for the benchmark dose associated with a 5% increase in the
         incidence of pancreatic lesions in male rats in an oral subchronic assay.\",\"url\":\"https://hero.epa.gov/hero/index.cfm/reference/details/reference_id/5490558\",\"hasPDF\":true,\"YEAR\":2001,\"allAuthors\":[\"Long,
-        G; Meek, ME\"],\"HEROID\":5490558,\"id\":5490558,\"project_key\":[2207,2245,2842,2843,2757],\"referencetype\":[\"journal
+        G; Meek, ME\"],\"HEROID\":5490558,\"id\":5490558,\"project_key\":[2207,2245,2757,2842,2843],\"referencetype\":[\"journal
         article\"],\"type\":\"reference\",\"pdfURL\":\"https://search.proquest.com/docview/14582298?accountid=171501\",\"doi\":\"10.1081/gnc-100103582\",\"sortYear\":2001,\"tag_path_text\":[\"IRIS|BBP
         (Butyl benzyl phthalate)|Literature Search|LitSearch Dec 2012|WOS\",\"IRIS|BBP
         (Butyl benzyl phthalate)|Secondary Literature|Risk assessments \",\"IRIS|Phthalates
@@ -40,9 +40,6 @@ interactions:
         2019 (Date Unlimited)|ProQuest\",\"OPPT REs|OPPT Evidence Map: Butyl benzyl
         phthalate (BBP)|Peer-Reviewed Literature|Literature Search September 2019
         (Date Unlimited)|WOS\",\"OPPT REs|OPPT Evidence Map: Butyl benzyl phthalate
-        (BBP)|Peer-Reviewed Literature|Literature Search: September 2021|Current Contents\",\"OPPT
-        REs|OPPT Evidence Map: Butyl benzyl phthalate (BBP)|Peer-Reviewed Literature|Literature
-        Search: September 2021|WoS\",\"OPPT REs|OPPT Evidence Map: Butyl benzyl phthalate
         (BBP)|Systematic Review|Hazard\",\"OPPT REs|OPPT Evidence Map: Di-ethylhexyl
         phthalate (DEHP)|Peer-Reviewed Literature|Literature Search September 2019
         (Date Unlimited)|Current Contents\",\"OPPT REs|OPPT Evidence Map: Di-ethylhexyl
@@ -50,7 +47,7 @@ interactions:
         (Date Unlimited)|ProQuest\",\"OPPT REs|OPPT Evidence Map: Di-ethylhexyl phthalate
         (DEHP)|Peer-Reviewed Literature|Literature Search September 2019 (Date Unlimited)|WOS\",\"OPPT
         REs|OPPT Evidence Map: Di-ethylhexyl phthalate (DEHP)|Systematic Review|Hazard\",\"Other|EBTC
-        Zebrafish|Litsearch 2018|WOS_Core Collection\"],\"category_key\":[2,32,18],\"PROJECTS\":[{\"PROJECT\":\"EBTC
+        Zebrafish|Litsearch 2018|WOS_Core Collection\"],\"category_key\":[2,18,32],\"PROJECTS\":[{\"PROJECT\":\"EBTC
         Zebrafish\",\"PROJECT_ID\":2757,\"USAGES\":[{\"USAGE_ID\":17338,\"USAGE\":\"Litsearch
         2018\",\"USAGES\":[{\"USAGE_ID\":17341,\"USAGE\":\"WOS_Core Collection\",\"USAGES\":[]}]}]},{\"PROJECT\":\"BBP
         (Butyl benzyl phthalate)\",\"PROJECT_ID\":2207,\"USAGES\":[{\"USAGE_ID\":5550,\"USAGE\":\"Secondary
@@ -65,38 +62,242 @@ interactions:
         Review\",\"USAGES\":[{\"USAGE_ID\":30948,\"USAGE\":\"Hazard\",\"USAGES\":[]}]},{\"USAGE_ID\":30833,\"USAGE\":\"Peer-Reviewed
         Literature\",\"USAGES\":[{\"USAGE_ID\":20032,\"USAGE\":\"Literature Search
         September 2019 (Date Unlimited)\",\"USAGES\":[{\"USAGE_ID\":20034,\"USAGE\":\"WOS\",\"USAGES\":[]},{\"USAGE_ID\":20240,\"USAGE\":\"ProQuest\",\"USAGES\":[]},{\"USAGE_ID\":20239,\"USAGE\":\"Current
-        Contents\",\"USAGES\":[]}]},{\"USAGE_ID\":34386,\"USAGE\":\"Literature Search:
-        September 2021\",\"USAGES\":[{\"USAGE_ID\":34388,\"USAGE\":\"Current Contents\",\"USAGES\":[]},{\"USAGE_ID\":34394,\"USAGE\":\"WoS\",\"USAGES\":[]}]}]}]},{\"PROJECT\":\"Phthalates
-        \u2013 Targeted Search for Epidemiological Studies\",\"PROJECT_ID\":2245,\"USAGES\":[{\"USAGE_ID\":12073,\"USAGE\":\"Source
+        Contents\",\"USAGES\":[]}]}]}]},{\"PROJECT\":\"Phthalates \u2013 Targeted
+        Search for Epidemiological Studies\",\"PROJECT_ID\":2245,\"USAGES\":[{\"USAGE_ID\":12073,\"USAGE\":\"Source
         - August 2017 Update (Private)\",\"USAGES\":[{\"USAGE_ID\":15272,\"USAGE\":\"WOS
-        - Forward Search Results\",\"USAGES\":[]}]},{\"USAGE_ID\":4544,\"USAGE\":\"Excluded\",\"USAGES\":[]}]}],\"tag_path_key\":[\"2|2207|5881|3822|2284\",\"2|2207|5550|4477\",\"2|2245|4544\",\"2|2245|12073|15272\",\"32|2842|30833|20032|20239\",\"32|2842|30833|20032|20240\",\"32|2842|30833|20032|20034\",\"32|2842|30833|34386|34388\",\"32|2842|30833|34386|34394\",\"32|2842|30944|30948\",\"32|2843|31065|20037|20209\",\"32|2843|31065|20037|20210\",\"32|2843|31065|20037|20039\",\"32|2843|31101|31230\",\"18|2757|17338|17341\"],\"firstAuthor\":\"Long\",\"AUTHORS\":\"Long,
-        G; Meek, ME\",\"noPDFAvailable\":false,\"tag_path_type\":[\"category|project|usage|usage|usage\",\"category|project|usage|usage\",\"category|project|usage\",\"category|project|usage|usage\",\"category|project|usage|usage|usage\",\"category|project|usage|usage|usage\",\"category|project|usage|usage|usage\",\"category|project|usage|usage|usage\",\"category|project|usage|usage|usage\",\"category|project|usage|usage\",\"category|project|usage|usage|usage\",\"category|project|usage|usage|usage\",\"category|project|usage|usage|usage\",\"category|project|usage|usage\",\"category|project|usage|usage\"],\"isPeerReviewed\":true,\"code\":\"pd\",\"isDeleted\":false,\"REDIRECT_DATA\":{},\"isPublic\":true,\"hasPublicDoc\":false,\"SOURCE\":\"Journal
+        - Forward Search Results\",\"USAGES\":[]}]},{\"USAGE_ID\":4544,\"USAGE\":\"Excluded\",\"USAGES\":[]}]}],\"tag_path_key\":[\"2|2207|5881|3822|2284\",\"2|2207|5550|4477\",\"2|2245|4544\",\"2|2245|12073|15272\",\"32|2842|30833|20032|20239\",\"32|2842|30833|20032|20240\",\"32|2842|30833|20032|20034\",\"32|2842|30944|30948\",\"32|2843|31065|20037|20209\",\"32|2843|31065|20037|20210\",\"32|2843|31065|20037|20039\",\"32|2843|31101|31230\",\"18|2757|17338|17341\"],\"firstAuthor\":\"Long\",\"AUTHORS\":\"Long,
+        G; Meek, ME\",\"noPDFAvailable\":false,\"tag_path_type\":[\"category|project|usage|usage|usage\",\"category|project|usage|usage\",\"category|project|usage\",\"category|project|usage|usage\",\"category|project|usage|usage|usage\",\"category|project|usage|usage|usage\",\"category|project|usage|usage|usage\",\"category|project|usage|usage\",\"category|project|usage|usage|usage\",\"category|project|usage|usage|usage\",\"category|project|usage|usage|usage\",\"category|project|usage|usage\",\"category|project|usage|usage\"],\"isPeerReviewed\":true,\"code\":\"pd\",\"isDeleted\":false,\"REDIRECT_DATA\":{},\"isPublic\":true,\"hasPublicDoc\":false,\"SOURCE\":\"Journal
         of Environmental Science and Health, Part C: Environmental Carcinogenesis
         & Ecotoxicology Reviews C19:105.\",\"wosid\":\"WOS:000174781300006\",\"TITLE\":\"Butylbenzylphthalate:
-        Hazard characterization and exposure-response analysis\",\"modified\":\"2022-01-07T19:59:04Z\",\"PMID\":\"\",\"keywords\":[\"Environment
+        Hazard characterization and exposure-response analysis\",\"modified\":\"2022-03-02T13:51:05Z\",\"PMID\":\"\",\"keywords\":[\"Environment
         Abstracts; RISK ASSESSMENT; DATA, CHEMICAL; DOSE RESPONSE PROFILES; TOXICOLOGY;
         ENA 07:General\"],\"journalTitle\":\"Journal of Environmental Science and
-        Health, Part C: Environmental Carcinogenesis & Ecotoxicology Reviews\",\"_version_\":1721327218635833344}],\"isValid\":true,\"message\":\"Success\",\"error\":\"\"} "
+        Health, Part C: Environmental Carcinogenesis & Ecotoxicology Reviews\",\"_version_\":1726196301405618176}],\"isValid\":true,\"message\":\"Success\",\"error\":\"\"} "
     headers:
       Connection:
       - Keep-Alive
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Wed, 26 Jan 2022 16:22:38 GMT
+      - Mon, 07 Mar 2022 08:27:00 GMT
       Keep-Alive:
       - timeout=5, max=100
       Server:
       - Apache/2.4.52 (Win64) OpenSSL/1.1.1m mod_jk/1.2.46
       Set-Cookie:
-      - CFID=9523731; Expires=Thu, 27-Jan-2022 16:22:38 GMT; Path=/; HttpOnly
-      - CFTOKEN=39706054; Expires=Thu, 27-Jan-2022 16:22:38 GMT; Path=/; HttpOnly
-      - JSESSIONID=325C692FBC4BA9EE50EC54EA51570898.cfusion; Path=/; Secure; HttpOnly
-      - LASTACCESSTIME=2022%2F01%2F26%2011%3A22%3A38; Path=/
+      - CFID=11205093; Expires=Tue, 08-Mar-2022 08:27:00 GMT; Path=/; HttpOnly
+      - CFTOKEN=54307876; Expires=Tue, 08-Mar-2022 08:27:00 GMT; Path=/; HttpOnly
+      - JSESSIONID=9ED02BACB944746C8FC1C684D91B03B6.cfusion; Path=/; Secure; HttpOnly
+      - LASTACCESSTIME=2022%2F03%2F07%2003%3A27%3A00; Path=/
       Strict-Transport-Security:
       - max-age=63072000; includeSubdomains; preload
       Transfer-Encoding:
       - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+- request:
+    body: retmax=1000&db=pubmed&retmode=xml&id=19425233
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '45'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.26.0
+    method: POST
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAHxRy27CMBC89ytcn0sc8yhN5Ri1JIcgAqhQJE5VSFbFkmMjx6Hl72sDoqKHXryT
+        ZGYys2aj71qiA5hGaBVjGoQYjfgdu0/m49VmkaJFu62hejFWlBKWYNHi/XWajRHuEDKb5oQkq8ST
+        8ivpAdHGokmh2sIcUTekESHpDCO8s3bfPBNS2SpQsg6U2AWf+kBUuRVkf/oP0a29wA8ahTSkgWNj
+        F+hvDn77hjMXQAoFY2EL67qgpZttE+M8TabZLMVo/qXAxNiFxk6cZwlaX2tjTqN+d9Dt9RjxnzhL
+        CgtjXe8lWKg420BheDcMI0ZOkOVa2R0Ph4yckRMcOX1kxE9/3sj94xscRPOf1+DGy1v/el3Fl76n
+        lesKZIwXRijrKk10a1QhOcuWyxnKmkatjnuIcSqhtEYrUbqWT8Ne57E3oIx41lXk2C0gtzuo3B5F
+        W8c4UxaMAu+81rKtgfddogtkJwF3dc/AX4aPeVPuBwAA//+kV11T2zoQ/Ss7ebntDHESCB+9k2Ym
+        ISmFoZSB9DJ9VGzFVrElX0kOuL++R5adD+pOy70vEMvS7tmzZ1fr3eCuCrmJrrfZ3Nt1Px4thEUm
+        PygVEZMRhQnPRMhSsupZhCpVcUl/4w2JClqVZrz95m0QZJMKk/CIVkqTTThNtbBYoUsZFcZqgU1T
+        4exUVu+4AcAwoYkxKhSVuVHPYwCHnyfLpQbr1boHdQ5AtPBgHIH7WzbRbJLkbc2ZTktiKTBXGw3w
+        U66V5fjv4oy55MSfc82Nk6N7jZ30KCLJSwSTpupJyJiWWmWgzW1VptA8GPX2HI1uWSxkDaYuh9tY
+        jgeD42H3pA/+t2tIws7m+bUKq58oivll5HUTKdGhf1gqoq837ztfIZ5+gII86X0LVqENXI6D/mHQ
+        76Nmdgwg+iXIZqHd/lrwZzueevgHxChUWYZAI2GEXEGdTFpaluAkKkJLakURNP3oYn7CCU3qu/JQ
+        DyhhhpacS0Ikj8i1VZQUGfNMMikyZFZz2ahG2PIAhIZpETlz/k3IU/xB7oUEpCofWZFagWptTJic
+        h4KbgD5yDchPYH3N0sLRHyZMxvy3WbSJVkWckH1S3UhkXBov10isVrApQ44jKXFfnXmicFAYenM4
+        684uL+ZvK6OT1arMOKT7TExrVhoXr4i4tGJVUg7v+AWjGVqBccSBbC+htUrXoMeBVJYBUpFtBFSH
+        DsQVQQF9YogcmjMIVNcC89z+fBgWX2QHWg0V4pG2ETiA9HENHKD7V2EM+33K88wX5pOCF/4Ibmc1
+        FVUIO9TheJyWKLIS6m5INjtp5FKlzHAa0Ju5VIO3BwSKABksmjypUBqVod78nkUuBp5PZxbLacST
+        MuLdo+72RLWkHSnu1JsLlkfJWzJFjFyDGItNGw4aacENsbp7gK8nYZNdeUARGj0L5Jgiy6vEOBCF
+        Fan4zmxT6xtNmjpvLsQi72oeF6nf9hMjIajiNaqMlSiJquOBQQi5EoLrN8CUCavCRMmoan+rQlYC
+        Ceierx0RL/tS7cUp0UHdP11JHEmWJtQib9TCUqNILQ3Xa68ZYHEhC+PU6UmxCQw6kW41GtAiQQcm
+        Y5FThIKg1lA2QBgRJ9Y1eUW86p2AKq3Z54ryBCj9pdDEuixbe+RuE9o+ojsVFlV3DZzUXNV1p6tf
+        7XW/0TUz9obh8psk6VJp3BWbldEHVG/168JRdDXqbRZGl1I4fZvxBZY3DyNUNlTge6Zcqb2F8Rfp
+        buJqhAEzc7kWuL/RQiyCv3Xl4Kt8goSE6G83zVX4kYOKpMrc/qH5yrVZs73zrhlCYFZpHN/fer5p
+        DlU/mgkMHlXnnQ6GR93+Ceq6/44WwUNAk5Q/wxdawEyLNdrkxvwCepGxG1OYfgTAczo8PR2gIexF
+        5pKzE/Xekyel5xPxm4TMePrIdWs+Zo6m1nTMJrvp+DNHd0rlrW6mTC+ZZnTe6mp6/npXF1DjL0Ji
+        qBO6aw/q7vWeJmnK28V8hT+GHlo9XT283tOMT9AaU9XqbILZUMmSpq3uJtPXu3sQUorHVmcP6Gtp
+        RJ9afT18avXV2/YL50TGBYv5mMvYeaif3BycCj8KuSnKb36xSF8u33dmmKSGh2edcT00Uj3KVdPx
+        7u5fHj8anh13xpuSuy/yXGmLYlOy+yW4D+hCrf+yLfZerniQvZdfUs1sXhXiuSpwvZfjOaoaJT/q
+        NQvN7sWkbUbevhzdpBmK/9+CY0Q8O+yfDs8wN+4uVt8t136yGPcPT8+6J+8Gx/5DpVneWNwHV38o
+        +ECap/HojsdY0eVNkS25HmMCfrEycpn/vLovcCcwN5F5avHJevyu0wysBjD3twHG1sn/d4f5vH/S
+        Gd/Wc85/dDc/p6NgGBwOguEfOx4e/QAAAP//zFnbbtswDP0Vw08rkMF3SQaCAEXTSzC4Q5cAQx/T
+        1us8xHEQOw/d14+ULV/Z1K1dLE+tHYmkSEk+h8fj+my1f9kBED/u12gluaDZOBjI+AKOTOsVbIz0
+        N3yQELDlc2ovgOKGOYhI9uhVJd4UltABjv5J9qtkFz3imb7V4W5AUA6Zac6S26Fms4cDWdmug6rU
+        bQ93B7hbfkVhZeUOwmSO07YCV4+ChVOjMesDYdouM4kwLxD4wFkIR8iEa5udNYCLueJkkg0P9WJ5
+        lqAWctlkPRPtOtxMtBVQpXlFlcZYJHdcyn0OzIMwAxi0idK4b90twQlzT/sDcJIcYg2uveUJTqVM
+        IsvLkiQNiPh+5IhNBseKirjkEieUXpMzRl0x32S3pXegjBE2Hl8ySUg6QY5WGtqQwzsrAkNxbXcP
+        TZqwfaoy2DcY4ZQKj1GnNAjjByCbQCJUn+OkNpLwbWojBTXK/Inh9t4Jt6PuBM9yHGrrB41Ggarc
+        KdXLNl3LIpx830TPyfYAyDfJsP9wjn02bRkCKEWkdA4fIvoKe/fFLmFeN4AK9/XL1aefdqixoDL1
+        Y52NkgbfotKA1ifaYvuAnZwrx3WHu/IcTn6YVti0iOF9mmrLnUQi2GQlbv93L04iasKjgtj9Sswd
+        yojUQ1IZ51CM4Qqywj9lPxeZ5ObNZNSfCgbZkuCURDdfZ+vZ9AbGJEgYc7Gw0IBQx1JKHTaQw7/6
+        qxpSUx/zC3nsBpggPsi/0yDaHrIQuVfxn2S7lb8j7nPZ8b+5j/Pkve6/JTXyDwZg1Auh2gB5ELNd
+        oaE1WgTFb0rUWjzl1S4fNSUYqQRWUmo5hhweRfpsWRL9L6Z/hszK/8remIjC1DExqjbZaAVt1Hek
+        0VSQ/wEAAP//QuOD5pgBAAAA//8DANWA3KkeHwAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Date:
+      - Mon, 07 Mar 2022 08:27:01 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C5754094EF30500005C39CE129BCA.1.1.m_3
+      NCBI-SID:
+      - FFA6B1B84D5D4F6C_4D1CSID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=FFA6B1B84D5D4F6C_4D1CSID; domain=.nih.gov; path=/; expires=Tue, 07
+        Mar 2023 08:27:01 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-Test-Test:
+      - test42
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+- request:
+    body: retmax=1000&db=pubmed&retmode=xml&id=5490558
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '44'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.26.0
+    method: POST
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAFxRUW+CMBh836/o+jxp68aUpdZswgNG0Axn4tOC0swm0Boobv77fWWGzb3QK9/d
+        cd/Bp19ViU6ybpTRE8w8itFU3PDbcDlbb1cRWrW7ShbPtVX7UmbSotXbyyKeITwgJF0khITr0JGS
+        nnSHWGPRPNdtXp/RkLKAkCjFCB+sPTZPhBS28HRZeVodvA9zInq/U+TYfYeY1l7gOwsoo8wDNoZA
+        /3OI6zeCQ4BSaTlTNrewC8rgbJsJTqJwEacRRstPLesJhtAYxEkcok2/Nhb+Q0B9f8yJmwge5lbO
+        THUspZWF4FuZ14IFI8ZJB3litD0IOuTkB4HgLBiM3emeV3J3fZUn1fReUMv9tZcT//EaXnn14su6
+        XeOmkOUEr2qlLWw0N22t81LwOMtSFDeNXp+Psp9TStnAHw8hsSP0fCC2EkFrsoAGVVv9Om5M2VZS
+        sBEnF8g7tngEjw64f+Di9e13F+iJotScvgEAAP//zFbvcppAEH8Vhu8poEhwhjBjmrFxxlhtiK0f
+        TzzhGrizx9GOj5N36BvkxboHgqhnaxI7k2+wt7e//fPb3bu4wSHE1DiB7FYXjCa+7wVEQBF7oUBa
+        jFdIsIsMkkdZwiISIs8ozyG2z735nEM2iiKXF26LCxt9Gd6uTg1VZ680FsRY48+/IZlsqc2xQBcc
+        h3glGM80QjUhj3GUJyWdQEdKEBeYE5RoIeHh3llCoI8+eMYOijdGEaEbTza5GEfUty0oR50dKYHk
+        NFR7uYgZHxJopYpIs9GVPtOrI22KErKoZEOUiRGCEvVJFsaYe0Yt8fqM4+Kr5xn1tzegREAgmZTW
+        3+B8YfwfIAF6fH4KMyXIUAkyfDnINaZh9vwkYiXMWAkzfjnMFGUJeiRvjsXYVkxap1GOIuxjGknL
+        mz/ZLwnwWZZYdmepvCfUHgZX+o1pOXbL1f0Nd7UNqYoOamr7B5LSqLE/GKt+o0vmex9ZTgVf+58w
+        TxFde0YlqLSDnrK3tqfeKEkfKPmRYxiXZts2L9tA56awGERDQh8JjfbHTyWuLe56F+MUAkrKSKo/
+        3/uCI5Dw9ShP55j7pmfsSTxZqc/L+3yeCUTDOpXtjuPo/v06hWBilpIUQ26Avnvq4M4W7Chsd+aO
+        vk1a9nRyMr5lt9u6P+ZsxZGcackroYdOyw0C0+x+PRXavOzYHd0fZADNYHSVZfwbuLGX/c0+lcqw
+        dQd3oLArAspk8S1GCyhoeachgGWGs5ATOVYlauWW6Vqurt2h74wHbEVC2ZYj3e9RkkJbwdLbuVXw
+        pGHzBADr0m0rAK4TxhZaP2G/YPsnLCRifRawrn0UbMwx7DiOz4HjmseDCoBb2TKXL5ozQMHw6Sig
+        blh0jup0Wo6q/H2cMg7DboqJIoZJDgN8SfDW0gSI5JiWwhIkPMIcartz6RWeOna3q7BfzEUSyrFc
+        wJzmq+VeKmwteB5peLnEocgOHFYbah3yDZYaofDC/Vn05tsDLwbHobN7k+S0uG1le6xiBNsnlG+8
+        MxTKtcyWIidD+SiD9239WvuPtXqpz5ZlOSpyjRkX76oLygWmcLS50d4NFeS6V4Fs9r/c/doIGoXl
+        mXa/zgROT3W+o6TYKl7D0D2b685x1xtPl1dne7aT7T8AAAD//yLkZH2Myl0fraMN64gDu3WJdjYe
+        QDX5oHYkZEgA2t0DdVdh/XFI714J0ac2wNsPhneDUQzEY34uxHkkW+ABbIGCmpRg2sY3M68U1JUF
+        KoWwiHdAKrAhnVpFHfsNcNuvjxzUsPY/xA12BQUgoeIMlL4BVA7WCfZMgcQnnKvgmQIZMYDFEHxI
+        BK7EDokNTQ3Ika+POiQDAAAA//9C44MGbQAAAAD//wMA+b9gHm8SAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Date:
+      - Mon, 07 Mar 2022 08:27:02 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 939B4C2CE2A63C8500004D57C4F5AF12.1.1.m_3
+      NCBI-SID:
+      - 1301D0762F84FA60_4EC9SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=1301D0762F84FA60_4EC9SID; domain=.nih.gov; path=/; expires=Tue, 07
+        Mar 2023 08:27:02 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '1'
+      X-Test-Test:
+      - test42
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
     status:
       code: 200
       message: OK

--- a/tests/data/cassettes/apps.study.test_api/TestStudyViewset.test_create_from_identifier_bad_requests.yaml
+++ b/tests/data/cassettes/apps.study.test_api/TestStudyViewset.test_create_from_identifier_bad_requests.yaml
@@ -1,0 +1,96 @@
+interactions:
+- request:
+    body: retmax=1000&db=pubmed&retmode=xml&id=-1
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '39'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.26.0
+    method: POST
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAFxQUW+DIBh8369gPK8CruvmgjSb+mBTrZldkz4ttpKVRNEodOu/H9rGzr7AAfcd
+        d0fnv2UBjrxpRSVdSCwMwZzd0Xt/5a23SQASvSt5/tYosS94yhVIPt+XoQfgBKF4GSHkr/2OFA2k
+        B0BaBRaZ1FlzAjYmDkJBDAE8KFW3rwjlKrdkUVpSHKzv6ojkfidQ3f+DKq0u8Is4mGBiGTY0hm59
+        sPENo8ZAIST3hMqUyQJSs+vWhVHgL8M4gGD1I3njQmMamuEo9MFmiA0Zoai7Y9TPFPeqsi644jmj
+        W541jDjPM4p6SKNKqgPDhn9GZuDEiHnu9m4djXfHD34U7aBlY9u+0bLHWi//tYbhS9C+6yrnhQuT
+        Rkhlsiwq3cisYDRM0xiEbSvXp5oP7xjj2cR2plOKOsLAN0TNgemL56Y7ocur4qYqdMkZeaToAmnP
+        ZsbpGXTtd/auBT2NQy20/AMAAP//zFbLctMwFP0VTTZsaPzIw4YRnnFD24TWackDpitGsdVEYEtG
+        thn891w7tpM4KqSQBatEV/I593mkJiqtOaztczt4wVIo3SUT/oZGzCchgooyH8qIte0exHTvrlYS
+        slCWtT6MwOUinsPNBr9J1xblWsgI+BFJEpIjxtFKBDl6CjMWJG8RieMQyMuugb2IphvCRYhiwRLB
+        GV93sXYAhx/ImvGKsuq7hzV3DMO6MKET9kwQ+95ZN0s3Qt4xmI+6Rx6n7zqPnXoLfSIhC2rbHUnS
+        KYHse+QbkVhr1hgCouU/F11irVnhCWcpI2HiuGBuFuB+if4nFt8jECZXEt2iKyXR7dXLiR5ISBOq
+        pPGUJN7LORY03oS5kmOBZkqWxUxJo+2qVuDzdUbW1KF8XYBXK3wjCU+VhS13qh/Ql+ueidwbfdi3
+        beiU2opdXwqeR457A3zVf+yuKfdzZzpx0XQyRuPxHDa3NjwSGU9l7ix5McCl2tEEa7W5gj6i90Zf
+        lssvBqhyTxvs829hvdnoWYpbmIRARAoOrYm+1IV6mAoVUhrRcvKu8143hn3T7jjVyKJqxEq12D/9
+        7Oe9vm11nBm0EpH+Bs2zOBYyfY2W3XkX3Ygfr+D/Q3cMKwVm27J1VGtfJ7Ve8Sfx55xX3yzcQ5Xa
+        mfE0jODj7xmFnOvGwOiboMr7xlLD7xj/BsluK3dtbhAPnaskdBtIvXLwjK7BIvNpFq2odHSstSy4
+        GIP7p3m2SlLC/Tq9+mAwhHuxkk4Is3UM3NiRPEsHEXp9y7jsfTiZ1zT7g44zInIFevyeiZ8soH/J
+        fjVCRtfsXpzMrfcLbjcM6CYPKLoHbtCJIPNTkvx1Dh77c2v44fPEGLzAj57ZcbzqJvo9r9aqfPUA
+        Kg7DM2kC2tkyQZ8mmzElATTT9ps9A7xBaOJLFqdCFqwHmUEe+SrkQsTML+Rt+rtUHcI4+GMGOv3E
+        6A71I6D2LFuBClcwWYmQJaA2B9+Vvb/n6ymO24aKwuUsAp0/9vPFBIZtDhUEl8UT47p8YpyaDB2K
+        3gKCG4TAiOcJS/49FeVkHXvaHrUTnX1jKbBWoRDBv3taas8x+k6Mzu+jGmGgH9UWStK8DM/RnvZR
+        0cHHMYlDITeMszN06NDWVdkcZxHh55iAoT3sqfDzQAp4S1xMoLtGAnQLrslSiM7AaVm6ruCERwqF
+        G/wcUZUafMywE+X/YE5sy3zOR6HSnSOCXwAAAP//ImCBoaGpiSUWCwKKU0uBbcH8vESi86IR1jSY
+        mldVmZufk59eSSAw9DEqLX20Hj9sRADY00y0s/EAqskHNcogYxPQHiio9wwbGIAMMyjh7MGaofbK
+        YZ1yFPPwGJ8LcR2p5nsA23SgRhqYtvHNzCsF2gIabICwiLcflNlSq6hivQFu6/WRwxnWnoY4wa6g
+        ACRUnIHS1obKwfrnnimQyIRzFTxTIKMXsOgxhDfKPVOwqUvJzwQqMtAzBPYn9OEtZg1zU01LA0MT
+        c11zFP36aPbqI6cZfdQhJQAAAAD//0LjgwadAAAAAP//AwBPpsLuLxMAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Date:
+      - Mon, 07 Mar 2022 08:27:21 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C5754094EF3050000303A068655C6.1.1.m_3
+      NCBI-SID:
+      - AE7CF81BE8E03F91_B6C0SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=AE7CF81BE8E03F91_B6C0SID; domain=.nih.gov; path=/; expires=Tue, 07
+        Mar 2023 08:27:21 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-Test-Test:
+      - test42
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/data/cassettes/apps.study.test_api/TestStudyViewset.test_create_from_identifier_valid_requests.yaml
+++ b/tests/data/cassettes/apps.study.test_api/TestStudyViewset.test_create_from_identifier_valid_requests.yaml
@@ -1,0 +1,176 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.26.0
+    method: GET
+    uri: https://hero.epa.gov/hero/ws/index.cfm/api/1.0/search/criteria/2199697/recordsperpage/100.json
+  response:
+    body:
+      string: '{"results":[{"REFERENCE_ID":2199697,"ABSTRACT":"HAPAB  Zooplankton
+        lipid samples from various stations in the Atlantic Ocean consistently contained
+        polychlorinated biphenyls in greater amounts than total DDT.  PCB ratios ranged
+        from 4.8 to GT 45,000.  Concentrations of PCBs in zooplankton from the northwest
+        Atlantic shelf were similar to those found in fish obtained near Great Gull
+        Island in Long Island Sound.  The median concentration was 40 ppm, higher
+        concentrations being found in the northern areas of New York and New Jersey
+        and in waters less than 1000 fathoms deep.  In the south Atlantic there was
+        a pronounced west-east gradient.  The chlorine content of the PCBs detected
+        was about 54%, an unexplained finding since the majority of the PCBs produced
+        in the U.S.  contains less chlorine.","url":"https://hero.epa.gov/hero/index.cfm/reference/details/reference_id/2199697","hasPDF":false,"YEAR":1972,"allAuthors":["Carmignani
+        GM $; Harvey, GR; Miklas, H; Risebrough, RW; Vreeland"],"HEROID":2199697,"id":2199697,"project_key":[384,2932],"referencetype":["technical
+        report"],"type":"reference","sortYear":1972,"tag_path_text":["IRIS|PCBs|Litsearches|Remaining","IRIS|PCBs|Litsearches|LitSearch
+        August 2015|Toxline","IRIS|PCBs|Considered","Other|PCB Support Projects|PCB
+        Commercial Mixture Congener Profiles|Screened (TIAB in SWIFT)|Excluded studies
+        (TIAB)"],"category_key":[2,18],"PROJECTS":[{"PROJECT":"PCB Support Projects","PROJECT_ID":2932,"USAGES":[{"USAGE_ID":29718,"USAGE":"PCB
+        Commercial Mixture Congener Profiles","USAGES":[{"USAGE_ID":29950,"USAGE":"Screened
+        (TIAB in SWIFT)","USAGES":[{"USAGE_ID":29952,"USAGE":"Excluded studies (TIAB)","USAGES":[]}]}]}]},{"PROJECT":"PCBs","PROJECT_ID":384,"USAGES":[{"USAGE_ID":7109,"USAGE":"Litsearches","USAGES":[{"USAGE_ID":7110,"USAGE":"LitSearch
+        August 2015","USAGES":[{"USAGE_ID":7113,"USAGE":"Toxline","USAGES":[]}]},{"USAGE_ID":7127,"USAGE":"Remaining","USAGES":[]}]},{"USAGE_ID":4737,"USAGE":"Considered","USAGES":[]}]}],"tag_path_key":["2|384|7109|7127","2|384|7109|7110|7113","2|384|4737","18|2932|29718|29950|29952"],"firstAuthor":"Carmignani
+        GM $","AUTHORS":"Carmignani GM $; Harvey, GR; Miklas, H; Risebrough, RW; Vreeland","noPDFAvailable":false,"tag_path_type":["category|project|usage|usage","category|project|usage|usage|usage","category|project|usage","category|project|usage|usage|usage"],"isPeerReviewed":false,"code":"re","isDeleted":false,"REDIRECT_DATA":{},"isPublic":true,"hasPublicDoc":false,"SOURCE":"(HAPAB/73/01317).","TITLE":"PCB
+        residues in Atlantic zooplankton","modified":"2022-02-11T16:23:23Z","PMID":"","_version_":1724484528219619328}],"isValid":true,"message":"Success","error":""} '
+    headers:
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Mon, 07 Mar 2022 08:27:21 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Server:
+      - Apache/2.4.52 (Win64) OpenSSL/1.1.1m mod_jk/1.2.46
+      Set-Cookie:
+      - CFID=11205102; Expires=Tue, 08-Mar-2022 08:27:21 GMT; Path=/; HttpOnly
+      - CFTOKEN=50529846; Expires=Tue, 08-Mar-2022 08:27:21 GMT; Path=/; HttpOnly
+      - JSESSIONID=66E856043B1D544462B876D9009994F1.cfusion; Path=/; Secure; HttpOnly
+      - LASTACCESSTIME=2022%2F03%2F07%2003%3A27%3A21; Path=/
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+- request:
+    body: retmax=1000&db=pubmed&retmode=xml&id=10357793
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '45'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.26.0
+    method: POST
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAGxR0W6CMBR931d0fZ5cKjrDUmo28AEjSIYz8WlBaWYTKASKm3+/lhk2zV56T9tz
+        T889pfOvskAn3rSikh4mlo3RnN3R+2Dtb3bJAiXdvuT5c6PEoeApVyh5e1mFPsIjgHgVAQSbwJCi
+        gfSASKvQMpNd1pzR2CYuwCLGCB+VqtsngFzllixKS4qj9VGdQB72Aur+Hag6dYHvxLWJTSzNxtrQ
+        rQ92fcKoNlAIyX2hMqVnQamuXevhaBGswniB0fpT8sbD2jTWzVEYoO0wNmbEdqazmetQMFeMBpni
+        flXWBVc8Z3THs4YR13Up9JBGlVRHZs8o/CDdcGbjMQVTzXrVbrav/CTaQcvkcqM1vdIizl+tofky
+        bx95lfPCw0kjpNIjLauukVnBaJimMQrbVm7ONR/ubTJxRo7jTCgYwsDXxI4jHRvPdYSiK38Vt1XR
+        lVxbpXCBtGezR63RA/MJxt6/AX0DAAD//5xX73PaOBD9V3by4UpmAuT39a6UGUrSkJZwnpK004/C
+        FlhzssVIchL3r7+3sjHQuHOX+wReyfv27b5dWUzlU5E3rPrN5v4u9nBwrzwqOBY2VrlZyVw65Qb9
+        ygo2f40WCwv+oa4vtv283jhvclU5msg1NsSUIil2rYVTgkSeUCzyWFpSOVnh3Z8ktJc2uHJsjM0a
+        +ymTXiyMVi7rDfp7fgeRWKm8xq5FGK1yCOqPky4StWNCBnb2jhbOWxH77b97+eyH3yStmY0pnC4p
+        kRkCwSrKQz4VPkRJ8nltHFsMjHhBWvOsnMn4XUS5ZAbGUieKDilR0qelTuVzqdcpfGg4o87V9QSL
+        qUjIyqSI4cxJW2SEZBTacIIy0O+MsQm+E+EkIUT1qHx5RE+pilNyxWolHcLxKoiozlUiEZxikj0a
+        VyblKFWrFIQ8nMWcWPkcS+eOQg2sdIX2Vb6l1oUW8CIysZJhOeXSmWYlrhSQCUedyXh82KP7FADO
+        F0lJIkngzUlHcSpyhFdhrdnIY8Es6zC7VuqQ1aCkgMNF1mAZFxmAwhTBy41gWD1aYVaGzb7IjGXv
+        VfIWJUVRj+4EejOU6ElaSUuscP4RDXpAqFzlK+LME6oTa7NUCxuqMZ5+PKQljGfdy2NwL8FtR6mH
+        AfK8G6faWNO97HZOj84IBVUJMnHYPe2uS6syfip116fKdGbdBeh00zKBNsogAXiJYcM2GbBOjinj
+        1mzyeFVYDnAHmOtDKsOgVRwnRwGFrUI2HyVKHVvJ0kCeKvmMo0Ym9IQKmQXsj0hDJ6LftH9Hx73j
+        i0O4rTMUxNd0W/ZlNiItH6V2IcKF8WlwCdxvSjuTv3FIqAuYXDjqfLsKf+CRoq5H5DS6j7B8uI8I
+        kXDBkBQROIYasfq1QRwtwf8cLyLYBFIh7gW75QKqIFKro8UJFisRucJaU+QJR7PZPp++CPuORakN
+        1zSXmxS5FFEnlBvWFcagl7lvBJ+8qGJN3m3eE3Tau+gujU4q/fq6M7I2rBYOgk56p5v3twqYTwEk
+        s7WxaKPNgtsyrucDtwLHa9Bo1nKHtMjuSaHyWx8IrgasBxeHcdY7q22hfTAcm97Zz+F4H5h1eboh
+        wHOpmv9tNQs4J73ff947n74jZZG1RHEZ/DYP/MIPPDW9gVFR50SXPKoKDL06E3ujJhxG25nVMqV2
+        51gmSlrIQMmqReE5gUuIt5pJdcJzaeqTDqYI7YGA2BmLv0dT40JiIeudAbwNe2klz7JExSini8Wj
+        RGw8ftci5g4JUxB0QiwyT/kgrc4KH2ZDNcD3BqTj03P3tNs+4hgsfGrsFGqmzafT99n7g+8HmyX6
+        KjDwNrYpJvJM4KPkWqwMvjKa58FHY2X4F9HnQb95GtzmOJWEdsMI5uZhMFoula6+Hm7zpdkzDL+O
+        iD+LOAVjaEfaI4qU925R2FWK/yM6uTg9Pz6ih/mIye28uvdUee5XRP6F0L2Ua9lKaEQ3rYRGN7uE
+        /hvKtc5aMe5o3opxN389xj2rpxVlTletKPOr/8EEWil/weVTO5dPr0f5IJWWthXmA123wny4fj3M
+        PMWJ/qP4W7QiTVpxJq+H+SJMK8BnmrVCfJ61YvS3TcvO81WBnh9iULDz+mlwY0XuW/s6rNQ/uHWN
+        Rxdn5xe4+GwMg1GMIVtmWAFU/X8wwjCMy+FsfEuz2wlNJlBmbRuMcaR6Ww4fcr7RhFugxC1hY65d
+        b36ruHEv0ehwblO+MrUa6eH2/cHV8cnl+enbg2F9xaD6JhCuNru7f/n62fnbi4PhF4kvGIsv6Hmx
+        xsngj2hm8u5Db96jG/P4xr/K32Wbv62vynfUm8Dy0u8/AAAA///cWW1v2jAQ/isRn2mx47xZiiKh
+        QEc3yqBjlfoxpYFmS4DxIrX/vuckHonjUDfLpKofMc495zv77rm7M3Ltt+TWyhRXMoP2xFKdF4Fp
+        ZOQOGq5XMSSWgsfy3fN+pfQ7/eNO4gQ8/ucYwqVxEHKQCdV0cTGtisfR+jckSrEW5st/JZY1ewoT
+        Fv+zU/BfnnsbrmBl9zI5Jg/hzoMiWVhx2RP6vvxxhAyX5sbcttg2SMebcsLOrqewEzQ54bSAqMNZ
+        wZuTfheSGRRHLI83BDXJ9ArhmW5QVXSkUwp33s+qHaih+ovosSG67dCfrC/km8rohCAE6CmbaohK
+        EXEuqHGhK4M6lgVRQqDuTdEtOr6bW1++KsL7EKQoAvhtBLQ6eo7ihsC+oX9D0xEmvvK5DWTijjco
+        dBy0KW85NNRi6AP/xtYlucTqN860mc+LnYzz6D3hkedNRLY5PHjXN7ChvARRaf80CgNWvWXfFBY8
+        dxDuF7toC2ycoXK1kIOdjnYT/Nrs5ptttGBZcNLx+usogazq9spfpeGoIFMBID13FUAwhAgzOwJD
+        WEbhSdQMdNWJKRHFYi9EcVC29FWdEGLLDnxqplXEvP/ILLhIjixEG7UzWxAmq7LSlhUUPP+ubBqL
+        JMrmwUlNSYlN79u1afqKq2rWPeuPYVuLWrKLMDo1FVp4YA6iVAIyZtW2qiEwMKuqiMfdcaWFy2W4
+        OPy3xyUXY9gVx8B92gbA6+PNqgXPOBgbdUbTJlmLItl3teEzuCpKoMoOYmVjEpk/Fnk0j194+6G5
+        SVt+W45OZe5nfeM27ifjHRLpIhH5TCkg49NViBLB/hAxKuPhVQCRmH8m75iYOLJkchscWmA8GFNs
+        1UjvatfrB9ZeviKG8RZUr8LnesJAmQ+cB8Eh8NwR7Nmw6jQbfeeTTTaV5XPnbIrdqZ2MWqVpr8mH
+        vSV5Z8QnmXbvlT/avAIAAP//KgV3HMG0jW8mAAAA///KKwXaAmxYQ1nE2w8spYtSq6hivQFu6/WR
+        wxk2pABxAgAAAP//sisoAAkVZ6AMN0DlYFO/nimQyIRzFTxTILPisOhBzPvD1WBTnpKfCVKrZ2hg
+        aawPmYDUNzLQMwMJGKLo1UezWh852eijLloAAAAA//9C44OWNQAAAAD//wMADCd6EJEhAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Date:
+      - Mon, 07 Mar 2022 08:27:22 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - 322C5754094EF30500004A3A090BBEB4.1.1.m_3
+      NCBI-SID:
+      - 6AC399CD7F7F9E23_49E6SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=6AC399CD7F7F9E23_49E6SID; domain=.nih.gov; path=/; expires=Tue, 07
+        Mar 2023 08:27:22 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-Test-Test:
+      - test42
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/data/cassettes/tests.client.test_client/TestClient.test_lit_import_pubmed.yaml
+++ b/tests/data/cassettes/tests.client.test_client/TestClient.test_lit_import_pubmed.yaml
@@ -1,0 +1,221 @@
+interactions:
+- request:
+    body: retmax=1000&db=pubmed&retmode=xml&id=10357793&id=20358181&id=6355494&id=8998951&id=3383337
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '90'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.26.0
+    method: POST
+    uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAGxR0W6CMBR931d0fZ5cKjrDUmo28AEjSIYz8WlBaWYTKASKm3+/lhk2zV56T9tz
+        T889pfOvskAn3rSikh4mlo3RnN3R+2Dtb3bJAiXdvuT5c6PEoeApVyh5e1mFPsIjgHgVAQSbwJCi
+        gfSASKvQMpNd1pzR2CYuwCLGCB+VqtsngFzllixKS4qj9VGdQB72Aur+Hag6dYHvxLWJTSzNxtrQ
+        rQ92fcKoNlAIyX2hMqVnQamuXevhaBGswniB0fpT8sbD2jTWzVEYoO0wNmbEdqazmetQMFeMBpni
+        flXWBVc8Z3THs4YR13Up9JBGlVRHZs8o/CDdcGbjMQVTzXrVbrav/CTaQcvkcqM1vdIizl+tofky
+        bx95lfPCw0kjpNIjLauukVnBaJimMQrbVm7ONR/ubTJxRo7jTCgYwsDXxI4jHRvPdYSiK38Vt1XR
+        lVxbpXCBtGezR63RA/MJxt6/AX0DAAD//5xX73PaOBD9V3by4UpmAuT39a6UGUrSkJZwnpK004/C
+        FlhzssVIchL3r7+3sjHQuHOX+wReyfv27b5dWUzlU5E3rPrN5v4u9nBwrzwqOBY2VrlZyVw65Qb9
+        ygo2f40WCwv+oa4vtv283jhvclU5msg1NsSUIil2rYVTgkSeUCzyWFpSOVnh3Z8ktJc2uHJsjM0a
+        +ymTXiyMVi7rDfp7fgeRWKm8xq5FGK1yCOqPky4StWNCBnb2jhbOWxH77b97+eyH3yStmY0pnC4p
+        kRkCwSrKQz4VPkRJ8nltHFsMjHhBWvOsnMn4XUS5ZAbGUieKDilR0qelTuVzqdcpfGg4o87V9QSL
+        qUjIyqSI4cxJW2SEZBTacIIy0O+MsQm+E+EkIUT1qHx5RE+pilNyxWolHcLxKoiozlUiEZxikj0a
+        VyblKFWrFIQ8nMWcWPkcS+eOQg2sdIX2Vb6l1oUW8CIysZJhOeXSmWYlrhSQCUedyXh82KP7FADO
+        F0lJIkngzUlHcSpyhFdhrdnIY8Es6zC7VuqQ1aCkgMNF1mAZFxmAwhTBy41gWD1aYVaGzb7IjGXv
+        VfIWJUVRj+4EejOU6ElaSUuscP4RDXpAqFzlK+LME6oTa7NUCxuqMZ5+PKQljGfdy2NwL8FtR6mH
+        AfK8G6faWNO97HZOj84IBVUJMnHYPe2uS6syfip116fKdGbdBeh00zKBNsogAXiJYcM2GbBOjinj
+        1mzyeFVYDnAHmOtDKsOgVRwnRwGFrUI2HyVKHVvJ0kCeKvmMo0Ym9IQKmQXsj0hDJ6LftH9Hx73j
+        i0O4rTMUxNd0W/ZlNiItH6V2IcKF8WlwCdxvSjuTv3FIqAuYXDjqfLsKf+CRoq5H5DS6j7B8uI8I
+        kXDBkBQROIYasfq1QRwtwf8cLyLYBFIh7gW75QKqIFKro8UJFisRucJaU+QJR7PZPp++CPuORakN
+        1zSXmxS5FFEnlBvWFcagl7lvBJ+8qGJN3m3eE3Tau+gujU4q/fq6M7I2rBYOgk56p5v3twqYTwEk
+        s7WxaKPNgtsyrucDtwLHa9Bo1nKHtMjuSaHyWx8IrgasBxeHcdY7q22hfTAcm97Zz+F4H5h1eboh
+        wHOpmv9tNQs4J73ff947n74jZZG1RHEZ/DYP/MIPPDW9gVFR50SXPKoKDL06E3ujJhxG25nVMqV2
+        51gmSlrIQMmqReE5gUuIt5pJdcJzaeqTDqYI7YGA2BmLv0dT40JiIeudAbwNe2klz7JExSini8Wj
+        RGw8ftci5g4JUxB0QiwyT/kgrc4KH2ZDNcD3BqTj03P3tNs+4hgsfGrsFGqmzafT99n7g+8HmyX6
+        KjDwNrYpJvJM4KPkWqwMvjKa58FHY2X4F9HnQb95GtzmOJWEdsMI5uZhMFoula6+Hm7zpdkzDL+O
+        iD+LOAVjaEfaI4qU925R2FWK/yM6uTg9Pz6ih/mIye28uvdUee5XRP6F0L2Ua9lKaEQ3rYRGN7uE
+        /hvKtc5aMe5o3opxN389xj2rpxVlTletKPOr/8EEWil/weVTO5dPr0f5IJWWthXmA123wny4fj3M
+        PMWJ/qP4W7QiTVpxJq+H+SJMK8BnmrVCfJ61YvS3TcvO81WBnh9iULDz+mlwY0XuW/s6rNQ/uHWN
+        Rxdn5xe4+GwMg1GMIVtmWAFU/X8wwjCMy+FsfEuz2wlNJlBmbRuMcaR6Ww4fcr7RhFugxC1hY65d
+        b36ruHEv0ehwblO+MrUa6eH2/cHV8cnl+enbg2F9xaD6JhCuNru7f/n62fnbi4PhF4kvGIsv6Hmx
+        xsngj2hm8u5Db96jG/P4xr/K32Wbv62vynfUm8Dy0u8/AAAA///cWVtv2jAU/isRz7TYcS62FEVC
+        gY5uwKBjk/aY0kC9JcC4SO2/73EuI3EcmmaZVPWpqnG+7/gc+1wv4Nqv4VZiyiuJQntyqZ4VgbFn
+        zAw03KxDCCw5i6W7F/1S6Xf+xZmGEVj8zymAS0MRosiEajq/GFfFY775DYFSroWz5b+IRckeg0j4
+        /+QU2X+ucxesYWX/PD1F98HehSJZWnHEE/q6+naCCBfHxlS32DZIx51lCbu4ntJOkOTM0wKjDmcF
+        a077XQhmUByJON6Q1CSzG4TnusHqsiOdMbjzXlLtQA3VX/KHhuw2Zd9FX8gza7MTghCwx9lUQ1aG
+        CL1ixpVem5RaFngJKXVvym6x8Y+F9elzTXoPnBRDQL/jkFbzJx42JPYM/QuajTDxap/bQCbuuINc
+        x0GbZS2HhlIMPci/sXVNrnH9G2fawub5TsZl9p70yNMmotgcHN3bCWwoLoFXOjyOAl9Ub8k3uQXX
+        GQSH5Z7vIBsXrJlYiGLa0Sb+r+1+sd3xpYiC047b3/AIoqrTK34Vu6McZg2C+NxlAkkRMs38BBnC
+        igdnqDnIqhNTASV8L3hxELbwVRUIsVUHPjfTSjBvP7JwLoojS96m3pktcJNlrLhlBQXPvwsb+yKF
+        sKlzqiekQqc/29Vp/IrLYlY96/ehW4tZqoswOjcVWnhgFDGmIBmLaruuIjBkVmWIh/1prQWrVbA8
+        /rfHpYYx7JJh4D7tfMjrw+26BctQjI0qpWnTpEURHbra8AlMxSOosv2wtjKJyh7L1JuHz1n7oblK
+        W35bVGcq84u+cRv3U+QdCnQ5EflIISDJp8sUhQT7XfioJA8vE8iJ+UeyjokJVQWTO//YQsaDMcNW
+        BXpXu93ci/byDTGM16h6pXyuJw2Us4HzwD/6rjOCPVtRnSaj73SyKaay2dw5mWJ3KiejVmHaa2bD
+        3gLeBfgoke6t+COobEXhGP91JvwFAAD//8orBdoCbFhDWcTbDyyli1KrqGK9AW7r9ZHDGTakAHEC
+        AAAA///Uml1v2jAUhv+KNalSKxHyHejNpJayNV07dYMK7dIQ02SQBCVhLf9+5xw7kNBAKWo17QaR
+        xPHH6+P4JM/7ebHAU3lY+9ygrpXo1w/kZK4PmR9IKl5Oz4b7r8s0FQ/SCMu2TePc1iWA1C2j7eEJ
+        s3avvtW0Xg0bfcu08L4eBgvGAq8Y5j4PgwVrZst34NR9B923eBjsel1Yd9UPYb7Fw6D155D9ZGkS
+        TfbYGaqFTMe2NKNjd1/3NPj47R4ejRtbQ9fdtjWYO2wNLzW74QfbGi6ySQiZDpEW2klUVrXD3oDF
+        2VCWO9zcYHnaSIhZicZhE6AdSzFxaDmItCgHrSeQum9MAOMV0Wn06fAA3g0jchpg5BUp6116X0wt
+        4/m1xeB0klOtDBIrcagHwj3XvH0WiP5tKpctBHK/utRqH61p2RkdPYc9z3A0wzQ0w7U9NFdUKthp
+        qKiYA8Qzh1GSk0LUtGKLFMlgxOe7xTq98q/uz6RRBDUhIRieJKBYCigy6csw3Uo5HVoJRKY/Zuly
+        gaCylF3hY2jUaDEYJ/7YdgvtAeaJhI8ue4rmgUTbh9Yl7zwhhm557AliI2/Th2CFBNHLUMJGYtdr
+        To8gFNSRAPF0wTORTMJVTER3OudxTHq32JQXEGCqjhZ0Yjpd5qL0aqxAMOK5sFQX4UriXJHmIPgi
+        jOBpzR4hpJZz5byYpgjYEjHJoEguqessChKBLLdYjsn3Mea5vJkrA4Y8XbdJTAvkqvVgBkVomtTQ
+        5LRgFXVh25AwUIGKRtBB9Ca08DyoRFLxkgMn9BUKq99yqPBASH+KajGWrpAyGlgmJiL6g8gW5gi7
+        hkQ4Rq0DqRTeNI3IG5DXZ4T8K7D3pvNqhTDN22MZhsheJxF0BQu82sdK8KngIc1Kp1GlMYz2zgk7
+        NXUTDQGVvwTlbTh25XEm8oVAQ4WQ6Lvq0oGJZ7kosGclfcZo5QleJPcQREQhcvQ1yLc5uq7sTvA3
+        5mpgmznNwzQrNIiAuPbEwj2mtEqJZ4gLVD6ADXmMwB5qsEl+NGNAuI1+aabjOaADOg3koDZWnTPq
+        02ad+LcDX7/uD3x20RuiN+Y3DPgjKHcvbAZ2I55oA5GOG6ndaHAw6O5RRkca+5WFzkoG1KKI+rEU
+        Aj04JRNfEyI/AVkLSOJkuYckIlNpQbtPHwJZAfOHb+9FyW9EKjHjC0lu+Arm8rFRkSPALygfNdNl
+        2Mia8fLbG7nn2awZlEMm8z0SzbC8GcrubeiaN3slLkUaMwikWTPJPgL+D3a4MkZpqvVC7EZTxPaO
+        58z/A8dtZqOqfXrJwp+Xqe46EzX2Zu/GOuOuVHkoe/0q8KG6amSv9bx0B3k1HLPjmXvJq+0YmguF
+        /gV5NSyrY3+qYOSPJ69GB9mn/FiuYMTHN/pegNnrOtq5rR3OWrsd5G53hAlgDUMyB9Mp+JHNd72e
+        c/dz6LoXTR34CwAA///U291OwyAUAOBX4QG4gAP94dLMVI3J1KTG7HLpdrGLRaO+fyzFrBucGkDa
+        sBfoaWkPPZwPMPhkJRRihM+ObOOpOQ/9vH9eK/5YNa8ihNvlCcDiI781SrSV5C8PvqMvgdX9698d
+        3MVTBvrKa5Covpo6mBLjEau+Pv4HPmy88CG4r8+gxgjl5mKdQ8nTJyYn4dFmdmpecBRBVlb3otWH
+        C/xZFHsZxz4X33duNzzcmcFlsrX1L4lGhk1KCB3yf1LEMxLbq2RmydH9Bre/ZxKGfuYXJSZXEuRi
+        ASW2ZaDZH5OIIeeKYc9zp/fYUb2sTqGSywLwTHPwzHJboVt3kFoqizwoODLf6vs9dElGowaYuDol
+        7am1k+D7Hwp0BI+tij2Lqf2KpFsoNFnaPrtJY46pLE+ypu06oiwwpv70K328N4xlt123//g+D+Es
+        2MUEt8XJqxvgsiEA5/Ja+surp2svHt5yb5fmLM1UkTcwvzyPWovJ8w8AAAD//8Iy84x9CmxwTD2b
+        GZuamlia4N89b4E+W2yEGlfmpMw8AwAAAP//oubMMxG75w0sLXRNDA2ImGlG2z0P8iRx08yYAeRV
+        mkPsNDNsJBNllhk8d5GaVwbaqQhpVilkpCbmlGTgnH72go3xKbhCtCl4QDVAVAIAAAD//9ycUU/b
+        MBDHv0oeN4lUQEs3Xic0TUWTJraJZydxW2tJHOKmCD797n9nNylNBHQtm/ZIFezz+e7s5Oe/n0fR
+        P56gVY8AMvPuPG439u+jHSm6KQF2AjB6scwejPny9TJ7NtMWhS1pj9iAcHnkZx4hYX/WWkAwrCfl
+        CqJ2QUJgJ+mSP9h6nXuLlRPsRFNbQwjqleWeSAHfMgWDIpll6IBszMKqCrr+grqlTs6jh3oU/azo
+        fzEL+p6Fw9QAQzLP0BhURo4ecpZFtbZeqNI8Sp+pLdO8ycJVAixEx0C2ULg3a8sc1muDR6asH5XB
+        eJmol/GWqZxxEEy5UcdzW+goDiRRyWcE0bgCehonBw4813Qjenuy4K2RIO6lYs23WtS65aPG+dE4
+        /vIBXfMa4kyKNwybIknW+ki+ACAdGFhlek5zTNYaj55NQU7mOwpwQqSqtRTAje0MLIUCwhCy3IaL
+        DzZXMlApKVeig4UWONGgq3cNwoXhIztm2RSqZCRKrWsMGG7xWBSh2JR+KQkw2Mk5BcsS7UA6edIS
+        Y5Vz1N1crSmgktwTdge5W2znMT0Zq3oFIEkvP00tmmJx/U56IoDgNIwxs2lT8Gg4+ta+pARH7HiJ
+        QsHB83w+INMVziaU1K8mj0qYyiw6IdLDhy54XOQJSkOvoe9UA3SjyRZyaYh6alvQNjKFAywojdvY
+        k4mJ0IoJQvTFkl2ZUSy2k8Eqa4xnaSrKIYk+cvIGPfOBg1BX+Rd/VjuY7sX9fNMDJk+x2e1BSnGu
+        ceFqjI55cqkCp3kwlVJAkDQ9DEm5yh+ccWEmJN9QeNRamZymH6ifkbhvWhLVddIcsZtoXfIVAJxu
+        id7J+xDICJVoDajX1jOKkZPQsswBNW1WaK/JM69FdzQnOMSAROlMb9sPX6iBRHD+Cog8H0Wfm5od
+        rjvv//TgXWNqxHWeo/Va42+ddXKdLIaCvpb6qHDrh6RM27MsdxHVmF8UWuHOFLGAgwpFidIDvzrK
+        DZrpAvDL+1riMSwLx8D613lz36/1vo2+9hPSPejyF6rUxQD4nQ2I5GfXe/TTzOcDnfQrpGf9CulD
+        497T8dmUVYBtan5HOXs58P1DXjydXEzAi1EQD6yYHVI6t4x2eFM3wHE/XJyNp7jMapjjbu+H31hB
+        +1eo6uklNJ3f2nKwb5dvShb/E2Xj2cdetcMnS1uSW41F/Yjyq3+DbBxI7nVs/DQZ9wKFK1p745uw
+        37rp7LdOoity/qtj5DcAAAD//9yca2/aMBSG/4q/VApSAecGeJMmdVXZKq1qtfYPuNRAVogzEmD9
+        9zvn2A4QMgoqXbt96YWkPr7Vsd8n7/nrqIR3/Fpz1Zc5rHeS3SSjo7CS16UMUVyrq0s4Zc6n7Gwy
+        0UvaTp7D2QqFRhqlo+CNekHf4dkXBxBht44xvRVdeis7tBBBXYhrVAHYLR4uhvb//N2slv8WgqFd
+        QE1lN7YF/9OC/soGvpBHdYN/a4/sO6fsc7zIbKquh9/VUBmB6lOILyduf3x0t19Vyd3ME+sfyny2
+        3H77lf9qbr8XhH9T5lJiij2RS4+3/TjodUNoMRcxTFY/ei/IpSdET8Q7zX6+EN0KffRfgFyqCYvF
+        JiwVR0YuQTdo8ljwg5FL6O+PXERns1FX8mlf5NKfpw/SqlWUFTPLJol6WOcvH5ge4uoFd/xYAzRj
+        xW41rG8Gjdw97wo0odgZRDjcHHidDra1Xkqo6Y4jMtUouLF+kg9QiAujaKX/f+6ch33/IN9fIJqR
+        fziTCZoX6xXygouvDZSEJVsq+chSnUIztCErY5vO+U+pj0uvV9Fil4UpBW1bzQVNjJWpiARtl9/W
+        /lU2U0YnMuYx+mjtAc/uk7xZAUTw2MkcHjprnNbdUmVIRjIuZnV36jwb05135k6TcFmSBQ26ouLl
+        IsU7wZcQsQVDOvCsLG2oy6qfc3zSGTyk3YTYVOChu4kGWaHdiPBUlHdlLHm2ZK/fqNAqL+aO67Rz
+        9ct4ExsteiGVjeQCE4Gi4p67OFAyb8GR7YRJqJme5+x8pqY6Q2nx4hvzMj150tAXzTBmA4lPBaYT
+        6Bky4I2ShYJmoopXwIbeTBD1SAo25fDmzFtCA2bQcfDjQo1xysIvMT9lPn7Bisecs+mo/TgyLsnI
+        5kK2o6KpYbuLCrgtqhuvF+X3bFEtWtLRb4YTbQW7qBfQf2aaM5UPit2rYonyvI1QwjA7R5QscKVZ
+        ZynOjphqMl+qFYK7T0pKkSejFPdPJCa5GBR6ONPTMhqZIbGZpbnQBbo0edE3DJAYEY/zLjetM5LK
+        grmOKGtImNRmgEWxZkliDcwJZAwFjobtOe8KxqbzkfXhW3DSqAwRXg1Duhr6dPU3AAAA//+0Xdtu
+        GjEQ/RW/oBKJ0EBShapSpbRpE6XhBajybGADLrCgvSTN33fOjL3rZb1qoOkTBMiuZ3zmeLxz8Zw7
+        UxdRyEqpIy1iS53Y+Hcer6LNLoujtKq3igiVbsUSDXqyJZcdRfDbaFTATRMadsdWplqggE9TKxar
+        INXkpD6y8cmjByiQEJHQOuG6Ym90siJy9MOorLyA9uSnSqc7I4xUxLmmCRnycruLIzL/WJr8ill6
+        l/pEXLEhrmBAdDCtruk64Zv+mMHpLst4DQeIy5bUHVsdjNl/pgXdRbfwjEDTXRcKMRMI6AGGKUHA
+        gBv1i1l8DYaQsYBOKGClNeKpbOOnZWgRRaD4xA836jmqDSMYCmo4iwbILISHDRoUCJBop2IYXDnd
+        VVeZZ8mbLcqZa5j1AQ1Q9gWy/YuW5fNyosu5bQ/5K4D3jMCLsRLj7Zv63gCyAgJapRK39Jtt02ro
+        1SlLAbV/toFdyoiQIotf7vDNbD1UH96DwL6rC3ptHBB+2LM/xOtJxX4qJiPaqhoOrROkGGetbhBs
+        5+ctMfSPrRPfdC5D9KHBB4FSZpK6qAhnBRjHCr1B6PfBAwTcCucgW4ygw5H8tORvwmKJmWyvXjsy
+        HMB05Dl9gStFn7zDUQ3k3jBN/ItQqnd2iEyeC7AnVbNE7Z3f97wqn0PGNM9YL/xhZcFI/ya0NXo8
+        3qAxpIhxT6qGDUErVu2N1cbAo7KFfVw1eof3A+fd82okz2W2TRwlSaaJfY6i2rb5ukS3Cys/qeNW
+        6EnPf+W2UPxwJLZ7g+6gJVlGGIYVbsn7Y9ZHjGg/mDdeFLTmfPtHPTPMQO2z034fxIR5k4C9wwYZ
+        d++8C+Nca9qF5BlC99L9wL8yrtAiu/+JlhNFOoqR3A9xjVNJDcHTGudBAiKlk2mcCyGjKNDAnmyd
+        uZtU5CnSlGsMfHpJ5nAnMbCnjFScpUbiCBwenaZkSfVJlena4OGTn8/hch7m6FexsE6aR+sOMbXF
+        1h3wEILWnh3qGVtYbCSdqnoMRm3V8Vb2nl1V6zfdv0lXXZuEZPLTrEg6Hb/IuminxxMc8yfOtV5v
+        Y06K8CWwqVdQ9jznb/EPyDuRvcKTedqKX4lNkOufQLqd2NyetdkYmz8mcKa5KxU705yHR1/2v40C
+        LIYEENqagBn8vURXPRBbRjwWeyqCDp2L4BgijC/bVLp2233kwAIsPAJdRkhsng6R3PC+M4/XZhXx
+        0TcYG+cukXeT8IZVsvu8QfyPHJMrogVUNQY714fb8H+5fnXjiPLxRdkNYqLTlbqBR9hRLgCthjrO
+        MRV5gj30ldUsp+896JQ4bpHh/fVXeIznl296pMINXT1q0MEoqIHR4dkvNzkRcPAWYSUfcdTBLQnx
+        bBraXrxVw4vb7XyRNjRvuFNhdd0doa8feZRlTWcqhJOSjshJGpLKoiQ8Lw/hDKsjbpInu2X4DIpx
+        g8bGR2hsbKL1KgrPzEjdh4F8799nnJMB/f58R0q3b197lMdL00xNGgSchAV8o9yuPwAAAP//In1p
+        Fm0XWWEdosV1QwGwgLMAnVqHe30V6uD3cD8nw8DAxMRQCVi6gUd+ab+Wy8TM3Bw0w5wIbOomp5ZC
+        uhhhkE4OubZHRIWZhzg6mpsHEHtggrGJgSHQGajj8CNjOZcp1uUgTqnANntmfhHu/dMDt6bL0Nwc
+        q5Nz8vNTwKdGKIALhUHl5KG0aI7CQyEG8EAHYHbBYhBa70AtMbfAGtRvAVZvg2NhB7DIxZo8XMHr
+        +wdRyqD5wj5w5YPl6gB4bTS804E5du975pWUJkH7Z+7AVl9RPmiqFDTCRJWDLWi60JHmxxMYYss5
+        kOMJoKeOB5eAJouosrTR0gibX6Br+jKriF5BTI9SHNyywraYD0dTiwoxPXq+PLaFLKZUXXEG7LCg
+        7bNHPcbAyAJ5zZchTU6YJ8qDg2/NGXydFt41ZwAAAAD//yrIzFSyCwZ1+0C9PkszS2C5bIypCQAA
+        AP//wnk2gJl+WmJiiR4omPRAWgfLKjVjYwtjY2NzAgcDWKCtLLNAXVlmjGWVGgAAAP//7F3LctpA
+        EPyVPXJARJYxoCM2lUpSfiWupHJdI9mmLCQikBP9faZndvVCcjAhj0rliK3Szs7O6tU93Tuz1Bp1
+        4h6YpVa3EnwBS81vktTG3boAk711AZqeiR0Es+Zhu3LLXutFhPZJy5LqYGOxpnJ/NDzGR3DhL6gs
+        BtksyCK6hM7gaZ3HQJPkGzwYBaWUOKSh0ZqAj/kWZyg4MTsrBRyNfQfE1ZfS0q47JmXiK18YVKTn
+        j6rkqBVe4oDraaFT8Jw4fnqYUtzAvVYZY0xxEjsbnd6HGwVkwsJYQcJYmvQpGwiiNccUv0FaAfgL
+        zUvu6ViarZzJmcpVoX2NJQDtbZEyhPcl0/EGe16gncZ6yACVgEX7oFZEA3Wto+Vik+R4NZ6KM7Qx
+        yKYj8WEwDtmRPo9YrRsTwf8la6ZhmyYqaGy1GhiRC6PwyaoRlDPpWfTrVQAsKLfsM8SXrVB+J0KI
+        m2fGpTo3evP107iMjSZVKQhH2HlbUhC9owEIS3dhyMSZXjmUN5Hz1xqnu9aP3eitJ/qguh56/cxm
+        6X2c3QhQvAw1WpkDpTMqT3rUSO5TvXowUD9gWVqsOKONoiGtgKfTyr6iGYqG1JZOhTSnp3lV23+e
+        RcBxAOIXNWU1LBq11TMrQFkxKeK8cld6r/hL6aPOFwea1EBNjRC8kFWlUmDgkNxFGVW5AJSUI741
+        lzGpIFzSCuONyyo0VCrdjFxuBTvyiq52+G2SbrUByjDA4bNDcAVaO3We8BvvykPZTNTyQn4cf2O8
+        1nkQjumTjqjSKGLLr+Q9pG8Fqqcp0pzx74DubfMNw7R2PxaQ9m3NT72oJIqsbBsZyOjbCRWagBHO
+        KJq7QHRJ+ehFmYPWbBfEMwlrwOekwqt05FddJCDvzyzasNLYby53hYVCLRQkAbEziWydLVF0fXNs
+        lDe0Izouyi3TNrjv81crHLVeQW2Bgujcoj+4DR1c818DH2uHlT6os3a452x3yX+LzL6lZOFzdani
+        X+el9yvIbrrQ8T2elHT62FeXZ8obj13/UDjtDd0wHpyrSAwV28CmdqhpDzv3bEOb8muSog/+F3u6
+        XyerVQeaOm1HU6e/xW1duWN/ePJv263/tzH/y23M/6zMO96znaH/Am/voTekmqKHsH1HvPAn78/f
+        ebPznVN94gKP9Zzp9k15zyBOTz+7I3d66X/aed6jyQgQbR4wcUzJW1GwbwA/LYLxHQAA///UXUEK
+        wjAQfJFSEm3Tsw8oiAi9VoT2VMGTvzeTlCLNKmuzkUjv7ZZkN5mdZEbOXHzDlwApjK1Gjf3t0R/Y
+        wznWmE9r+zA/f4AGvKrgzEugqvVBKDirbyv+2QCtlaPJJgDXTLPyBcJlQGH7lAkbt29yiNc/35HC
+        6jff2hYyS07vEY/xI3nPTwOa6Eb795wlii+hLoJqzGTpaqqh3w3jDKkloiQJSwD3o8NOEYxN+xdi
+        Nb9IFbcgUY7vwQqVTcxlqWoqRSzePbum4Ol66d1eT0RLJo1bvfgMNEaT2ve4oNaNuFnAjXZfBLUN
+        Xvb94z7IDKDfAhBk7HJPkEnBFJSMJ9KjFU6PGDI3PcO6ZGHENT1Y71+p6fEEAAD//yLiTA/yrR/Q
+        +VX4DCPJF3hb6pnrgWaFyJ4rBQAAAP//QuMHAxurAAAAAP//AwCQ2/KcUZ0AAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-RateLimit-Limit,X-RateLimit-Remaining
+      Cache-Control:
+      - private
+      Connection:
+      - Keep-Alive
+      Content-Security-Policy:
+      - upgrade-insecure-requests
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Date:
+      - Mon, 07 Mar 2022 03:15:06 GMT
+      Keep-Alive:
+      - timeout=4, max=40
+      NCBI-PHID:
+      - D0BD6ED2C856ED2500004BB03A6012D1.1.1.m_3
+      NCBI-SID:
+      - 3CA260ED0F7BC5DF_C864SID
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - Finatra
+      Set-Cookie:
+      - ncbi_sid=3CA260ED0F7BC5DF_C864SID; domain=.nih.gov; path=/; expires=Tue, 07
+        Mar 2023 03:15:07 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-RateLimit-Limit:
+      - '3'
+      X-RateLimit-Remaining:
+      - '2'
+      X-Test-Test:
+      - test42
+      X-UA-Compatible:
+      - IE=Edge
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/hawc/apps/lit/test_api.py
+++ b/tests/hawc/apps/lit/test_api.py
@@ -368,12 +368,6 @@ class TestSearchViewset:
         assert resp.status_code == 400
         assert resp.data == {"non_field_errors": ["API currently only supports imports"]}
 
-        # check database
-        new_payload = {**payload, **{"source": 1}}
-        resp = c.post(url, new_payload, format="json")
-        assert resp.status_code == 400
-        assert resp.data == {"non_field_errors": ["API currently only supports HERO imports"]}
-
         # check bad csv
         bad_search_strings = [
             "",
@@ -431,9 +425,7 @@ class TestSearchViewset:
         resp = c.post(url, payload, format="json")
         assert resp.status_code == 400
         assert resp.data == {
-            "non_field_errors": [
-                "Import failed; the following HERO IDs could not be imported: 41589"
-            ]
+            "non_field_errors": ["The following HERO ID(s) could not be imported: 41589"]
         }
 
 

--- a/tests/hawc/apps/lit/test_api.py
+++ b/tests/hawc/apps/lit/test_api.py
@@ -309,6 +309,7 @@ class TestSearchViewset:
         c = APIClient()
         assert c.login(email="team@hawcproject.org", password="pw") is True
 
+        # HERO import
         payload = {
             "assessment": db_keys.assessment_working,
             "search_type": "i",
@@ -316,6 +317,18 @@ class TestSearchViewset:
             "title": "demo title",
             "description": "",
             "search_string": "5490558",
+        }
+        resp = c.post(url, payload, format="json")
+        assert resp.status_code == 201
+
+        # PubMed import
+        payload = {
+            "assessment": db_keys.assessment_working,
+            "search_type": "i",
+            "source": 1,
+            "title": "demo title 1",
+            "description": "",
+            "search_string": "19425233",
         }
         resp = c.post(url, payload, format="json")
         assert resp.status_code == 201
@@ -368,6 +381,14 @@ class TestSearchViewset:
         assert resp.status_code == 400
         assert resp.data == {"non_field_errors": ["API currently only supports imports"]}
 
+        # check database
+        new_payload = {**payload, **{"source": 3}}
+        resp = c.post(url, new_payload, format="json")
+        assert resp.status_code == 400
+        assert resp.data == {
+            "non_field_errors": ["API currently only supports PubMed/HERO imports"]
+        }
+
         # check bad csv
         bad_search_strings = [
             "",
@@ -410,15 +431,12 @@ class TestSearchViewset:
         c = APIClient()
         assert c.login(email="team@hawcproject.org", password="pw") is True
 
-        # check that the "GET" method is disabled
-        assert c.get(url).status_code == 405
-
-        # check success!
+        # check missing id
         payload = {
             "assessment": db_keys.assessment_working,
             "search_type": "i",
             "source": 2,
-            "title": "demo title 1",
+            "title": "demo title 2",
             "description": "",
             "search_string": "41589",
         }

--- a/tests/hawc/apps/lit/test_forms.py
+++ b/tests/hawc/apps/lit/test_forms.py
@@ -135,7 +135,7 @@ class TestImportForm:
         )
         assert form.is_valid() is False
         assert form.errors == {
-            "search_string": ["Import failed; the following HERO IDs could not be imported: 41589"]
+            "search_string": ["The following HERO ID(s) could not be imported: 41589"]
         }
 
 
@@ -265,10 +265,7 @@ class TestReferenceForm:
         # bad pubmed validation check
         form = ReferenceForm(instance=ref, data={**data, "hero_id": -1})
         assert form.is_valid() is False
-        assert (
-            form.errors["hero_id"][0]
-            == "Import failed; the following HERO IDs could not be imported: -1"
-        )
+        assert form.errors["hero_id"][0] == "The following HERO ID(s) could not be imported: -1"
 
         # make sure pubmed is unchanged by default
         form = ReferenceForm(instance=ref, data=data)
@@ -311,7 +308,7 @@ class TestReferenceForm:
         # bad pubmed validation check
         form = ReferenceForm(instance=ref, data={**data, "pubmed_id": -1})
         assert form.is_valid() is False
-        assert form.errors["pubmed_id"][0] == "Invalid PubMed ID: -1"
+        assert form.errors["pubmed_id"][0] == "The following PubMed ID(s) could not be imported: -1"
 
         # make sure pubmed is unchanged by default
         form = ReferenceForm(instance=ref, data=data)

--- a/tests/hawc/apps/lit/test_imports.py
+++ b/tests/hawc/apps/lit/test_imports.py
@@ -192,7 +192,7 @@ class TestHero:
             response,
             "form",
             "search_string",
-            "Import failed; the following HERO IDs could not be imported: 99999999",
+            "The following HERO ID(s) could not be imported: 99999999",
         )
         assert models.Search.objects.count() == initial_searches
 

--- a/tests/hawc/apps/lit/test_serializers.py
+++ b/tests/hawc/apps/lit/test_serializers.py
@@ -212,8 +212,7 @@ class TestReferenceReplaceHeroIdSerializer:
         serializer = ReferenceReplaceHeroIdSerializer(data=data, context={"assessment": assessment})
         assert serializer.is_valid() is False
         assert (
-            serializer.errors["replace"][0]
-            == "Import failed; the following HERO IDs could not be imported: -1"
+            serializer.errors["replace"][0] == "The following HERO ID(s) could not be imported: -1"
         )
 
     def test_bad_reference_id(self, db_keys):

--- a/tests/hawc/apps/study/test_api.py
+++ b/tests/hawc/apps/study/test_api.py
@@ -24,7 +24,12 @@ class TestStudyViewset:
         assert len(json.pop("riskofbiases")) == 1
         assert json == {
             "id": 1,
-            "assessment": {"id": 1, "url": "/assessment/1/", "enable_risk_of_bias": True, "name": "Chemical Z",},
+            "assessment": {
+                "id": 1,
+                "url": "/assessment/1/",
+                "enable_risk_of_bias": True,
+                "name": "Chemical Z",
+            },
             "searches": [],
             "identifiers": [
                 {
@@ -114,7 +119,10 @@ class TestStudyViewset:
         data["reference_id"] = db_keys.reference_linked
         response = client.post(url, data)
         assert response.status_code == 400
-        assert str(response.data[0]) == f"Reference ID {db_keys.reference_linked} already linked with a study."
+        assert (
+            str(response.data[0])
+            == f"Reference ID {db_keys.reference_linked} already linked with a study."
+        )
 
     def test_create_valid_requests(self, db_keys):
         # this is a correct request
@@ -135,7 +143,10 @@ class TestStudyViewset:
         # now that it has been create, we should not be able to create it again
         response = client.post(url, data)
         assert response.status_code == 400
-        assert str(response.data[0]) == f"Reference ID {db_keys.reference_unlinked} already linked with a study."
+        assert (
+            str(response.data[0])
+            == f"Reference ID {db_keys.reference_unlinked} already linked with a study."
+        )
 
     def test_create_from_identifier_permissions(self, db_keys):
         url = reverse("study:api:study-create-from-identifier")
@@ -170,7 +181,9 @@ class TestStudyViewset:
         assert str(response.data["db_id"][0]) == "This field is required."
 
         # study with identifier must not already exist
-        existing_study = Study.objects.filter(assessment_id=db_keys.assessment_working, identifiers__database=2).first()
+        existing_study = Study.objects.filter(
+            assessment_id=db_keys.assessment_working, identifiers__database=2
+        ).first()
         ident = existing_study.identifiers.filter(database=2).first()
         data = {
             "db_type": "HERO",
@@ -188,7 +201,10 @@ class TestStudyViewset:
         data = {"db_type": "PUBMED", "db_id": -1, "assessment_id": db_keys.assessment_working}
         response = client.post(url, data)
         assert response.status_code == 400
-        assert str(response.data["non_field_errors"][0]) == "The following PubMed ID(s) could not be imported: -1"
+        assert (
+            str(response.data["non_field_errors"][0])
+            == "The following PubMed ID(s) could not be imported: -1"
+        )
 
     @pytest.mark.vcr
     def test_create_from_identifier_valid_requests(self, db_keys):
@@ -200,7 +216,11 @@ class TestStudyViewset:
         data = {"db_type": "HERO", "db_id": 2199697, "assessment_id": db_keys.assessment_working}
         response = client.post(url, data)
         assert response.status_code == 201
-        assert Study.objects.get(pk=response.data["id"]).identifiers.filter(database=2, unique_id=str(2199697)).exists()
+        assert (
+            Study.objects.get(pk=response.data["id"])
+            .identifiers.filter(database=2, unique_id=str(2199697))
+            .exists()
+        )
 
         # PubMed request with additional fields
         data = {
@@ -213,5 +233,7 @@ class TestStudyViewset:
         assert response.status_code == 201
         assert response.data["bioassay"]
         assert (
-            Study.objects.get(pk=response.data["id"]).identifiers.filter(database=1, unique_id=str(10357793)).exists()
+            Study.objects.get(pk=response.data["id"])
+            .identifiers.filter(database=1, unique_id=str(10357793))
+            .exists()
         )

--- a/tests/hawc/apps/study/test_api.py
+++ b/tests/hawc/apps/study/test_api.py
@@ -3,6 +3,8 @@ from django.test.client import Client
 from django.urls import reverse
 from rest_framework.test import APIClient
 
+from hawc.apps.study.models import Study
+
 
 @pytest.mark.django_db
 class TestStudyViewset:
@@ -144,4 +146,92 @@ class TestStudyViewset:
         assert (
             str(response.data[0])
             == f"Reference ID {db_keys.reference_unlinked} already linked with a study."
+        )
+
+    def test_create_from_identifier_permissions(self, db_keys):
+        url = reverse("study:api:study-create-from-identifier")
+        data = {
+            "db_type": "Short citation.",
+            "db_id": 1,
+            "assessment_id": db_keys.assessment_working,
+        }
+
+        # reviewers shouldn't be able to create
+        client = APIClient()
+        assert client.login(username="reviewer@hawcproject.org", password="pw") is True
+        response = client.post(url, data)
+        assert response.status_code == 403
+
+        # public shouldn't be able to create
+        client = APIClient()
+        response = client.post(url, data)
+        assert response.status_code == 403
+
+    def test_create_from_identifier_bad_requests(self, db_keys):
+        url = reverse("study:api:study-create-from-identifier")
+        client = APIClient()
+        assert client.login(username="team@hawcproject.org", password="pw") is True
+
+        # payload must have db_type and db_id
+        data = {"assessment_id": db_keys.assessment_working}
+        response = client.post(url, data)
+        assert response.status_code == 400
+        assert str(response.data["db_type"][0]) == "This field is required."
+        assert str(response.data["db_id"][0]) == "This field is required."
+
+        # study with identifier must not already exist
+        existing_study = Study.objects.filter(
+            assessment_id=db_keys.assessment_working, identifiers__database=2
+        ).first()
+        ident = existing_study.identifiers.filter(database=2).first()
+        data = {
+            "db_type": "HERO",
+            "db_id": ident.unique_id,
+            "assessment_id": db_keys.assessment_working,
+        }
+        response = client.post(url, data)
+        assert response.status_code == 400
+        assert (
+            str(response.data["non_field_errors"][0])
+            == "Study for this assessment and identifier already exists (study 1)"
+        )
+
+        # IDs must be valid
+        data = {"db_type": "PUBMED", "db_id": -1, "assessment_id": db_keys.assessment_working}
+        response = client.post(url, data)
+        assert response.status_code == 400
+        assert (
+            str(response.data["non_field_errors"][0])
+            == "The following PubMed ID(s) could not be imported: -1"
+        )
+
+    def test_create_from_identifier_valid_requests(self, db_keys):
+        url = reverse("study:api:study-create-from-identifier")
+        client = APIClient()
+        assert client.login(username="team@hawcproject.org", password="pw") is True
+
+        # HERO request
+        data = {"db_type": "HERO", "db_id": 2199697, "assessment_id": db_keys.assessment_working}
+        response = client.post(url, data)
+        assert response.status_code == 201
+        assert (
+            Study.objects.get(pk=response.data["id"])
+            .identifiers.filter(database=2, unique_id=str(2199697))
+            .exists()
+        )
+
+        # PubMed request with additional fields
+        data = {
+            "db_type": "PUBMED",
+            "db_id": 10357793,
+            "assessment_id": db_keys.assessment_working,
+            "bioassay": True,
+        }
+        response = client.post(url, data)
+        assert response.status_code == 201
+        assert response.data["bioassay"]
+        assert (
+            Study.objects.get(pk=response.data["id"])
+            .identifiers.filter(database=1, unique_id=str(10357793))
+            .exists()
         )

--- a/tests/hawc/apps/study/test_api.py
+++ b/tests/hawc/apps/study/test_api.py
@@ -24,12 +24,7 @@ class TestStudyViewset:
         assert len(json.pop("riskofbiases")) == 1
         assert json == {
             "id": 1,
-            "assessment": {
-                "id": 1,
-                "url": "/assessment/1/",
-                "enable_risk_of_bias": True,
-                "name": "Chemical Z",
-            },
+            "assessment": {"id": 1, "url": "/assessment/1/", "enable_risk_of_bias": True, "name": "Chemical Z",},
             "searches": [],
             "identifiers": [
                 {
@@ -119,10 +114,7 @@ class TestStudyViewset:
         data["reference_id"] = db_keys.reference_linked
         response = client.post(url, data)
         assert response.status_code == 400
-        assert (
-            str(response.data[0])
-            == f"Reference ID {db_keys.reference_linked} already linked with a study."
-        )
+        assert str(response.data[0]) == f"Reference ID {db_keys.reference_linked} already linked with a study."
 
     def test_create_valid_requests(self, db_keys):
         # this is a correct request
@@ -143,10 +135,7 @@ class TestStudyViewset:
         # now that it has been create, we should not be able to create it again
         response = client.post(url, data)
         assert response.status_code == 400
-        assert (
-            str(response.data[0])
-            == f"Reference ID {db_keys.reference_unlinked} already linked with a study."
-        )
+        assert str(response.data[0]) == f"Reference ID {db_keys.reference_unlinked} already linked with a study."
 
     def test_create_from_identifier_permissions(self, db_keys):
         url = reverse("study:api:study-create-from-identifier")
@@ -167,6 +156,7 @@ class TestStudyViewset:
         response = client.post(url, data)
         assert response.status_code == 403
 
+    @pytest.mark.vcr
     def test_create_from_identifier_bad_requests(self, db_keys):
         url = reverse("study:api:study-create-from-identifier")
         client = APIClient()
@@ -180,9 +170,7 @@ class TestStudyViewset:
         assert str(response.data["db_id"][0]) == "This field is required."
 
         # study with identifier must not already exist
-        existing_study = Study.objects.filter(
-            assessment_id=db_keys.assessment_working, identifiers__database=2
-        ).first()
+        existing_study = Study.objects.filter(assessment_id=db_keys.assessment_working, identifiers__database=2).first()
         ident = existing_study.identifiers.filter(database=2).first()
         data = {
             "db_type": "HERO",
@@ -200,11 +188,9 @@ class TestStudyViewset:
         data = {"db_type": "PUBMED", "db_id": -1, "assessment_id": db_keys.assessment_working}
         response = client.post(url, data)
         assert response.status_code == 400
-        assert (
-            str(response.data["non_field_errors"][0])
-            == "The following PubMed ID(s) could not be imported: -1"
-        )
+        assert str(response.data["non_field_errors"][0]) == "The following PubMed ID(s) could not be imported: -1"
 
+    @pytest.mark.vcr
     def test_create_from_identifier_valid_requests(self, db_keys):
         url = reverse("study:api:study-create-from-identifier")
         client = APIClient()
@@ -214,11 +200,7 @@ class TestStudyViewset:
         data = {"db_type": "HERO", "db_id": 2199697, "assessment_id": db_keys.assessment_working}
         response = client.post(url, data)
         assert response.status_code == 201
-        assert (
-            Study.objects.get(pk=response.data["id"])
-            .identifiers.filter(database=2, unique_id=str(2199697))
-            .exists()
-        )
+        assert Study.objects.get(pk=response.data["id"]).identifiers.filter(database=2, unique_id=str(2199697)).exists()
 
         # PubMed request with additional fields
         data = {
@@ -231,7 +213,5 @@ class TestStudyViewset:
         assert response.status_code == 201
         assert response.data["bioassay"]
         assert (
-            Study.objects.get(pk=response.data["id"])
-            .identifiers.filter(database=1, unique_id=str(10357793))
-            .exists()
+            Study.objects.get(pk=response.data["id"]).identifiers.filter(database=1, unique_id=str(10357793)).exists()
         )


### PR DESCRIPTION
Added a form and API that allows a user to create a study from a given database (PubMed or HERO) and database ID. This also creates an identifier and reference as needed, and fails if the study already exists for an assessment.

_Other changes:_
- Refactored identifier methods to better separate validation and creation logic
  - PubMed and HERO methods now better mirror eachother, so further refactoring was done to take advantage of that
- Added PubMed imports to search API
- Fixed bug where a negative PubMed ID was allowed on a reference