### PR TITLE
"Save and continue editing" button on risk of bias form

### DIFF
--- a/frontend/riskofbias/robStudyForm/Root.js
+++ b/frontend/riskofbias/robStudyForm/Root.js
@@ -29,21 +29,35 @@ class Root extends Component {
                     })}
                     <div className="well">
                         <Completeness number={store.numIncompleteScores} />
-                        <button
-                            className="btn btn-primary mr-3"
-                            type="button"
-                            onClick={() => store.submitScores(false)}>
-                            Save and continue editing
-                        </button>
-                        <button
-                            className="btn btn-primary mr-3"
-                            type="button"
-                            onClick={() => store.submitScores(true)}>
-                            Save and return
-                        </button>
-                        <button className="btn btn-light" onClick={store.cancelSubmitScores}>
-                            Cancel
-                        </button>
+                        {store.changedSavedDiv ? (
+                            <div className="alert alert-info">
+                                <p className="mb-0">
+                                    <i className="fa fa-save mr-2" />
+                                    Changes saved!
+                                </p>
+                            </div>
+                        ) : null}
+                        <div className="d-flex justify-content-between">
+                            <button
+                                className="btn btn-primary"
+                                type="button"
+                                onClick={() => store.submitScores(false)}>
+                                Save and continue editing
+                            </button>
+                            <div>
+                                <button
+                                    className="btn btn-light mr-3"
+                                    onClick={store.cancelSubmitScores}>
+                                    Cancel
+                                </button>
+                                <button
+                                    className="btn btn-primary"
+                                    type="button"
+                                    onClick={() => store.submitScores(true)}>
+                                    Save and return
+                                </button>
+                            </div>
+                        </div>
                     </div>
                 </form>
             </div>

--- a/frontend/riskofbias/robStudyForm/Root.js
+++ b/frontend/riskofbias/robStudyForm/Root.js
@@ -30,12 +30,18 @@ class Root extends Component {
                     <div className="well">
                         <Completeness number={store.numIncompleteScores} />
                         <button
-                            className="btn btn-primary space"
+                            className="btn btn-primary mr-3"
                             type="button"
-                            onClick={store.submitScores}>
-                            Save changes
+                            onClick={() => store.submitScores(false)}>
+                            Save and continue editing
                         </button>
-                        <button className="ml-3 btn btn-light" onClick={store.cancelSubmitScores}>
+                        <button
+                            className="btn btn-primary mr-3"
+                            type="button"
+                            onClick={() => store.submitScores(true)}>
+                            Save and return
+                        </button>
+                        <button className="btn btn-light" onClick={store.cancelSubmitScores}>
                             Cancel
                         </button>
                     </div>

--- a/frontend/riskofbias/robStudyForm/store.js
+++ b/frontend/riskofbias/robStudyForm/store.js
@@ -142,7 +142,7 @@ class RobFormStore extends StudyRobStore {
     @action.bound cancelSubmitScores() {
         window.location.href = this.config.cancelUrl;
     }
-    @action.bound submitScores() {
+    @action.bound submitScores(redirect) {
         const payload = {
                 id: this.config.riskofbias.id,
                 scores: this.editableScores.map(score => {
@@ -171,9 +171,9 @@ class RobFormStore extends StudyRobStore {
         this.error = null;
         return fetch(url, opts)
             .then(response => {
-                if (response.ok) {
+                if (response.ok && redirect) {
                     window.location.href = this.config.cancelUrl;
-                } else {
+                } else if (!response.ok) {
                     response.text().then(text => {
                         this.error = text;
                     });

--- a/frontend/riskofbias/robStudyForm/store.js
+++ b/frontend/riskofbias/robStudyForm/store.js
@@ -171,9 +171,13 @@ class RobFormStore extends StudyRobStore {
         this.error = null;
         return fetch(url, opts)
             .then(response => {
-                if (response.ok && redirect) {
-                    window.location.href = this.config.cancelUrl;
-                } else if (!response.ok) {
+                if (response.ok) {
+                    if (redirect) {
+                        window.location.href = this.config.cancelUrl;
+                    } else {
+                        this.setChangedSavedDiv();
+                    }
+                } else {
                     response.text().then(text => {
                         this.error = text;
                     });
@@ -182,6 +186,13 @@ class RobFormStore extends StudyRobStore {
             .catch(error => {
                 this.error = error;
             });
+    }
+    @observable changedSavedDiv = false;
+    @action.bound setChangedSavedDiv() {
+        this.changedSavedDiv = true;
+        setTimeout(() => {
+            this.changedSavedDiv = false;
+        }, 2000);
     }
     @action.bound createScoreOverride(payload) {
         let url = `${this.config.riskofbias.scores_url}?assessment_id=${this.config.assessment_id}`,


### PR DESCRIPTION
Added a "Save and continue editing" button to the RoB form, which will save the data without redirecting the user to a different page.

![image](https://user-images.githubusercontent.com/999952/178576510-2c9c4c6e-cc60-4057-93e4-411e9360cf05.png)

Also added a "toast" (2s) to notify user when changes were saved.