### PR TITLE
fix blank text in study evaluations

### DIFF
--- a/frontend/lit/components/Reference.js
+++ b/frontend/lit/components/Reference.js
@@ -126,7 +126,7 @@ class Reference extends Component {
                 ) : null}
                 {data.has_study ? (
                     <p className="my-1">
-                        <strong>HAWC study extraction:&nbsp;</strong>
+                        <strong>HAWC study details:&nbsp;</strong>
                         <a href={reference.get_study_url()}>{data.study_short_citation}</a>
                     </p>
                 ) : null}

--- a/frontend/riskofbias/robStudyForm/Completeness.js
+++ b/frontend/riskofbias/robStudyForm/Completeness.js
@@ -6,15 +6,21 @@ class Completeness extends Component {
         let display =
             this.props.number > 0 ? (
                 <div className="alert alert-danger">
-                    <p>{this.props.number} note(s) still need input.</p>
-                    <p>
-                        Notes should only be left blank if &quot;Not applicable&quot; judgment is
-                        selected.
-                    </p>
+                    <p className="mb-0">{this.props.number} note(s) still need input.</p>
+                    <ul>
+                        <li>
+                            Notes are required the &quot;Not reported&quot; judgment is selected.
+                        </li>
+                        <li>
+                            It is recommended, but not required, to add notes for all other
+                            judgments (except for &quot;Not applicable&quot; which is
+                            self-explanatory)
+                        </li>
+                    </ul>
                 </div>
             ) : (
                 <div className="alert alert-success">
-                    <p>All items complete! Ready to submit.</p>
+                    <p className="mb-0">All items complete! Ready to submit.</p>
                 </div>
             );
         return display;

--- a/frontend/riskofbias/robStudyForm/Completeness.js
+++ b/frontend/riskofbias/robStudyForm/Completeness.js
@@ -3,27 +3,31 @@ import PropTypes from "prop-types";
 
 class Completeness extends Component {
     render() {
-        let display =
-            this.props.number > 0 ? (
-                <div className="alert alert-danger">
-                    <p className="mb-0">{this.props.number} note(s) still need input.</p>
+        const {number} = this.props,
+            className = number > 0 ? "alert alert-danger" : "alert alert-success",
+            message =
+                number === 0
+                    ? "All items complete! Ready to submit."
+                    : number === 1
+                    ? "1 item still needs input:"
+                    : `${number} items still need input:`;
+        return (
+            <div className={className}>
+                <p>{message}</p>
+                {number > 0 ? (
                     <ul>
                         <li>
-                            Notes are required the &quot;Not reported&quot; judgment is selected.
+                            Notes are required if the &quot;Not reported&quot; judgment is selected.
                         </li>
                         <li>
                             It is recommended, but not required, to add notes for all other
-                            judgments (except for &quot;Not applicable&quot; which is
+                            judgments (except for &quot;Not applicable&quot;, which is
                             self-explanatory)
                         </li>
                     </ul>
-                </div>
-            ) : (
-                <div className="alert alert-success">
-                    <p className="mb-0">All items complete! Ready to submit.</p>
-                </div>
-            );
-        return display;
+                ) : null}
+            </div>
+        );
     }
 }
 

--- a/frontend/riskofbias/robStudyForm/store.js
+++ b/frontend/riskofbias/robStudyForm/store.js
@@ -27,11 +27,15 @@ class RobFormStore extends StudyRobStore {
         return _.find(this.activeRobs, {id: this.config.riskofbias.id});
     }
     @computed get numIncompleteScores() {
-        return this.editableScores.filter(score => {
-            return (
-                _.includes(NR_KEYS, score.score) && score.notes.replace(/<\/?[^>]+(>|$)/g, "") == ""
-            );
-        }).length;
+        /*
+        A review is complete if all scores either:
+        1) have a score not equal to NR (default score when created)
+        2) have an NR score, but notes were added
+        */
+        const isIncomplete = score => {
+            return _.includes(NR_KEYS, score.score) && !h.hasInnerText(score.notes);
+        };
+        return this.editableScores.filter(isIncomplete).length;
     }
 
     updateRobScore(score, riskofbias, overrideOptions) {

--- a/frontend/shared/utils/helpers.js
+++ b/frontend/shared/utils/helpers.js
@@ -311,7 +311,7 @@ const helpers = {
         // wrap text with html tag to ensure it is a valid jQuery selector expression
         // then return whether there is text content
         return (
-            $(`<p>${text}</p>`)
+            $(`<div>${text}</div>`)
                 .text()
                 .trim().length > 0
         );

--- a/hawc/apps/riskofbias/constants.py
+++ b/hawc/apps/riskofbias/constants.py
@@ -60,6 +60,7 @@ SCORE_CHOICES: Tuple[Tuple[int, str], ...] = (
 SCORE_CHOICES_MAP: Dict[int, str] = {k: v for k, v in SCORE_CHOICES}
 
 NA_SCORES: Tuple[int, ...] = (10, 20)
+NR_SCORES: Tuple[int, ...] = (12, 22)
 
 SCORE_SYMBOLS: Dict[int, str] = {
     0: "━",

--- a/hawc/apps/riskofbias/migrations/0026_fix_blank_text.py
+++ b/hawc/apps/riskofbias/migrations/0026_fix_blank_text.py
@@ -1,0 +1,18 @@
+from django.db import migrations
+
+from ..constants import NR_SCORES
+
+
+def forwards_func(apps, schema_editor):
+    RiskOfBiasScore = apps.get_model("riskofbias", "RiskOfBiasScore")
+    RiskOfBiasScore.objects.filter(score__in=NR_SCORES, notes="<p> </p>").update(notes="<p>-</p>")
+
+
+def reverse_func(apps, schema_editor):
+    RiskOfBiasScore = apps.get_model("riskofbias", "RiskOfBiasScore")
+    RiskOfBiasScore.objects.filter(score__in=NR_SCORES, notes="<p>-</p>").update(notes="<p> </p>")
+
+
+class Migration(migrations.Migration):
+    dependencies = [("riskofbias", "0025_alter_riskofbias_study")]
+    operations = [migrations.RunPython(forwards_func, reverse_code=reverse_func)]

--- a/hawc/apps/riskofbias/models.py
+++ b/hawc/apps/riskofbias/models.py
@@ -261,18 +261,18 @@ class RiskOfBias(models.Model):
         self.save()
 
     @property
-    def is_complete(self):
+    def is_complete(self) -> bool:
         """
-        The rich text editor used for notes input adds HTML tags even if input
-        is empty, so HTML needs to be stripped out.
+        A review is complete if all scores either:
+        1) have a score not equal to NR (default score when created)
+        2) have an NR score, but notes were added
         """
-        return all(
-            [
-                len(strip_tags(score.notes).strip()) > 0
-                for score in self.scores.all()
-                if score.score not in constants.NA_SCORES
-            ]
-        )
+        incomplete = [
+            item
+            for item in self.scores.all()
+            if item.score in constants.NR_SCORES and len(strip_tags(item.notes).strip()) == 0
+        ]
+        return len(incomplete) == 0
 
     @property
     def study_reviews_complete(self):

--- a/tests/data/api/api-summary-table-set-data.json
+++ b/tests/data/api/api-summary-table-set-data.json
@@ -92,7 +92,7 @@
       "riskofbias_id": 3,
       "score_id": 6,
       "score_label": "base",
-      "score_notes": "<p>Fine, but subsets are imprortant</p>",
+      "score_notes": "<p>Fine, but subsets are important</p>",
       "score_score": 16,
       "study_id": 1
     },

--- a/tests/data/fixtures/db.yaml
+++ b/tests/data/fixtures/db.yaml
@@ -4197,7 +4197,7 @@
     label: base
     score: 16
     bias_direction: 2
-    notes: <p>Fine, but subsets are imprortant</p>
+    notes: <p>Fine, but subsets are important</p>
 - model: riskofbias.riskofbiasscore
   pk: 7
   fields:


### PR DESCRIPTION
The client and server tests for determining if a study evaluation is complete were not returning the same answer; this PR corrects this.  A study evaluation is now marked complete if the following are true:

- All non-NR scores are marked as complete
- All NR scores with non-blank text are marked as complete

The default score when a new evaluation is created is NR with blank text. These two rules ensure that each score has been "touched" in one way or another