### PR TITLE
Add command to start postgres on windows

### DIFF
--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -201,6 +201,13 @@ On Mac/Linux; if you have tmux installed, there's a one-line command to start th
     # use the bundled dev `tmux` dev environment
     make dev
 
+On Windows; if you created the pgdata folder in %HOMEPATH%\dev, there's a short command to start the database
+
+.. code-block:: bash
+
+    # start postgres db (if pgdata folder is located in %HOMEPATH%\dev)
+    make startdb
+
 Visual Studio Code
 ------------------
 

--- a/make.bat
+++ b/make.bat
@@ -112,6 +112,6 @@ goto :eof
 cloc --exclude-dir=migrations,node_modules,public,private,vendor,venv --exclude-ext=json,yaml,svg,toml,ini --vcs=git --counted loc-files.txt .
 goto :eof
 
-:startdb  (start postgres database)
+:startdb
 pg_ctl -D %HOMEPATH%\dev\pgdata -l %HOMEPATH%\dev\pgdata\logs\logfile start
 goto :eof

--- a/make.bat
+++ b/make.bat
@@ -17,6 +17,7 @@ if /I %1 == test-refresh goto :test-refresh
 if /I %1 == test-js goto :test-js
 if /I %1 == coverage goto :coverage
 if /I %1 == loc goto :loc
+if /I %1 == startdb goto :startdb
 goto :help
 
 :help
@@ -36,6 +37,7 @@ echo.  format-py         modify python code using black and show flake8 issues
 echo.  lint-js           check for javascript formatting issues
 echo.  format-js         modify javascript code if possible using linters and formatters
 echo.  loc               generate lines of code report
+echo.  startdb           start postgres db
 goto :eof
 
 :sync-dev
@@ -108,4 +110,8 @@ goto :eof
 
 :loc
 cloc --exclude-dir=migrations,node_modules,public,private,vendor,venv --exclude-ext=json,yaml,svg,toml,ini --vcs=git --counted loc-files.txt .
+goto :eof
+
+:startdb  (start postgres database)
+pg_ctl -D %HOMEPATH%\dev\pgdata -l %HOMEPATH%\dev\pgdata\logs\logfile start
 goto :eof

--- a/make.bat
+++ b/make.bat
@@ -37,7 +37,7 @@ echo.  format-py         modify python code using black and show flake8 issues
 echo.  lint-js           check for javascript formatting issues
 echo.  format-js         modify javascript code if possible using linters and formatters
 echo.  loc               generate lines of code report
-echo.  startdb           start postgres db
+echo.  startdb           start postgres db (if pgdata folder is located in %HOMEPATH%\dev)
 goto :eof
 
 :sync-dev


### PR DESCRIPTION
Adds startdb command to make.bat, which starts the postgres database for working in a dev environment. 