### PR TITLE
update scrub_db admin names

### DIFF
--- a/hawc/apps/myuser/management/commands/scrub_db.py
+++ b/hawc/apps/myuser/management/commands/scrub_db.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
         Faker.seed(555)
 
         # slow; since we're using the same password for everyone... cache it
-        hash_password = make_password("password")
+        hash_password = make_password("pw")
 
         # generate
         for user in get_user_model().objects.all():
@@ -60,7 +60,7 @@ class Command(BaseCommand):
         )
         superuser.first_name = "Super"
         superuser.last_name = "Duper"
-        superuser.email = "webmaster@hawcproject.org"
+        superuser.email = "admin@hawcproject.org"
         superuser.external_id = "sudo"
         user.password = hash_password
         superuser.save()
@@ -71,9 +71,9 @@ class Command(BaseCommand):
         Rewrite complete!
 
         - All {num_users} users have randomly generated names and email addresses.
-        - All {num_users} users have passwords set to `password`
-        - A superuser has the username `webmaster@hawcproject.org`
-        - A superuser has the password `password`
+        - All {num_users} users have passwords set to `pw`
+        - A superuser has the username `admin@hawcproject.org`
+        - A superuser has the password `pw`
         """
         )
 

--- a/hawc/main/settings/base.py
+++ b/hawc/main/settings/base.py
@@ -171,8 +171,8 @@ CACHE_10_MIN = 60 * 10
 
 # Email settings
 EMAIL_SUBJECT_PREFIX = os.environ.get("EMAIL_SUBJECT_PREFIX", "[HAWC] ")
-DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL", "webmaster@hawcproject.org")
-SERVER_EMAIL = os.environ.get("SERVER_EMAIL", "webmaster@hawcproject.org")
+DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL", "admin@hawcproject.org")
+SERVER_EMAIL = os.environ.get("SERVER_EMAIL", "admin@hawcproject.org")
 
 # External page handlers
 EXTERNAL_CONTACT_US = os.getenv("HAWC_EXTERNAL_CONTACT_US", "")

--- a/scripts/client/bioassay-crud.ipynb
+++ b/scripts/client/bioassay-crud.ipynb
@@ -52,7 +52,7 @@
    ],
    "source": [
     "client = HawcClient('https://hawcproject.org')\n",
-    "client.authenticate(email='webmaster@hawcproject.org', password=getpass())\n",
+    "client.authenticate(email='admin@hawcproject.org', password=getpass())\n",
     "assessment_id = 100500210"
    ]
   },

--- a/scripts/client/lit-crud-references.ipynb
+++ b/scripts/client/lit-crud-references.ipynb
@@ -49,7 +49,7 @@
    ],
    "source": [
     "client = HawcClient('https://hawcproject.org')\n",
-    "client.authenticate(email='webmaster@hawcproject.org', password=getpass())\n",
+    "client.authenticate(email='admin@hawcproject.org', password=getpass())\n",
     "assessment_id = 100500159"
    ]
   },

--- a/scripts/client/lit-tagging-references.ipynb
+++ b/scripts/client/lit-tagging-references.ipynb
@@ -49,7 +49,7 @@
    ],
    "source": [
     "client = HawcClient('https://hawcproject.org')\n",
-    "client.authenticate(email='webmaster@hawcproject.org', password=getpass())\n",
+    "client.authenticate(email='admin@hawcproject.org', password=getpass())\n",
     "assessment_id = 100500210"
    ]
   },

--- a/scripts/client/r-client.ipynb
+++ b/scripts/client/r-client.ipynb
@@ -1,814 +1,662 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# R client example\n",
-    "\n",
-    "\n",
-    "This notebook serves two purposes:\n",
-    "\n",
-    "1. A demo notebook to demonstrate how to use the R client\n",
-    "2. A \"smoke-test\" noteook to ensure that the methods actually work\n",
-    "\n",
-    "For more detailed and verbose tutorials, refer to the [python tutorials](https://hawc.readthedocs.io/api.html#tutorials). The clients should be nearly identical.\n",
-    "\n",
-    "## Setup\n",
-    "\n",
-    "Install the R client:\n",
-    "\n",
-    "```R\n",
-    "devtools::install_github(\"shapiromatron/hawc\", subdir=\"client/r/rhawc\")\n",
-    "```\n",
-    "\n",
-    "Or, if in development mode:\n",
-    "\n",
-    "```R\n",
-    "# assuming jupyter was started at the root directory\n",
-    "source(\"../../client/r/rhawc/R/HawcClient.R\")\n",
-    "```\n",
-    "\n",
-    "Login and authenticate:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "base_url = \"https://hawcproject.org\"\n",
-    "email = \"admin@hawcproject.org\"\n",
-    "\n",
-    "client = HawcClient(base_url)\n",
-    "client$authenticate(email, getPass::getPass())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "HAWC R client version:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "client$version__"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "## Check read-only methods\n",
-    "\n",
-    "These are **safe** methods that do not modify any state on HAWC. They pull data from the server."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Assessment app"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "head(client$assessment_public())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "head(client$assessment_bioassay_ml_dataset())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "###  Literature app"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "assessment_id = 100000044"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "head(client$lit_tags(assessment_id))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "head(client$lit_reference_tags(assessment_id))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "head(client$lit_reference_ids(assessment_id))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "ref_ids = client$lit_references(assessment_id)\n",
-    "first_ref_id = ref_ids[1, 'HAWC.ID']\n",
-    "head(ref_ids)\n",
-    "first_ref_id"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "head(client$lit_reference(first_ref_id))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Risk of bias/study evaluation"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "assessment_id = 100000053"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "head(client$rob_data(assessment_id))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "head(client$rob_full_data(assessment_id))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Animal bioassay"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "assessment_id = 100500065"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "head(client$ani_data(assessment_id))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "head(client$ani_data_summary(assessment_id))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "resp = client$ani_endpoints(assessment_id)\n",
-    "length(resp)\n",
-    "resp[[1]]$id"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Epidemiology"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "assessment_id = 508"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "head(client$epi_data(assessment_id))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "resp = client$epi_endpoints(assessment_id)\n",
-    "length(resp)\n",
-    "resp[[1]]$id"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Epidemiology meta-analysis"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "hawc_public_client = HawcClient('https://hawcproject.org')\n",
-    "assessment_id = 94"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "head(hawc_public_client$epimeta_data(assessment_id))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### In vitro"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "assessment_id = 100000039"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "head(client$invitro_data(assessment_id))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Summary"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "assessment_id = 508"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "head(client$visual_list(assessment_id))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "## Checking destructive write methods\n",
-    "\n",
-    "These are **unsafe** methods that mutate and modify data on the server. Take care when executing these methods."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "assessment_id = 100500210"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# lit_import_hero\n",
-    "client$lit_import_hero(\n",
-    "    assessment_id = assessment_id,\n",
-    "    title = glue::glue(\"hero import {round(runif(1, 1, 1000))}\"),\n",
-    "    description = \"description\",\n",
-    "    ids = c(1037843)\n",
-    ")\n",
-    "refs = client$lit_reference_ids(assessment_id)\n",
-    "ref_id = refs[refs[, \"hero_id\"] == 1037843, \"reference_id\"]\n",
-    "ref_id"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# reference update\n",
-    "payload = list(year = 2020)\n",
-    "head(client$lit_update_reference(ref_id, data=payload))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# reference delete\n",
-    "client$lit_delete_reference(ref_id)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Complete bioassay extraction"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# lit_reference_ids\n",
-    "client$lit_import_hero(\n",
-    "    assessment_id = assessment_id,\n",
-    "    title = glue::glue(\"hero import {round(runif(1, 1, 1000))}\"),\n",
-    "    description = \"description\",\n",
-    "    ids = c(4322522)\n",
-    ")\n",
-    "refs = client$lit_reference_ids(assessment_id)\n",
-    "ref_id = refs[refs[, \"hero_id\"] == 4322522, \"reference_id\"]\n",
-    "ref_id"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# lit_import_reference_tags\n",
-    "tag_id = client$lit_tags(assessment_id)[1, \"id\"]\n",
-    "csv = glue::glue(\"reference_id,tag_id\\n{ref_id},{tag_id}\")\n",
-    "client$lit_import_reference_tags(assessment_id, csv, 'append')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# study_create\n",
-    "data = list(\n",
-    "    bioassay = TRUE,\n",
-    "    epi = FALSE,\n",
-    "    epi_meta = FALSE,\n",
-    "    in_vitro = FALSE,\n",
-    "    coi_reported = 3,\n",
-    "    coi_details = \"\",\n",
-    "    funding_source = \"Acme industries\",\n",
-    "    study_identifier = \"4322522\",\n",
-    "    contact_author = FALSE,\n",
-    "    ask_author = \"\",\n",
-    "    published = TRUE,\n",
-    "    summary = \"\",\n",
-    "    editable = TRUE\n",
-    ")\n",
-    "study = client$study_create(\n",
-    "    reference_id = ref_id,\n",
-    "    short_citation = \"York, 2003, 4322522\",\n",
-    "    full_citation = \"York RG. 2003. Oral (galvage) dosage-range developmental toxicity study of potassium perfluorobutane sulfonate (PFBS) in rats.\",\n",
-    "    data = data    \n",
-    ")\n",
-    "head(study)\n",
-    "study_id = study$id"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# rob_create\n",
-    "tryCatch({\n",
-    "    client$rob_create(study_id)\n",
-    "}, error = function(e) {\n",
-    "    cat('err caught (expected)')\n",
-    "})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# ani_create_experiment\n",
-    "data = list(\n",
-    "    study_id = study_id,     \n",
-    "    name = \"30 day oral\",     \n",
-    "    type = \"St\",\n",
-    "    has_multiple_generations = FALSE,\n",
-    "    chemical = \"2,3,7,8-Tetrachlorodibenzo-P-dioxin\",\n",
-    "    cas = \"1746-01-6\",\n",
-    "    chemical_source = \"ABC Inc.\",\n",
-    "    purity_available = TRUE,\n",
-    "    purity_qualifier = \"≥\",\n",
-    "    purity = 99.9,\n",
-    "    vehicle = \"DMSO\",\n",
-    "    guideline_compliance = \"not reported\",\n",
-    "    description = \"Details here.\"\n",
-    ")\n",
-    "experiment = client$ani_create_experiment(data)\n",
-    "experiment_id = experiment$id\n",
-    "experiment_id"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# ani_create_animal_group\n",
-    "data = list(\n",
-    "    experiment_id = experiment_id,     \n",
-    "    name = \"Female C57BL/6 Mice\",\n",
-    "    species = 2,\n",
-    "    strain = 6,\n",
-    "    sex = \"F\",\n",
-    "    animal_source = \"Charles River\",\n",
-    "    lifestage_exposed = \"Adult\",\n",
-    "    lifestage_assessed = \"Adult\",\n",
-    "    generation = \"\",\n",
-    "    comments = \"Detailed comments here\",\n",
-    "    diet = \"...\",\n",
-    "    dosing_regime=list(\n",
-    "        route_of_exposure = \"OR\",\n",
-    "        duration_exposure = 30,\n",
-    "        duration_exposure_text = \"30 days\",\n",
-    "        duration_observation = 180,\n",
-    "        num_dose_groups = 3,\n",
-    "        positive_control = TRUE,\n",
-    "        negative_control = \"VT\",\n",
-    "        description = \"...\",\n",
-    "        doses  = list(\n",
-    "            list(dose_group_id = 0, dose = 0, dose_units_id = 1),\n",
-    "            list(dose_group_id = 1, dose = 50, dose_units_id = 1),\n",
-    "            list(dose_group_id = 2, dose = 100, dose_units_id = 1),\n",
-    "            list(dose_group_id = 0, dose = 0, dose_units_id = 2),\n",
-    "            list(dose_group_id = 1, dose = 3.7, dose_units_id = 2),\n",
-    "            list(dose_group_id = 2, dose = 11.4, dose_units_id = 2)\n",
-    "        )\n",
-    "    )\n",
-    ")\n",
-    "animal_group = client$ani_create_animal_group(data)\n",
-    "animal_group_id = animal_group$id\n",
-    "animal_group_id"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "data = list(\n",
-    "    animal_group_id = animal_group_id,\n",
-    "    name = \"Relative liver weight\",\n",
-    "    system = \"Hepatic\",\n",
-    "    organ = \"Liver\",\n",
-    "    effect = \"Organ weight\",\n",
-    "    effect_subtype = \"Relative weight\",\n",
-    "    litter_effects = \"NA\",\n",
-    "    litter_effect_notes = \"\",\n",
-    "    observation_time = 104,\n",
-    "    observation_time_units = 5,\n",
-    "    observation_time_text = \"104 weeks\",\n",
-    "    data_location = \"Figure 2B\",\n",
-    "    expected_adversity_direction = 3,\n",
-    "    response_units = \"g/100g BW\",\n",
-    "    data_type = \"C\",\n",
-    "    variance_type = 1,\n",
-    "    confidence_interval = 0.95,\n",
-    "    NOEL = 1,  # should be the corresponding dose_group_id below or -999\n",
-    "    LOEL = 2,  # should be the corresponding dose_group_id below or -999\n",
-    "    FEL = -999,  # should be the corresponding dose_group_id below or -999\n",
-    "    data_reported = TRUE,\n",
-    "    data_extracted = TRUE,\n",
-    "    values_estimated = FALSE,\n",
-    "    monotonicity = 8,\n",
-    "    statistical_test = \"ANOVA + Dunnett's test\",\n",
-    "    trend_value = 0.0123,\n",
-    "    trend_result = 2,\n",
-    "    diagnostic = \"...\",\n",
-    "    power_notes = \"...\",\n",
-    "    results_notes = \"...\",\n",
-    "    endpoint_notes = \"...\",\n",
-    "    groups = list(\n",
-    "        list(\n",
-    "            dose_group_id = 0,\n",
-    "            n = 10,\n",
-    "            response = 4.35,\n",
-    "            variance = 0.29,\n",
-    "            significant = FALSE\n",
-    "        ),\n",
-    "        list(\n",
-    "            dose_group_id = 1,\n",
-    "            n = 10,\n",
-    "            response = 5.81,\n",
-    "            variance = 0.47,\n",
-    "            significant = FALSE\n",
-    "        ),\n",
-    "        list(\n",
-    "            dose_group_id = 2,\n",
-    "            n = 10,\n",
-    "            response = 7.72,\n",
-    "            variance = 0.63,\n",
-    "            significant = TRUE,\n",
-    "            significance_level = 0.035\n",
-    "        )\n",
-    "    )\n",
-    ")\n",
-    "endpoint = client$ani_create_endpoint(data)\n",
-    "glue::glue(\"{base_url}{endpoint$url}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "r"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# cleanup\n",
-    "client$lit_delete_reference(ref_id)"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "R",
-   "language": "R",
-   "name": "ir"
-  },
-  "language_info": {
-   "codemirror_mode": "r",
-   "file_extension": ".r",
-   "mimetype": "text/x-r-source",
-   "name": "R",
-   "pygments_lexer": "r",
-   "version": "3.6.1"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "# R client example\n",
+                "\n",
+                "\n",
+                "This notebook serves two purposes:\n",
+                "\n",
+                "1. A demo notebook to demonstrate how to use the R client\n",
+                "2. A \"smoke-test\" noteook to ensure that the methods actually work\n",
+                "\n",
+                "For more detailed and verbose tutorials, refer to the [python tutorials](https://hawc.readthedocs.io/api.html#tutorials). The clients should be nearly identical.\n",
+                "\n",
+                "## Setup\n",
+                "\n",
+                "Install the R client:\n",
+                "\n",
+                "```R\n",
+                "devtools::install_github(\"shapiromatron/hawc\", subdir=\"client/r/rhawc\")\n",
+                "```\n",
+                "\n",
+                "Or, if in development mode:\n",
+                "\n",
+                "```R\n",
+                "# assuming jupyter was started at the root directory\n",
+                "source(\"../../client/r/rhawc/R/HawcClient.R\")\n",
+                "```\n",
+                "\n",
+                "Login and authenticate:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "base_url = \"https://hawcproject.org\"\n",
+                "email = \"admin@hawcproject.org\"\n",
+                "\n",
+                "client = HawcClient(base_url)\n",
+                "client$authenticate(email, getPass::getPass())"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "HAWC R client version:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "client$version__"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "---\n",
+                "\n",
+                "## Check read-only methods\n",
+                "\n",
+                "These are **safe** methods that do not modify any state on HAWC. They pull data from the server."
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "### Assessment app"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "head(client$assessment_public())"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "head(client$assessment_bioassay_ml_dataset())"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "###  Literature app"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "assessment_id = 100000044"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "head(client$lit_tags(assessment_id))"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "head(client$lit_reference_tags(assessment_id))"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "head(client$lit_reference_ids(assessment_id))"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "ref_ids = client$lit_references(assessment_id)\n",
+                "first_ref_id = ref_ids[1, 'HAWC.ID']\n",
+                "head(ref_ids)\n",
+                "first_ref_id"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "head(client$lit_reference(first_ref_id))"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "### Risk of bias/study evaluation"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "assessment_id = 100000053"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "head(client$rob_data(assessment_id))"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "head(client$rob_full_data(assessment_id))"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "### Animal bioassay"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "assessment_id = 100500065"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "head(client$ani_data(assessment_id))"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "head(client$ani_data_summary(assessment_id))"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "resp = client$ani_endpoints(assessment_id)\n",
+                "length(resp)\n",
+                "resp[[1]]$id"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "### Epidemiology"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "assessment_id = 508"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "head(client$epi_data(assessment_id))"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "resp = client$epi_endpoints(assessment_id)\n",
+                "length(resp)\n",
+                "resp[[1]]$id"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "### Epidemiology meta-analysis"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "hawc_public_client = HawcClient('https://hawcproject.org')\n",
+                "assessment_id = 94"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "head(hawc_public_client$epimeta_data(assessment_id))"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "### In vitro"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "assessment_id = 100000039"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "head(client$invitro_data(assessment_id))"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "### Summary"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "assessment_id = 508"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "head(client$visual_list(assessment_id))"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "---\n",
+                "\n",
+                "## Checking destructive write methods\n",
+                "\n",
+                "These are **unsafe** methods that mutate and modify data on the server. Take care when executing these methods."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "assessment_id = 100500210"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# lit_import_hero\n",
+                "client$lit_import_hero(\n",
+                "    assessment_id = assessment_id,\n",
+                "    title = glue::glue(\"hero import {round(runif(1, 1, 1000))}\"),\n",
+                "    description = \"description\",\n",
+                "    ids = c(1037843)\n",
+                ")\n",
+                "refs = client$lit_reference_ids(assessment_id)\n",
+                "ref_id = refs[refs[, \"hero_id\"] == 1037843, \"reference_id\"]\n",
+                "ref_id"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# reference update\n",
+                "payload = list(year = 2020)\n",
+                "head(client$lit_update_reference(ref_id, data=payload))"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# reference delete\n",
+                "client$lit_delete_reference(ref_id)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "### Complete bioassay extraction"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# lit_reference_ids\n",
+                "client$lit_import_hero(\n",
+                "    assessment_id = assessment_id,\n",
+                "    title = glue::glue(\"hero import {round(runif(1, 1, 1000))}\"),\n",
+                "    description = \"description\",\n",
+                "    ids = c(4322522)\n",
+                ")\n",
+                "refs = client$lit_reference_ids(assessment_id)\n",
+                "ref_id = refs[refs[, \"hero_id\"] == 4322522, \"reference_id\"]\n",
+                "ref_id"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# lit_import_reference_tags\n",
+                "tag_id = client$lit_tags(assessment_id)[1, \"id\"]\n",
+                "csv = glue::glue(\"reference_id,tag_id\\n{ref_id},{tag_id}\")\n",
+                "client$lit_import_reference_tags(assessment_id, csv, 'append')"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# study_create\n",
+                "data = list(\n",
+                "    bioassay = TRUE,\n",
+                "    epi = FALSE,\n",
+                "    epi_meta = FALSE,\n",
+                "    in_vitro = FALSE,\n",
+                "    coi_reported = 3,\n",
+                "    coi_details = \"\",\n",
+                "    funding_source = \"Acme industries\",\n",
+                "    study_identifier = \"4322522\",\n",
+                "    contact_author = FALSE,\n",
+                "    ask_author = \"\",\n",
+                "    published = TRUE,\n",
+                "    summary = \"\",\n",
+                "    editable = TRUE\n",
+                ")\n",
+                "study = client$study_create(\n",
+                "    reference_id = ref_id,\n",
+                "    short_citation = \"York, 2003, 4322522\",\n",
+                "    full_citation = \"York RG. 2003. Oral (galvage) dosage-range developmental toxicity study of potassium perfluorobutane sulfonate (PFBS) in rats.\",\n",
+                "    data = data    \n",
+                ")\n",
+                "head(study)\n",
+                "study_id = study$id"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# rob_create\n",
+                "tryCatch({\n",
+                "    client$rob_create(study_id)\n",
+                "}, error = function(e) {\n",
+                "    cat('err caught (expected)')\n",
+                "})"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# ani_create_experiment\n",
+                "data = list(\n",
+                "    study_id = study_id,     \n",
+                "    name = \"30 day oral\",     \n",
+                "    type = \"St\",\n",
+                "    has_multiple_generations = FALSE,\n",
+                "    chemical = \"2,3,7,8-Tetrachlorodibenzo-P-dioxin\",\n",
+                "    cas = \"1746-01-6\",\n",
+                "    chemical_source = \"ABC Inc.\",\n",
+                "    purity_available = TRUE,\n",
+                "    purity_qualifier = \"≥\",\n",
+                "    purity = 99.9,\n",
+                "    vehicle = \"DMSO\",\n",
+                "    guideline_compliance = \"not reported\",\n",
+                "    description = \"Details here.\"\n",
+                ")\n",
+                "experiment = client$ani_create_experiment(data)\n",
+                "experiment_id = experiment$id\n",
+                "experiment_id"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# ani_create_animal_group\n",
+                "data = list(\n",
+                "    experiment_id = experiment_id,     \n",
+                "    name = \"Female C57BL/6 Mice\",\n",
+                "    species = 2,\n",
+                "    strain = 6,\n",
+                "    sex = \"F\",\n",
+                "    animal_source = \"Charles River\",\n",
+                "    lifestage_exposed = \"Adult\",\n",
+                "    lifestage_assessed = \"Adult\",\n",
+                "    generation = \"\",\n",
+                "    comments = \"Detailed comments here\",\n",
+                "    diet = \"...\",\n",
+                "    dosing_regime=list(\n",
+                "        route_of_exposure = \"OR\",\n",
+                "        duration_exposure = 30,\n",
+                "        duration_exposure_text = \"30 days\",\n",
+                "        duration_observation = 180,\n",
+                "        num_dose_groups = 3,\n",
+                "        positive_control = TRUE,\n",
+                "        negative_control = \"VT\",\n",
+                "        description = \"...\",\n",
+                "        doses  = list(\n",
+                "            list(dose_group_id = 0, dose = 0, dose_units_id = 1),\n",
+                "            list(dose_group_id = 1, dose = 50, dose_units_id = 1),\n",
+                "            list(dose_group_id = 2, dose = 100, dose_units_id = 1),\n",
+                "            list(dose_group_id = 0, dose = 0, dose_units_id = 2),\n",
+                "            list(dose_group_id = 1, dose = 3.7, dose_units_id = 2),\n",
+                "            list(dose_group_id = 2, dose = 11.4, dose_units_id = 2)\n",
+                "        )\n",
+                "    )\n",
+                ")\n",
+                "animal_group = client$ani_create_animal_group(data)\n",
+                "animal_group_id = animal_group$id\n",
+                "animal_group_id"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "data = list(\n",
+                "    animal_group_id = animal_group_id,\n",
+                "    name = \"Relative liver weight\",\n",
+                "    system = \"Hepatic\",\n",
+                "    organ = \"Liver\",\n",
+                "    effect = \"Organ weight\",\n",
+                "    effect_subtype = \"Relative weight\",\n",
+                "    litter_effects = \"NA\",\n",
+                "    litter_effect_notes = \"\",\n",
+                "    observation_time = 104,\n",
+                "    observation_time_units = 5,\n",
+                "    observation_time_text = \"104 weeks\",\n",
+                "    data_location = \"Figure 2B\",\n",
+                "    expected_adversity_direction = 3,\n",
+                "    response_units = \"g/100g BW\",\n",
+                "    data_type = \"C\",\n",
+                "    variance_type = 1,\n",
+                "    confidence_interval = 0.95,\n",
+                "    NOEL = 1,  # should be the corresponding dose_group_id below or -999\n",
+                "    LOEL = 2,  # should be the corresponding dose_group_id below or -999\n",
+                "    FEL = -999,  # should be the corresponding dose_group_id below or -999\n",
+                "    data_reported = TRUE,\n",
+                "    data_extracted = TRUE,\n",
+                "    values_estimated = FALSE,\n",
+                "    monotonicity = 8,\n",
+                "    statistical_test = \"ANOVA + Dunnett's test\",\n",
+                "    trend_value = 0.0123,\n",
+                "    trend_result = 2,\n",
+                "    diagnostic = \"...\",\n",
+                "    power_notes = \"...\",\n",
+                "    results_notes = \"...\",\n",
+                "    endpoint_notes = \"...\",\n",
+                "    groups = list(\n",
+                "        list(\n",
+                "            dose_group_id = 0,\n",
+                "            n = 10,\n",
+                "            response = 4.35,\n",
+                "            variance = 0.29,\n",
+                "            significant = FALSE\n",
+                "        ),\n",
+                "        list(\n",
+                "            dose_group_id = 1,\n",
+                "            n = 10,\n",
+                "            response = 5.81,\n",
+                "            variance = 0.47,\n",
+                "            significant = FALSE\n",
+                "        ),\n",
+                "        list(\n",
+                "            dose_group_id = 2,\n",
+                "            n = 10,\n",
+                "            response = 7.72,\n",
+                "            variance = 0.63,\n",
+                "            significant = TRUE,\n",
+                "            significance_level = 0.035\n",
+                "        )\n",
+                "    )\n",
+                ")\n",
+                "endpoint = client$ani_create_endpoint(data)\n",
+                "glue::glue(\"{base_url}{endpoint$url}\")"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# cleanup\n",
+                "client$lit_delete_reference(ref_id)"
+            ]
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "R",
+            "language": "R",
+            "name": "ir"
+        },
+        "language_info": {
+            "codemirror_mode": "r",
+            "file_extension": ".r",
+            "mimetype": "text/x-r-source",
+            "name": "R",
+            "pygments_lexer": "r",
+            "version": "3.6.1"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 4
 }

--- a/scripts/client/r-client.ipynb
+++ b/scripts/client/r-client.ipynb
@@ -1,662 +1,662 @@
 {
-    "cells": [
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "# R client example\n",
-                "\n",
-                "\n",
-                "This notebook serves two purposes:\n",
-                "\n",
-                "1. A demo notebook to demonstrate how to use the R client\n",
-                "2. A \"smoke-test\" noteook to ensure that the methods actually work\n",
-                "\n",
-                "For more detailed and verbose tutorials, refer to the [python tutorials](https://hawc.readthedocs.io/api.html#tutorials). The clients should be nearly identical.\n",
-                "\n",
-                "## Setup\n",
-                "\n",
-                "Install the R client:\n",
-                "\n",
-                "```R\n",
-                "devtools::install_github(\"shapiromatron/hawc\", subdir=\"client/r/rhawc\")\n",
-                "```\n",
-                "\n",
-                "Or, if in development mode:\n",
-                "\n",
-                "```R\n",
-                "# assuming jupyter was started at the root directory\n",
-                "source(\"../../client/r/rhawc/R/HawcClient.R\")\n",
-                "```\n",
-                "\n",
-                "Login and authenticate:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "base_url = \"https://hawcproject.org\"\n",
-                "email = \"admin@hawcproject.org\"\n",
-                "\n",
-                "client = HawcClient(base_url)\n",
-                "client$authenticate(email, getPass::getPass())"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "HAWC R client version:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "client$version__"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "---\n",
-                "\n",
-                "## Check read-only methods\n",
-                "\n",
-                "These are **safe** methods that do not modify any state on HAWC. They pull data from the server."
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "### Assessment app"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "head(client$assessment_public())"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "head(client$assessment_bioassay_ml_dataset())"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "###  Literature app"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "assessment_id = 100000044"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "head(client$lit_tags(assessment_id))"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "head(client$lit_reference_tags(assessment_id))"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "head(client$lit_reference_ids(assessment_id))"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "ref_ids = client$lit_references(assessment_id)\n",
-                "first_ref_id = ref_ids[1, 'HAWC.ID']\n",
-                "head(ref_ids)\n",
-                "first_ref_id"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "head(client$lit_reference(first_ref_id))"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "### Risk of bias/study evaluation"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "assessment_id = 100000053"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "head(client$rob_data(assessment_id))"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "head(client$rob_full_data(assessment_id))"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "### Animal bioassay"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "assessment_id = 100500065"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "head(client$ani_data(assessment_id))"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "head(client$ani_data_summary(assessment_id))"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "resp = client$ani_endpoints(assessment_id)\n",
-                "length(resp)\n",
-                "resp[[1]]$id"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "### Epidemiology"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "assessment_id = 508"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "head(client$epi_data(assessment_id))"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "resp = client$epi_endpoints(assessment_id)\n",
-                "length(resp)\n",
-                "resp[[1]]$id"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "### Epidemiology meta-analysis"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "hawc_public_client = HawcClient('https://hawcproject.org')\n",
-                "assessment_id = 94"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "head(hawc_public_client$epimeta_data(assessment_id))"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "### In vitro"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "assessment_id = 100000039"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "head(client$invitro_data(assessment_id))"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "### Summary"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "assessment_id = 508"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "head(client$visual_list(assessment_id))"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "---\n",
-                "\n",
-                "## Checking destructive write methods\n",
-                "\n",
-                "These are **unsafe** methods that mutate and modify data on the server. Take care when executing these methods."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "assessment_id = 100500210"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# lit_import_hero\n",
-                "client$lit_import_hero(\n",
-                "    assessment_id = assessment_id,\n",
-                "    title = glue::glue(\"hero import {round(runif(1, 1, 1000))}\"),\n",
-                "    description = \"description\",\n",
-                "    ids = c(1037843)\n",
-                ")\n",
-                "refs = client$lit_reference_ids(assessment_id)\n",
-                "ref_id = refs[refs[, \"hero_id\"] == 1037843, \"reference_id\"]\n",
-                "ref_id"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# reference update\n",
-                "payload = list(year = 2020)\n",
-                "head(client$lit_update_reference(ref_id, data=payload))"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# reference delete\n",
-                "client$lit_delete_reference(ref_id)"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                "### Complete bioassay extraction"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# lit_reference_ids\n",
-                "client$lit_import_hero(\n",
-                "    assessment_id = assessment_id,\n",
-                "    title = glue::glue(\"hero import {round(runif(1, 1, 1000))}\"),\n",
-                "    description = \"description\",\n",
-                "    ids = c(4322522)\n",
-                ")\n",
-                "refs = client$lit_reference_ids(assessment_id)\n",
-                "ref_id = refs[refs[, \"hero_id\"] == 4322522, \"reference_id\"]\n",
-                "ref_id"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# lit_import_reference_tags\n",
-                "tag_id = client$lit_tags(assessment_id)[1, \"id\"]\n",
-                "csv = glue::glue(\"reference_id,tag_id\\n{ref_id},{tag_id}\")\n",
-                "client$lit_import_reference_tags(assessment_id, csv, 'append')"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# study_create\n",
-                "data = list(\n",
-                "    bioassay = TRUE,\n",
-                "    epi = FALSE,\n",
-                "    epi_meta = FALSE,\n",
-                "    in_vitro = FALSE,\n",
-                "    coi_reported = 3,\n",
-                "    coi_details = \"\",\n",
-                "    funding_source = \"Acme industries\",\n",
-                "    study_identifier = \"4322522\",\n",
-                "    contact_author = FALSE,\n",
-                "    ask_author = \"\",\n",
-                "    published = TRUE,\n",
-                "    summary = \"\",\n",
-                "    editable = TRUE\n",
-                ")\n",
-                "study = client$study_create(\n",
-                "    reference_id = ref_id,\n",
-                "    short_citation = \"York, 2003, 4322522\",\n",
-                "    full_citation = \"York RG. 2003. Oral (galvage) dosage-range developmental toxicity study of potassium perfluorobutane sulfonate (PFBS) in rats.\",\n",
-                "    data = data    \n",
-                ")\n",
-                "head(study)\n",
-                "study_id = study$id"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# rob_create\n",
-                "tryCatch({\n",
-                "    client$rob_create(study_id)\n",
-                "}, error = function(e) {\n",
-                "    cat('err caught (expected)')\n",
-                "})"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# ani_create_experiment\n",
-                "data = list(\n",
-                "    study_id = study_id,     \n",
-                "    name = \"30 day oral\",     \n",
-                "    type = \"St\",\n",
-                "    has_multiple_generations = FALSE,\n",
-                "    chemical = \"2,3,7,8-Tetrachlorodibenzo-P-dioxin\",\n",
-                "    cas = \"1746-01-6\",\n",
-                "    chemical_source = \"ABC Inc.\",\n",
-                "    purity_available = TRUE,\n",
-                "    purity_qualifier = \"≥\",\n",
-                "    purity = 99.9,\n",
-                "    vehicle = \"DMSO\",\n",
-                "    guideline_compliance = \"not reported\",\n",
-                "    description = \"Details here.\"\n",
-                ")\n",
-                "experiment = client$ani_create_experiment(data)\n",
-                "experiment_id = experiment$id\n",
-                "experiment_id"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# ani_create_animal_group\n",
-                "data = list(\n",
-                "    experiment_id = experiment_id,     \n",
-                "    name = \"Female C57BL/6 Mice\",\n",
-                "    species = 2,\n",
-                "    strain = 6,\n",
-                "    sex = \"F\",\n",
-                "    animal_source = \"Charles River\",\n",
-                "    lifestage_exposed = \"Adult\",\n",
-                "    lifestage_assessed = \"Adult\",\n",
-                "    generation = \"\",\n",
-                "    comments = \"Detailed comments here\",\n",
-                "    diet = \"...\",\n",
-                "    dosing_regime=list(\n",
-                "        route_of_exposure = \"OR\",\n",
-                "        duration_exposure = 30,\n",
-                "        duration_exposure_text = \"30 days\",\n",
-                "        duration_observation = 180,\n",
-                "        num_dose_groups = 3,\n",
-                "        positive_control = TRUE,\n",
-                "        negative_control = \"VT\",\n",
-                "        description = \"...\",\n",
-                "        doses  = list(\n",
-                "            list(dose_group_id = 0, dose = 0, dose_units_id = 1),\n",
-                "            list(dose_group_id = 1, dose = 50, dose_units_id = 1),\n",
-                "            list(dose_group_id = 2, dose = 100, dose_units_id = 1),\n",
-                "            list(dose_group_id = 0, dose = 0, dose_units_id = 2),\n",
-                "            list(dose_group_id = 1, dose = 3.7, dose_units_id = 2),\n",
-                "            list(dose_group_id = 2, dose = 11.4, dose_units_id = 2)\n",
-                "        )\n",
-                "    )\n",
-                ")\n",
-                "animal_group = client$ani_create_animal_group(data)\n",
-                "animal_group_id = animal_group$id\n",
-                "animal_group_id"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "data = list(\n",
-                "    animal_group_id = animal_group_id,\n",
-                "    name = \"Relative liver weight\",\n",
-                "    system = \"Hepatic\",\n",
-                "    organ = \"Liver\",\n",
-                "    effect = \"Organ weight\",\n",
-                "    effect_subtype = \"Relative weight\",\n",
-                "    litter_effects = \"NA\",\n",
-                "    litter_effect_notes = \"\",\n",
-                "    observation_time = 104,\n",
-                "    observation_time_units = 5,\n",
-                "    observation_time_text = \"104 weeks\",\n",
-                "    data_location = \"Figure 2B\",\n",
-                "    expected_adversity_direction = 3,\n",
-                "    response_units = \"g/100g BW\",\n",
-                "    data_type = \"C\",\n",
-                "    variance_type = 1,\n",
-                "    confidence_interval = 0.95,\n",
-                "    NOEL = 1,  # should be the corresponding dose_group_id below or -999\n",
-                "    LOEL = 2,  # should be the corresponding dose_group_id below or -999\n",
-                "    FEL = -999,  # should be the corresponding dose_group_id below or -999\n",
-                "    data_reported = TRUE,\n",
-                "    data_extracted = TRUE,\n",
-                "    values_estimated = FALSE,\n",
-                "    monotonicity = 8,\n",
-                "    statistical_test = \"ANOVA + Dunnett's test\",\n",
-                "    trend_value = 0.0123,\n",
-                "    trend_result = 2,\n",
-                "    diagnostic = \"...\",\n",
-                "    power_notes = \"...\",\n",
-                "    results_notes = \"...\",\n",
-                "    endpoint_notes = \"...\",\n",
-                "    groups = list(\n",
-                "        list(\n",
-                "            dose_group_id = 0,\n",
-                "            n = 10,\n",
-                "            response = 4.35,\n",
-                "            variance = 0.29,\n",
-                "            significant = FALSE\n",
-                "        ),\n",
-                "        list(\n",
-                "            dose_group_id = 1,\n",
-                "            n = 10,\n",
-                "            response = 5.81,\n",
-                "            variance = 0.47,\n",
-                "            significant = FALSE\n",
-                "        ),\n",
-                "        list(\n",
-                "            dose_group_id = 2,\n",
-                "            n = 10,\n",
-                "            response = 7.72,\n",
-                "            variance = 0.63,\n",
-                "            significant = TRUE,\n",
-                "            significance_level = 0.035\n",
-                "        )\n",
-                "    )\n",
-                ")\n",
-                "endpoint = client$ani_create_endpoint(data)\n",
-                "glue::glue(\"{base_url}{endpoint$url}\")"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# cleanup\n",
-                "client$lit_delete_reference(ref_id)"
-            ]
-        }
-    ],
-    "metadata": {
-        "kernelspec": {
-            "display_name": "R",
-            "language": "R",
-            "name": "ir"
-        },
-        "language_info": {
-            "codemirror_mode": "r",
-            "file_extension": ".r",
-            "mimetype": "text/x-r-source",
-            "name": "R",
-            "pygments_lexer": "r",
-            "version": "3.6.1"
-        }
-    },
-    "nbformat": 4,
-    "nbformat_minor": 4
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# R client example\n",
+    "\n",
+    "\n",
+    "This notebook serves two purposes:\n",
+    "\n",
+    "1. A demo notebook to demonstrate how to use the R client\n",
+    "2. A \"smoke-test\" noteook to ensure that the methods actually work\n",
+    "\n",
+    "For more detailed and verbose tutorials, refer to the [python tutorials](https://hawc.readthedocs.io/api.html#tutorials). The clients should be nearly identical.\n",
+    "\n",
+    "## Setup\n",
+    "\n",
+    "Install the R client:\n",
+    "\n",
+    "```R\n",
+    "devtools::install_github(\"shapiromatron/hawc\", subdir=\"client/r/rhawc\")\n",
+    "```\n",
+    "\n",
+    "Or, if in development mode:\n",
+    "\n",
+    "```R\n",
+    "# assuming jupyter was started at the root directory\n",
+    "source(\"../../client/r/rhawc/R/HawcClient.R\")\n",
+    "```\n",
+    "\n",
+    "Login and authenticate:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "base_url = \"https://hawcproject.org\"\n",
+    "email = \"admin@hawcproject.org\"\n",
+    "\n",
+    "client = HawcClient(base_url)\n",
+    "client$authenticate(email, getPass::getPass())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "HAWC R client version:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client$version__"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Check read-only methods\n",
+    "\n",
+    "These are **safe** methods that do not modify any state on HAWC. They pull data from the server."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Assessment app"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "head(client$assessment_public())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "head(client$assessment_bioassay_ml_dataset())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "###  Literature app"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assessment_id = 100000044"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "head(client$lit_tags(assessment_id))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "head(client$lit_reference_tags(assessment_id))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "head(client$lit_reference_ids(assessment_id))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_ids = client$lit_references(assessment_id)\n",
+    "first_ref_id = ref_ids[1, 'HAWC.ID']\n",
+    "head(ref_ids)\n",
+    "first_ref_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "head(client$lit_reference(first_ref_id))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Risk of bias/study evaluation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assessment_id = 100000053"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "head(client$rob_data(assessment_id))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "head(client$rob_full_data(assessment_id))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Animal bioassay"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assessment_id = 100500065"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "head(client$ani_data(assessment_id))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "head(client$ani_data_summary(assessment_id))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resp = client$ani_endpoints(assessment_id)\n",
+    "length(resp)\n",
+    "resp[[1]]$id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Epidemiology"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assessment_id = 508"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "head(client$epi_data(assessment_id))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resp = client$epi_endpoints(assessment_id)\n",
+    "length(resp)\n",
+    "resp[[1]]$id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Epidemiology meta-analysis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hawc_public_client = HawcClient('https://hawcproject.org')\n",
+    "assessment_id = 94"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "head(hawc_public_client$epimeta_data(assessment_id))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### In vitro"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assessment_id = 100000039"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "head(client$invitro_data(assessment_id))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assessment_id = 508"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "head(client$visual_list(assessment_id))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Checking destructive write methods\n",
+    "\n",
+    "These are **unsafe** methods that mutate and modify data on the server. Take care when executing these methods."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assessment_id = 100500210"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# lit_import_hero\n",
+    "client$lit_import_hero(\n",
+    "    assessment_id = assessment_id,\n",
+    "    title = glue::glue(\"hero import {round(runif(1, 1, 1000))}\"),\n",
+    "    description = \"description\",\n",
+    "    ids = c(1037843)\n",
+    ")\n",
+    "refs = client$lit_reference_ids(assessment_id)\n",
+    "ref_id = refs[refs[, \"hero_id\"] == 1037843, \"reference_id\"]\n",
+    "ref_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# reference update\n",
+    "payload = list(year = 2020)\n",
+    "head(client$lit_update_reference(ref_id, data=payload))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# reference delete\n",
+    "client$lit_delete_reference(ref_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Complete bioassay extraction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# lit_reference_ids\n",
+    "client$lit_import_hero(\n",
+    "    assessment_id = assessment_id,\n",
+    "    title = glue::glue(\"hero import {round(runif(1, 1, 1000))}\"),\n",
+    "    description = \"description\",\n",
+    "    ids = c(4322522)\n",
+    ")\n",
+    "refs = client$lit_reference_ids(assessment_id)\n",
+    "ref_id = refs[refs[, \"hero_id\"] == 4322522, \"reference_id\"]\n",
+    "ref_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# lit_import_reference_tags\n",
+    "tag_id = client$lit_tags(assessment_id)[1, \"id\"]\n",
+    "csv = glue::glue(\"reference_id,tag_id\\n{ref_id},{tag_id}\")\n",
+    "client$lit_import_reference_tags(assessment_id, csv, 'append')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# study_create\n",
+    "data = list(\n",
+    "    bioassay = TRUE,\n",
+    "    epi = FALSE,\n",
+    "    epi_meta = FALSE,\n",
+    "    in_vitro = FALSE,\n",
+    "    coi_reported = 3,\n",
+    "    coi_details = \"\",\n",
+    "    funding_source = \"Acme industries\",\n",
+    "    study_identifier = \"4322522\",\n",
+    "    contact_author = FALSE,\n",
+    "    ask_author = \"\",\n",
+    "    published = TRUE,\n",
+    "    summary = \"\",\n",
+    "    editable = TRUE\n",
+    ")\n",
+    "study = client$study_create(\n",
+    "    reference_id = ref_id,\n",
+    "    short_citation = \"York, 2003, 4322522\",\n",
+    "    full_citation = \"York RG. 2003. Oral (galvage) dosage-range developmental toxicity study of potassium perfluorobutane sulfonate (PFBS) in rats.\",\n",
+    "    data = data    \n",
+    ")\n",
+    "head(study)\n",
+    "study_id = study$id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# rob_create\n",
+    "tryCatch({\n",
+    "    client$rob_create(study_id)\n",
+    "}, error = function(e) {\n",
+    "    cat('err caught (expected)')\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ani_create_experiment\n",
+    "data = list(\n",
+    "    study_id = study_id,     \n",
+    "    name = \"30 day oral\",     \n",
+    "    type = \"St\",\n",
+    "    has_multiple_generations = FALSE,\n",
+    "    chemical = \"2,3,7,8-Tetrachlorodibenzo-P-dioxin\",\n",
+    "    cas = \"1746-01-6\",\n",
+    "    chemical_source = \"ABC Inc.\",\n",
+    "    purity_available = TRUE,\n",
+    "    purity_qualifier = \"≥\",\n",
+    "    purity = 99.9,\n",
+    "    vehicle = \"DMSO\",\n",
+    "    guideline_compliance = \"not reported\",\n",
+    "    description = \"Details here.\"\n",
+    ")\n",
+    "experiment = client$ani_create_experiment(data)\n",
+    "experiment_id = experiment$id\n",
+    "experiment_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ani_create_animal_group\n",
+    "data = list(\n",
+    "    experiment_id = experiment_id,     \n",
+    "    name = \"Female C57BL/6 Mice\",\n",
+    "    species = 2,\n",
+    "    strain = 6,\n",
+    "    sex = \"F\",\n",
+    "    animal_source = \"Charles River\",\n",
+    "    lifestage_exposed = \"Adult\",\n",
+    "    lifestage_assessed = \"Adult\",\n",
+    "    generation = \"\",\n",
+    "    comments = \"Detailed comments here\",\n",
+    "    diet = \"...\",\n",
+    "    dosing_regime=list(\n",
+    "        route_of_exposure = \"OR\",\n",
+    "        duration_exposure = 30,\n",
+    "        duration_exposure_text = \"30 days\",\n",
+    "        duration_observation = 180,\n",
+    "        num_dose_groups = 3,\n",
+    "        positive_control = TRUE,\n",
+    "        negative_control = \"VT\",\n",
+    "        description = \"...\",\n",
+    "        doses  = list(\n",
+    "            list(dose_group_id = 0, dose = 0, dose_units_id = 1),\n",
+    "            list(dose_group_id = 1, dose = 50, dose_units_id = 1),\n",
+    "            list(dose_group_id = 2, dose = 100, dose_units_id = 1),\n",
+    "            list(dose_group_id = 0, dose = 0, dose_units_id = 2),\n",
+    "            list(dose_group_id = 1, dose = 3.7, dose_units_id = 2),\n",
+    "            list(dose_group_id = 2, dose = 11.4, dose_units_id = 2)\n",
+    "        )\n",
+    "    )\n",
+    ")\n",
+    "animal_group = client$ani_create_animal_group(data)\n",
+    "animal_group_id = animal_group$id\n",
+    "animal_group_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = list(\n",
+    "    animal_group_id = animal_group_id,\n",
+    "    name = \"Relative liver weight\",\n",
+    "    system = \"Hepatic\",\n",
+    "    organ = \"Liver\",\n",
+    "    effect = \"Organ weight\",\n",
+    "    effect_subtype = \"Relative weight\",\n",
+    "    litter_effects = \"NA\",\n",
+    "    litter_effect_notes = \"\",\n",
+    "    observation_time = 104,\n",
+    "    observation_time_units = 5,\n",
+    "    observation_time_text = \"104 weeks\",\n",
+    "    data_location = \"Figure 2B\",\n",
+    "    expected_adversity_direction = 3,\n",
+    "    response_units = \"g/100g BW\",\n",
+    "    data_type = \"C\",\n",
+    "    variance_type = 1,\n",
+    "    confidence_interval = 0.95,\n",
+    "    NOEL = 1,  # should be the corresponding dose_group_id below or -999\n",
+    "    LOEL = 2,  # should be the corresponding dose_group_id below or -999\n",
+    "    FEL = -999,  # should be the corresponding dose_group_id below or -999\n",
+    "    data_reported = TRUE,\n",
+    "    data_extracted = TRUE,\n",
+    "    values_estimated = FALSE,\n",
+    "    monotonicity = 8,\n",
+    "    statistical_test = \"ANOVA + Dunnett's test\",\n",
+    "    trend_value = 0.0123,\n",
+    "    trend_result = 2,\n",
+    "    diagnostic = \"...\",\n",
+    "    power_notes = \"...\",\n",
+    "    results_notes = \"...\",\n",
+    "    endpoint_notes = \"...\",\n",
+    "    groups = list(\n",
+    "        list(\n",
+    "            dose_group_id = 0,\n",
+    "            n = 10,\n",
+    "            response = 4.35,\n",
+    "            variance = 0.29,\n",
+    "            significant = FALSE\n",
+    "        ),\n",
+    "        list(\n",
+    "            dose_group_id = 1,\n",
+    "            n = 10,\n",
+    "            response = 5.81,\n",
+    "            variance = 0.47,\n",
+    "            significant = FALSE\n",
+    "        ),\n",
+    "        list(\n",
+    "            dose_group_id = 2,\n",
+    "            n = 10,\n",
+    "            response = 7.72,\n",
+    "            variance = 0.63,\n",
+    "            significant = TRUE,\n",
+    "            significance_level = 0.035\n",
+    "        )\n",
+    "    )\n",
+    ")\n",
+    "endpoint = client$ani_create_endpoint(data)\n",
+    "glue::glue(\"{base_url}{endpoint$url}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cleanup\n",
+    "client$lit_delete_reference(ref_id)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "R",
+   "language": "R",
+   "name": "ir"
+  },
+  "language_info": {
+   "codemirror_mode": "r",
+   "file_extension": ".r",
+   "mimetype": "text/x-r-source",
+   "name": "R",
+   "pygments_lexer": "r",
+   "version": "3.6.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/scripts/client/r-client.ipynb
+++ b/scripts/client/r-client.ipynb
@@ -35,11 +35,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "base_url = \"https://hawcproject.org\"\n",
-    "email = \"webmaster@hawcproject.org\"\n",
+    "email = \"admin@hawcproject.org\"\n",
     "\n",
     "client = HawcClient(base_url)\n",
     "client$authenticate(email, getPass::getPass())"
@@ -55,7 +59,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "client$version__"
@@ -82,7 +90,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "head(client$assessment_public())"
@@ -91,7 +103,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "head(client$assessment_bioassay_ml_dataset())"
@@ -107,7 +123,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "assessment_id = 100000044"
@@ -116,7 +136,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "head(client$lit_tags(assessment_id))"
@@ -125,7 +149,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "head(client$lit_reference_tags(assessment_id))"
@@ -134,7 +162,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "head(client$lit_reference_ids(assessment_id))"
@@ -143,7 +175,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "ref_ids = client$lit_references(assessment_id)\n",
@@ -155,7 +191,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "head(client$lit_reference(first_ref_id))"
@@ -171,7 +211,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "assessment_id = 100000053"
@@ -180,7 +224,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "head(client$rob_data(assessment_id))"
@@ -189,7 +237,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "head(client$rob_full_data(assessment_id))"
@@ -205,7 +257,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "assessment_id = 100500065"
@@ -214,7 +270,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "head(client$ani_data(assessment_id))"
@@ -223,7 +283,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "head(client$ani_data_summary(assessment_id))"
@@ -232,7 +296,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "resp = client$ani_endpoints(assessment_id)\n",
@@ -250,7 +318,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "assessment_id = 508"
@@ -259,7 +331,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "head(client$epi_data(assessment_id))"
@@ -268,7 +344,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "resp = client$epi_endpoints(assessment_id)\n",
@@ -286,7 +366,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "hawc_public_client = HawcClient('https://hawcproject.org')\n",
@@ -296,7 +380,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "head(hawc_public_client$epimeta_data(assessment_id))"
@@ -312,7 +400,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "assessment_id = 100000039"
@@ -321,7 +413,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "head(client$invitro_data(assessment_id))"
@@ -337,7 +433,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "assessment_id = 508"
@@ -346,7 +446,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "head(client$visual_list(assessment_id))"
@@ -366,7 +470,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "assessment_id = 100500210"
@@ -375,7 +483,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# lit_import_hero\n",
@@ -393,7 +505,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# reference update\n",
@@ -404,7 +520,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# reference delete\n",
@@ -421,7 +541,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# lit_reference_ids\n",
@@ -439,7 +563,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# lit_import_reference_tags\n",
@@ -451,7 +579,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# study_create\n",
@@ -483,7 +615,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# rob_create\n",
@@ -497,7 +633,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# ani_create_experiment\n",
@@ -524,7 +664,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# ani_create_animal_group\n",
@@ -567,7 +711,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "data = list(\n",
@@ -634,7 +782,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "r"
+    }
+   },
    "outputs": [],
    "source": [
     "# cleanup\n",

--- a/tests/frontend/integration/tests/login.py
+++ b/tests/frontend/integration/tests/login.py
@@ -17,7 +17,7 @@ def login(driver, root_url):
     # invalid password check
     msg = "Please enter a correct email and password."
     assert h.Text(msg).exists() is False
-    h.write("webmaster@hawcproject.org", into="Email*")
+    h.write("admin@hawcproject.org", into="Email*")
     h.write("not my password", into="Password*")
 
     # changed to target the specific login button in the form seems


### PR DESCRIPTION
Update the scrubbed database admin name and password to match the test fixture database. Less context switching between using "real" data and "test" data.

The admin email/username is `admin@hawcproject.org`, and the password is now `pw`.