### PR TITLE
metric validation in riskofbias api creation

### DIFF
--- a/hawc/apps/riskofbias/serializers.py
+++ b/hawc/apps/riskofbias/serializers.py
@@ -1,5 +1,3 @@
-import copy
-
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied, ValidationError
 from django.db import transaction
@@ -215,7 +213,7 @@ class RiskOfBiasSerializer(serializers.ModelSerializer):
             if len(extra_scores) > 0:
                 extra_scores = ", ".join(map(str, extra_scores))
                 raise serializers.ValidationError(
-                    f"Metrics {extra_scores} were submitted and are not required for this study type"
+                    f"Metrics {extra_scores} were submitted but are not required for this study type"
                 )
             for metric in required_metrics:
                 domain = metric.domain

--- a/tests/hawc/apps/riskofbias/test_api.py
+++ b/tests/hawc/apps/riskofbias/test_api.py
@@ -375,7 +375,9 @@ def test_riskofbias_create():
     resp = client.post(url, payload, format="json")
     assert resp.status_code == 400
     extra_ids = ", ".join(map(str, [metric.id for metric in extra_metrics]))
-    assert f"Metrics {extra_ids} were submitted but are not required for this study type" in str(resp.content)
+    assert f"Metrics {extra_ids} were submitted but are not required for this study type" in str(
+        resp.content
+    )
 
     # no default score submitted for a metric
     RiskOfBias.objects.all().delete()

--- a/tests/hawc/apps/riskofbias/test_api.py
+++ b/tests/hawc/apps/riskofbias/test_api.py
@@ -375,7 +375,7 @@ def test_riskofbias_create():
     resp = client.post(url, payload, format="json")
     assert resp.status_code == 400
     extra_ids = ", ".join(map(str, [metric.id for metric in extra_metrics]))
-    assert f"Metrics {extra_ids} were submitted and are not required for this study type" in str(resp.content)
+    assert f"Metrics {extra_ids} were submitted but are not required for this study type" in str(resp.content)
 
     # no default score submitted for a metric
     RiskOfBias.objects.all().delete()

--- a/tests/hawc/apps/riskofbias/test_api.py
+++ b/tests/hawc/apps/riskofbias/test_api.py
@@ -374,7 +374,8 @@ def test_riskofbias_create():
     payload = build_upload_payload(study, pm_author, new_metrics, first_valid_score)
     resp = client.post(url, payload, format="json")
     assert resp.status_code == 400
-    assert b"not required for this study type" in resp.content
+    extra_ids = ", ".join(map(str, [metric.id for metric in extra_metrics]))
+    assert f"Metrics {extra_ids} were submitted and are not required for this study type" in str(resp.content)
 
     # no default score submitted for a metric
     RiskOfBias.objects.all().delete()

--- a/tests/hawc/apps/riskofbias/test_api.py
+++ b/tests/hawc/apps/riskofbias/test_api.py
@@ -368,6 +368,14 @@ def test_riskofbias_create():
     assert resp.status_code == 400
     assert b"No score for metric" in resp.content
 
+    # metric scores submitted that are not required for the given study type
+    extra_metrics = RiskOfBiasMetric.objects.filter(required_animal=False)
+    new_metrics = required_metrics.union(extra_metrics)
+    payload = build_upload_payload(study, pm_author, new_metrics, first_valid_score)
+    resp = client.post(url, payload, format="json")
+    assert resp.status_code == 400
+    assert b"not required for this study type" in resp.content
+
     # no default score submitted for a metric
     RiskOfBias.objects.all().delete()
     payload = build_upload_payload(study, pm_author, required_metrics, first_valid_score)


### PR DESCRIPTION
Adds a validation check to the rob metric serializer; now all metric scores should have a metric_id that is in the required metrics list for the study