### PR TITLE
Epiv1 ComparisonSet API Changes

### DIFF
--- a/hawc/apps/epi/api.py
+++ b/hawc/apps/epi/api.py
@@ -478,7 +478,7 @@ class Result(EditPermissionsCheckMixin, AssessmentEditViewset):
 
 
 class ComparisonSet(EditPermissionsCheckMixin, AssessmentEditViewset):
-    edit_check_keys = ["study_population"]
+    edit_check_keys = ["study_population", "outcome"]
     assessment_filter_args = "assessment"  # todo: fix
     model = models.ComparisonSet
     serializer_class = serializers.ComparisonSetSerializer

--- a/tests/hawc/apps/epi/test_api.py
+++ b/tests/hawc/apps/epi/test_api.py
@@ -945,6 +945,11 @@ class TestComparisonSetApi:
                 "expected_keys": {"study_population"},
                 "data": self.get_upload_data({"study_population": 999}),
             },
+            {
+                "desc": "cant have both study pop and outcome",
+                "expected_code": 400,
+                "data": self.get_upload_data({"outcome": generic_get_any(models.Outcome).id}),
+            },
         )
 
         generic_test_scenarios(client, url, scenarios)
@@ -984,12 +989,31 @@ class TestComparisonSetApi:
             with pytest.raises(ObjectDoesNotExist):
                 models.ComparisonSet.objects.get(id=just_created_comparison_set_id)
 
+        ExposurelessData = self.get_upload_data()
+        ExposurelessData.pop("exposure")
+        ExposurelessOutcome = self.get_upload_data({"outcome": generic_get_any(models.Outcome).id})
+        ExposurelessOutcome.pop("exposure")
+        ExposurelessOutcome.pop("study_population")
         create_scenarios = (
             {
                 "desc": "basic comparison_set creation",
                 "expected_code": 201,
                 "expected_keys": {"id"},
                 "data": self.get_upload_data(),
+                "post_request_test": comparison_set_lookup_test,
+            },
+            {
+                "desc": "no exposure comparison_set creation",
+                "expected_code": 201,
+                "expected_keys": {"id"},
+                "data": ExposurelessData,
+                "post_request_test": comparison_set_lookup_test,
+            },
+            {
+                "desc": "comparison_set creation with outcome, no exposure",
+                "expected_code": 201,
+                "expected_keys": {"id"},
+                "data": ExposurelessOutcome,
                 "post_request_test": comparison_set_lookup_test,
             },
         )


### PR DESCRIPTION
Updates made to Epiv1 API/serializer for ComparisonSets to facilitate migration of napthalene data.
- Exposures are now optional
- Study population XOR outcome is accepted for creation (previously only accepted outcomes)