### PR TITLE
Add "Other inferences" field to summary judgement cell in EPT

### DIFF
--- a/frontend/summary/summaryTable/evidenceProfileTable/IntegrationForm.js
+++ b/frontend/summary/summaryTable/evidenceProfileTable/IntegrationForm.js
@@ -111,6 +111,15 @@ const IntegrationForm = observer(props => {
                         }
                     />
                 </div>
+
+                <div className="col-md-6">
+                    <QuillTextInput
+                        label="Other inferences"
+                        helpText="Other Mode of Action (MOA) analysis inferences (e.g., judgments relevant to dose response analysis), relevant information from other sources (e.g., read across)"
+                        value={summary_judgement.other}
+                        onChange={value => store.updateValue("summary_judgement.other", value)}
+                    />
+                </div>
             </div>
         </>
     );

--- a/frontend/summary/summaryTable/evidenceProfileTable/Table.js
+++ b/frontend/summary/summaryTable/evidenceProfileTable/Table.js
@@ -85,6 +85,7 @@ class SummaryCell extends Component {
                     label="Susceptible populations and lifestages"
                     html={summary_judgement.susceptibility}
                 />
+                <TextBlock label="Other inferences" html={summary_judgement.other} />
             </td>
         );
     }

--- a/hawc/apps/assessment/migrations/0030_assessment_part1.py
+++ b/hawc/apps/assessment/migrations/0030_assessment_part1.py
@@ -157,8 +157,10 @@ class Migration(migrations.Migration):
             model_name="assessment",
             name="public_on",
             field=models.DateTimeField(
-                help_text="The date this assessment was released to be viewed by the general public.",
+                blank=True,
+                help_text="The assessment can be viewed by the general public.",
                 null=True,
+                verbose_name="Public",
             ),
         ),
         migrations.RunPython(set_public_on, unset_public_on),

--- a/hawc/apps/summary/migrations/0036_ept_summary_judgment_other.py
+++ b/hawc/apps/summary/migrations/0036_ept_summary_judgment_other.py
@@ -1,0 +1,34 @@
+from django.db import migrations
+
+
+def change_ept_settings(apps, schema_editor):
+    SummaryTable = apps.get_model("summary", "SummaryTable")
+    updates = []
+
+    for table in SummaryTable.objects.filter(table_type=1):
+        table.content["summary_judgement"]["other"] = "<p></p>"
+        updates.append(table)
+
+    SummaryTable.objects.bulk_update(updates, ["content"])
+
+
+def unchange_ept_settings(apps, schema_editor):
+    SummaryTable = apps.get_model("summary", "SummaryTable")
+    updates = []
+
+    for table in SummaryTable.objects.filter(table_type=1):
+        table.content["summary_judgement"].pop("other")
+        updates.append(table)
+
+    SummaryTable.objects.bulk_update(updates, ["content"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("summary", "0035_textures"),
+    ]
+
+    operations = [
+        migrations.RunPython(change_ept_settings, reverse_code=unchange_ept_settings),
+    ]

--- a/hawc/tools/tables/ept.py
+++ b/hawc/tools/tables/ept.py
@@ -58,6 +58,7 @@ class SummaryJudgementCell(BaseCell):
     human_relevance: str
     cross_stream_coherence: str
     susceptibility: str
+    other: str
 
     hide_content: bool
 
@@ -83,6 +84,8 @@ class SummaryJudgementCell(BaseCell):
         text += self.cross_stream_coherence
         text += tag_wrapper("\nSusceptible populations and lifestages:", "p", "em")
         text += self.susceptibility
+        text += tag_wrapper("\nOther inferences:", "p", "em")
+        text += self.other
         parser.feed(text, block)
         if self.judgement != SummaryJudgementChoices.NoJudgement:
             for paragraph in block.paragraphs[0:2]:
@@ -476,6 +479,7 @@ class EvidenceProfileTable(BaseTable):
                 "human_relevance": "<p></p>",
                 "cross_stream_coherence": "<p></p>",
                 "susceptibility": "<p></p>",
+                "other": "<p></p>",
                 "hide_content": False,
             },
         }


### PR DESCRIPTION
Added "Other inferences" to the summary judgment cell in HAWC's EPTs.

### Form
![image](https://user-images.githubusercontent.com/46504563/158903092-f8da113a-9b3b-4f0c-9866-f3df75ec5b7f.png)

### Display
|Without text|With text|
|-----|-----|
|![image](https://user-images.githubusercontent.com/46504563/158903669-07925397-22ab-4d2f-8139-861ad6fa7292.png)|![image](https://user-images.githubusercontent.com/46504563/158903792-c600d385-70ca-4729-b9d2-e36e8d5e2464.png)|