### PR TITLE
Fix "assigned tasks" pages

### DIFF
--- a/frontend/mgmt/TaskAssignments/components/RobTaskRow.js
+++ b/frontend/mgmt/TaskAssignments/components/RobTaskRow.js
@@ -3,9 +3,9 @@ import PropTypes from "prop-types";
 
 class RobTaskRow extends Component {
     render() {
-        const {assessment} = this.props.task.scores[0].metric.domain,
-            {study_name, study_id, url_edit} = this.props.task.scores[0],
-            robText = this.props.task.final ? "Edit final review" : "Edit review";
+        const {task, study} = this.props,
+            {assessment} = study,
+            robText = task.final ? "Edit final review" : "Edit review";
 
         return (
             <tr>
@@ -15,10 +15,10 @@ class RobTaskRow extends Component {
                     </td>
                 ) : null}
                 <td>
-                    <a href={`/study/${study_id}/`}>{study_name}</a>
+                    <a href={`/study/${study.id}/`}>{study.short_citation}</a>
                 </td>
                 <td>
-                    <a className="btn btn-light" href={url_edit}>
+                    <a className="btn btn-light" href={`/rob/${task.id}/update/`}>
                         <i className="fa fa-edit" /> {robText}
                     </a>
                 </td>
@@ -28,6 +28,7 @@ class RobTaskRow extends Component {
 }
 RobTaskRow.propTypes = {
     task: PropTypes.object.isRequired,
+    study: PropTypes.object.isRequired,
     showAssessment: PropTypes.bool.isRequired,
 };
 

--- a/frontend/mgmt/TaskAssignments/components/RobTasks.js
+++ b/frontend/mgmt/TaskAssignments/components/RobTasks.js
@@ -1,3 +1,5 @@
+import _ from "lodash";
+
 import React, {Component} from "react";
 import PropTypes from "prop-types";
 
@@ -5,7 +7,7 @@ import RobTaskRow from "./RobTaskRow";
 
 class RobTasks extends Component {
     render() {
-        const {tasks, showAssessment} = this.props,
+        const {tasks, studies, showAssessment} = this.props,
             hasTasks = this.props.tasks.length > 0;
         return (
             <div>
@@ -25,9 +27,17 @@ class RobTasks extends Component {
                             </tr>
                         </thead>
                         <tbody>
-                            {tasks.map((task, i) => (
-                                <RobTaskRow showAssessment={showAssessment} task={task} key={i} />
-                            ))}
+                            {tasks.map((task, i) => {
+                                let study = _.find(studies, s => s.id == task.study);
+                                return (
+                                    <RobTaskRow
+                                        showAssessment={showAssessment}
+                                        task={task}
+                                        study={study}
+                                        key={i}
+                                    />
+                                );
+                            })}
                         </tbody>
                     </table>
                 ) : (
@@ -41,6 +51,7 @@ class RobTasks extends Component {
 }
 RobTasks.propTypes = {
     tasks: PropTypes.array,
+    studies: PropTypes.array,
     showAssessment: PropTypes.bool,
 };
 

--- a/frontend/mgmt/TaskAssignments/containers/RobRoot.js
+++ b/frontend/mgmt/TaskAssignments/containers/RobRoot.js
@@ -9,7 +9,13 @@ import RobTasks from "../components/RobTasks";
 class RobRoot extends Component {
     render() {
         const store = this.props.robStore;
-        return <RobTasks tasks={store.config.rob_tasks} showAssessment={store.showAssessment} />;
+        return (
+            <RobTasks
+                tasks={store.config.rob_tasks}
+                studies={store.config.rob_studies}
+                showAssessment={store.showAssessment}
+            />
+        );
     }
 }
 

--- a/hawc/apps/mgmt/views.py
+++ b/hawc/apps/mgmt/views.py
@@ -8,6 +8,7 @@ from ..assessment.models import Assessment
 from ..common.crumbs import Breadcrumb
 from ..common.helper import WebappConfig
 from ..common.views import BaseList, LoginRequiredMixin, TeamMemberOrHigherMixin, WebappMixin
+from ..study.serializers import StudyAssessmentSerializer
 from . import models
 
 
@@ -46,11 +47,29 @@ class RobTaskMixin:
     def get_rob_queryset(self, RiskOfBias):
         raise NotImplementedError("Abstract method; requires implementation")
 
+    def set_study_ids(self, rob_qs: None):
+        if rob_qs is None:
+            RiskOfBias = apps.get_model("riskofbias", "RiskOfBias")
+            rob_qs = self.get_rob_queryset(RiskOfBias)
+        self._study_ids = rob_qs.values_list("study_id", flat=True)
+
+    def get_study_ids(self):
+        if not hasattr(self, "_study_ids"):
+            self.set_study_ids()
+        return self._study_ids
+
     def get_review_tasks(self):
         RiskOfBias = apps.get_model("riskofbias", "RiskOfBias")
         rob_tasks = self.get_rob_queryset(RiskOfBias)
+        self.set_study_ids(rob_tasks)
         filtered_tasks = [rob for rob in rob_tasks if rob.is_complete is False]
         return RiskOfBias.get_qs_json(filtered_tasks, json_encode=False)
+
+    def get_review_studies(self):
+        Study = apps.get_model("study", "Study")
+        study_qs = Study.objects.filter(id__in=self.get_study_ids())
+        study_ser = StudyAssessmentSerializer(study_qs, many=True)
+        return list(study_ser.data)
 
     def get_app_config(self, context) -> WebappConfig:
         assessment_id = self.assessment.id if hasattr(self, "assessment") else None
@@ -67,6 +86,7 @@ class RobTaskMixin:
                 "csrf": get_token(self.request),
                 "user": self.request.user.id,
                 "rob_tasks": self.get_review_tasks(),
+                "rob_studies": self.get_review_studies(),
                 "tasks": {
                     "submit_url": reverse("mgmt:api:task-list"),
                     "url": task_url,
@@ -81,7 +101,7 @@ class RobTaskMixin:
         )
 
 
-class UserAssignments(WebappMixin, RobTaskMixin, LoginRequiredMixin, ListView):
+class UserAssignments(RobTaskMixin, WebappMixin, LoginRequiredMixin, ListView):
     model = models.Task
     template_name = "mgmt/user_assignments.html"
 


### PR DESCRIPTION
If a user had any assigned and unfinished reviews then the "assigned tasks" pages would break:

- /mgmt/my-assignments/
- /mgmt/my-assignments/{assessment_id}/

Likely a regression from #469, this PR addresses this bug by making study/assessment data available again.

## After fix
### Snippet from all assigned tasks page
>![image](https://user-images.githubusercontent.com/46504563/161654831-0db031a0-f233-46ed-a95f-150698bcb634.png)
----------
### Snippet from assessment assigned tasks page
>![image](https://user-images.githubusercontent.com/46504563/161655022-c9c3f996-b18b-4135-aeeb-ba80e4e635fc.png)
----------