### PR TITLE
Build new features flags structure in hawc

### DIFF
--- a/hawc/apps/assessment/forms.py
+++ b/hawc/apps/assessment/forms.py
@@ -195,6 +195,8 @@ class AssessmentModulesForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        if not settings.HAWC_FEATURES.ENABLE_EPI_V2:
+            self.fields["epi_version"].disabled = True
         self.fields[
             "enable_risk_of_bias"
         ].label = f"Enable {self.instance.get_rob_name_display().lower()}"

--- a/hawc/apps/study/templates/study/study_detail.html
+++ b/hawc/apps/study/templates/study/study_detail.html
@@ -45,7 +45,7 @@
               {% if assessment.epi_version == 1 %}
                 <a class="dropdown-item" href="{% url 'epi:sp_create' object.pk %}">Create new study population</a>
                 <a class="dropdown-item" href="{% url 'epi:sp_copy_selector' object.pk %}">Copy from existing</a>
-              {% elif assessment.epi_version == 2 %}
+              {% elif assessment.epi_version == 2 and ENABLE_EPI_V2 %}
                 <a class="dropdown-item" href="{% url 'epiv2:design_create' object.pk %}">Create new study population</a>
               {% endif %}
             {% endif %}
@@ -111,7 +111,11 @@
       {% if assessment.epi_version == 1 %}
         {% include "epi/_studypopulation_list.html" with object_list=object.study_populations.all %}
       {% elif assessment.epi_version == 2 %}
+        {% if ENABLE_EPI_V2 %}
         {% include "epiv2/fragments/_design_list.html" with object_list=object.designs.all %}
+        {% else %}
+        <div class="alert alert-warning">We're close to release a new epi schema but not ready yet; contact us for details!</div>
+        {% endif %}
       {% endif %}
     {% endif %}
 

--- a/hawc/apps/study/views.py
+++ b/hawc/apps/study/views.py
@@ -1,4 +1,5 @@
 from django.apps import apps
+from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.db.models import Q
@@ -118,6 +119,7 @@ class StudyRead(BaseDetail):
             "attachments": self.object.get_attachments_dict() if attachments_viewable else None,
         }
         context["internal_communications"] = self.object.get_communications()
+        context["ENABLE_EPI_V2"] = settings.HAWC_FEATURES.ENABLE_EPI_V2
         return context
 
 

--- a/hawc/constants.py
+++ b/hawc/constants.py
@@ -1,6 +1,20 @@
+import os
+import json
 from enum import Enum
+
+from pydantic import BaseModel
 
 
 class AuthProvider(str, Enum):
     django = "django"
     external = "external"
+
+
+class FeatureFlags(BaseModel):
+    THIS_IS_AN_EXAMPLE: bool = True
+    ENABLE_ECO: bool = False
+    ENABLE_EPI_V2: bool = False
+
+    @classmethod
+    def from_env(cls, variable) -> "FeatureFlags":
+        return cls.parse_obj(json.loads(os.environ.get(variable, "{}")))

--- a/hawc/main/settings/base.py
+++ b/hawc/main/settings/base.py
@@ -8,7 +8,7 @@ from typing import List, Tuple
 
 from django.urls import reverse_lazy
 
-from hawc.constants import AuthProvider
+from hawc.constants import AuthProvider, FeatureFlags
 from hawc.services.utils.git import Commit
 
 PROJECT_PATH = Path(__file__).parents[2].absolute()
@@ -41,6 +41,9 @@ ADMIN_URL_PREFIX = os.getenv("ADMIN_URL_PREFIX", "f09ea0b8-c3d5-4ff9-86c4-27f00e
 
 # {PRIME, EPA}
 HAWC_FLAVOR = os.getenv("HAWC_FLAVOR", "PRIME")
+
+# Feature flags
+HAWC_FEATURES = FeatureFlags.from_env("HAWC_FEATURE_FLAGS")
 
 # Template processors
 TEMPLATES = [
@@ -123,7 +126,7 @@ INSTALLED_APPS = (
     "hawc.apps.epiv2",
 )
 
-if os.getenv("HAWC_INCLUDE_ECO", "False") == "True":
+if HAWC_FEATURES.ENABLE_ECO:
     INSTALLED_APPS = INSTALLED_APPS + ("hawc.apps.eco",)
 
 

--- a/hawc/main/settings/local.example.py
+++ b/hawc/main/settings/local.example.py
@@ -32,3 +32,6 @@ BMD_HOST = "http://example.com"  # optional; used for BMD module
 
 # SET HAWC FLAVOR (see docs)
 HAWC_FLAVOR = "PRIME"
+
+# override feature flags
+HAWC_FEATURES.THIS_IS_AN_EXAMPLE = True

--- a/tests/hawc/main/test_settings.py
+++ b/tests/hawc/main/test_settings.py
@@ -1,0 +1,23 @@
+import os
+from unittest import mock
+
+from hawc.constants import FeatureFlags
+
+TEST_ENV_VARIABLE = "_HAWC_FEATURE_FLAGS_TEST_"
+
+
+class TestFeatureFlags:
+    @mock.patch.dict(os.environ, {TEST_ENV_VARIABLE: '{"THIS_IS_AN_EXAMPLE":false}'})
+    def test_env_false(self):
+        flags = FeatureFlags.from_env(TEST_ENV_VARIABLE)
+        assert flags.THIS_IS_AN_EXAMPLE is False
+
+    @mock.patch.dict(os.environ, {TEST_ENV_VARIABLE: '{"THIS_IS_AN_EXAMPLE":true}'})
+    def test_env_true(self):
+        flags = FeatureFlags.from_env(TEST_ENV_VARIABLE)
+        assert flags.THIS_IS_AN_EXAMPLE is True
+
+    def test_no_env(self):
+        assert TEST_ENV_VARIABLE not in os.environ
+        flags = FeatureFlags.from_env(TEST_ENV_VARIABLE)
+        assert flags.THIS_IS_AN_EXAMPLE is True


### PR DESCRIPTION
Propose adding a new feature flag for enabling/disabling features during development.

The flags can be added to a standard pydantic structure in `hawc.constants`: 

```python
from pydantic import BaseModel

class FeatureFlags(BaseModel):
    THIS_IS_AN_EXAMPLE: bool = True
    ENABLE_ECO: bool = False
    ENABLE_EPI_V2: bool = False
```

Flags are available everywhere here:

```python
from django.conf import settings

assert settings.Features.THIS_IS_AN_EXAMPLE is True
```

In development environments, for most flags you can toggle them by modifying your `hawc/main/settings/local.py` file and just turning the flag on/off:

```python
# override feature flags
HAWC_FEATURES.THIS_IS_AN_EXAMPLE = True
```

In server environments, you'll save a JSON file to a environment variable, for example:

```bash
export HAWC_FEATURE_FLAGS='{"THIS_IS_AN_EXAMPLE":true}'
```
