### PR TITLE
catch Excel export IllegalCharacterException

### DIFF
--- a/hawc/apps/assessment/models.py
+++ b/hawc/apps/assessment/models.py
@@ -22,7 +22,7 @@ from reversion import revisions as reversion
 
 from hawc.services.epa.dsstox import DssSubstance
 
-from ..common.helper import HAWCDjangoJSONEncoder, SerializerHelper, new_window_a, read_excel
+from ..common.helper import HAWCDjangoJSONEncoder, SerializerHelper, new_window_a
 from ..common.models import get_private_data_storage
 from ..materialized.models import refresh_all_mvs
 from ..myuser.models import HAWCUser
@@ -796,7 +796,7 @@ class DatasetRevision(models.Model):
         """
         kwargs = {}
         if suffix == ".xlsx":
-            func = read_excel
+            func = pd.read_excel
             if worksheet_name:
                 kwargs["sheet_name"] = worksheet_name
         elif suffix in [".csv", ".tsv"]:

--- a/hawc/apps/common/helper.py
+++ b/hawc/apps/common/helper.py
@@ -31,6 +31,8 @@ def read_excel(*args, **kwargs):
     """
     We use openpyxl as the engine since the default xlrd is no longer maintained.
     """
+    # TODO - remove this - this is now the default
+    # https://pandas.pydata.org/docs/reference/api/pandas.read_excel.html
     kwargs.update(engine="openpyxl")
     return pd.read_excel(*args, **kwargs)
 

--- a/hawc/apps/common/helper.py
+++ b/hawc/apps/common/helper.py
@@ -27,16 +27,6 @@ from rest_framework.renderers import JSONRenderer
 logger = logging.getLogger(__name__)
 
 
-def read_excel(*args, **kwargs):
-    """
-    We use openpyxl as the engine since the default xlrd is no longer maintained.
-    """
-    # TODO - remove this - this is now the default
-    # https://pandas.pydata.org/docs/reference/api/pandas.read_excel.html
-    kwargs.update(engine="openpyxl")
-    return pd.read_excel(*args, **kwargs)
-
-
 def rename_duplicate_columns(df: pd.DataFrame) -> pd.DataFrame:
     """Rename column headers inplace to ensure no header names are duplicated.
 

--- a/hawc/apps/lit/api.py
+++ b/hawc/apps/lit/api.py
@@ -315,7 +315,7 @@ class LiteratureAssessmentViewset(LegacyAssessmentAdapterMixin, viewsets.Generic
             raise ValidationError({"file": "File extension must be .xlsx"})
 
         try:
-            df = pd.read_excel(file_)
+            df = pd.read_excel(file_, engine="openpyxl")
         except (BadZipFile, ValueError):
             raise ParseError({"file": "Unable to parse excel file"})
 

--- a/hawc/apps/lit/api.py
+++ b/hawc/apps/lit/api.py
@@ -25,7 +25,7 @@ from ..common.api import (
     OncePerMinuteThrottle,
     PaginationWithCount,
 )
-from ..common.helper import FlatExport, re_digits, read_excel, tryParseInt
+from ..common.helper import FlatExport, re_digits, tryParseInt
 from ..common.renderers import PandasRenderers
 from ..common.serializers import UnusedSerializer
 from ..common.views import create_object_log
@@ -315,7 +315,7 @@ class LiteratureAssessmentViewset(LegacyAssessmentAdapterMixin, viewsets.Generic
             raise ValidationError({"file": "File extension must be .xlsx"})
 
         try:
-            df = read_excel(file_)
+            df = pd.read_excel(file_)
         except (BadZipFile, ValueError):
             raise ParseError({"file": "Unable to parse excel file"})
 

--- a/hawc/apps/lit/api.py
+++ b/hawc/apps/lit/api.py
@@ -315,6 +315,7 @@ class LiteratureAssessmentViewset(LegacyAssessmentAdapterMixin, viewsets.Generic
             raise ValidationError({"file": "File extension must be .xlsx"})
 
         try:
+            # engine required since this is a BytesIO stream
             df = pd.read_excel(file_, engine="openpyxl")
         except (BadZipFile, ValueError):
             raise ParseError({"file": "Unable to parse excel file"})

--- a/hawc/apps/lit/forms.py
+++ b/hawc/apps/lit/forms.py
@@ -3,6 +3,7 @@ from io import StringIO
 from typing import Dict, List, Tuple, Union
 
 import numpy as np
+import pandas as pd
 from django import forms
 from django.db import transaction
 from django.urls import reverse, reverse_lazy
@@ -10,7 +11,6 @@ from django.urls import reverse, reverse_lazy
 from ...services.utils import ris
 from ..assessment.models import Assessment
 from ..common.forms import BaseFormHelper, addPopupLink
-from ..common.helper import read_excel
 from ..study.models import Study
 from . import constants, models
 
@@ -559,7 +559,7 @@ class ReferenceExcelUploadForm(forms.Form):
             )
 
         try:
-            df = read_excel(fn.file)
+            df = pd.read_excel(fn.file)
             df = df[["HAWC ID", "Full text URL"]]
             df["Full text URL"].fillna("", inplace=True)
             assert df["HAWC ID"].dtype == np.int64

--- a/hawc/apps/summary/forms.py
+++ b/hawc/apps/summary/forms.py
@@ -2,6 +2,7 @@ import json
 from collections import OrderedDict
 from urllib.parse import urlparse, urlunparse
 
+import pandas as pd
 from django import forms
 from django.db.models import Q
 from django.urls import reverse
@@ -13,7 +14,6 @@ from ..animal.models import Endpoint
 from ..assessment.models import DoseUnits, EffectTag
 from ..common import selectable
 from ..common.forms import ASSESSMENT_UNIQUE_MESSAGE, BaseFormHelper, form_actions_apply_filters
-from ..common.helper import read_excel
 from ..epi.models import Outcome
 from ..invitro.models import IVChemical, IVEndpointCategory
 from ..lit.models import ReferenceFilterTag
@@ -1065,7 +1065,7 @@ class DataPivotUploadForm(DataPivotForm):
             else:
                 worksheet_name = wb.sheetnames[0]
 
-            df = read_excel(excel_file, sheet_name=worksheet_name)
+            df = pd.read_excel(excel_file, sheet_name=worksheet_name)
 
             # check data
             if df.shape[0] < 2:

--- a/hawc/apps/summary/migrations/0017_datapivotupload_excel_file.py
+++ b/hawc/apps/summary/migrations/0017_datapivotupload_excel_file.py
@@ -10,8 +10,6 @@ import pandas as pd
 from django.conf import settings
 from django.db import migrations
 
-from hawc.apps.common.helper import read_excel
-
 
 def _read_tsv(fn: str, encoding: str) -> Optional[pd.DataFrame]:
     try:
@@ -22,7 +20,7 @@ def _read_tsv(fn: str, encoding: str) -> Optional[pd.DataFrame]:
 
 def _read_excel(fn: str) -> Optional[pd.DataFrame]:
     try:
-        return read_excel(fn)
+        return pd.read_excel(fn)
     except Exception:
         return None
 

--- a/hawc/apps/summary/models.py
+++ b/hawc/apps/summary/models.py
@@ -4,6 +4,7 @@ import os
 from operator import methodcaller
 from typing import Dict, List
 
+import pandas as pd
 from django.apps import apps
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
@@ -28,7 +29,6 @@ from ..common.helper import (
     HAWCDjangoJSONEncoder,
     ReportExport,
     SerializerHelper,
-    read_excel,
     tryParseInt,
 )
 from ..common.models import get_model_copy_name
@@ -711,7 +711,7 @@ class DataPivotUpload(DataPivot):
 
     def get_dataset(self) -> FlatExport:
         worksheet_name = self.worksheet_name if len(self.worksheet_name) > 0 else 0
-        df = read_excel(self.excel_file.file, sheet_name=worksheet_name)
+        df = pd.read_excel(self.excel_file.file, sheet_name=worksheet_name)
         filename = os.path.splitext(os.path.basename(self.excel_file.file.name))[0]
         return FlatExport(df=df, filename=filename)
 

--- a/hawc/templates/includes/epa/footer.html
+++ b/hawc/templates/includes/epa/footer.html
@@ -45,6 +45,7 @@
                         </div>
                         <ul class="menu">
                             <li><a href="https://www.epa.gov/home/forms/contact-us">Contact EPA</a></li>
+                            <li><a href="https://www.epa.gov/web-policies-and-procedures/epa-disclaimers">EPA Disclaimers</a></li>
                             <li><a href="https://www.epa.gov/home/epa-hotlines">Hotlines</a></li>
                             <li><a href="https://www.epa.gov/foia">FOIA Requests</a></li>
                             <li><a href="https://www.epa.gov/home/frequent-questions-specific-epa-programstopics">Frequent

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,8 +29,8 @@ myst-parser==0.16.1
 
 # computational
 numpy==1.22.2
-pandas==1.4.1
-  openpyxl==3.0.9
+pandas==1.4.3
+  openpyxl==3.0.10
 plotly==5.6.0
 pyarrow==7.0.0
 scipy==1.8.0

--- a/tests/hawc/apps/common/test_helper.py
+++ b/tests/hawc/apps/common/test_helper.py
@@ -1,6 +1,5 @@
 import time
 from io import StringIO
-from pathlib import Path
 
 import pandas as pd
 
@@ -94,15 +93,6 @@ def test_try_parse_list_ints():
     # edge cases
     assert helper.try_parse_list_ints("a") == []
     assert helper.try_parse_list_ints("1,a") == []
-
-
-def test_read_excel():
-    # excel file should be read in as a dataframe without error
-    iris_xlsx_fn = str(
-        Path(__file__).parents[3] / "data/private-data/assessment/dataset-revision/iris.xlsx"
-    )
-    df = helper.read_excel(iris_xlsx_fn)
-    assert not df.empty
 
 
 def test_int_or_float():

--- a/tests/hawc/apps/common/test_renderers.py
+++ b/tests/hawc/apps/common/test_renderers.py
@@ -119,7 +119,7 @@ def test_xlsx_renderer(basic_export):
     )
     df2 = pd.read_excel(BytesIO(response))
     assert df2.to_dict(orient="records") == [{"test": "test--test"}]
-    assert resp_obj["Content-Disposition"] == "attachment; filename=test.xlsx"
+    assert resp_obj["Content-Disposition"] == "attachment; filename=name.xlsx"
 
 
 def test_xlsx_response_error(basic_export):

--- a/tests/hawc/apps/common/test_renderers.py
+++ b/tests/hawc/apps/common/test_renderers.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 from rest_framework.test import APIRequestFactory
 
 from hawc.apps.common import renderers
-from hawc.apps.common.helper import FlatExport, read_excel
+from hawc.apps.common.helper import FlatExport
 
 
 @pytest.fixture
@@ -71,7 +71,7 @@ def test_xlsx_renderer(basic_export):
     response = renderers.PandasXlsxRenderer().render(
         data=basic_export, renderer_context={"response": resp_obj}
     )
-    df2 = read_excel(BytesIO(response))
+    df2 = pd.read_excel(BytesIO(response))
     assert df2.to_dict(orient="records") == [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
     assert resp_obj["Content-Disposition"] == "attachment; filename=fn.xlsx"
 
@@ -94,7 +94,7 @@ def test_xlsx_renderer(basic_export):
     response = renderers.PandasXlsxRenderer().render(
         data=FlatExport(df=df, filename="fn"), renderer_context={"response": Response()}
     )
-    df2 = read_excel(BytesIO(response))
+    df2 = pd.read_excel(BytesIO(response))
     assert check_is_close(df, df2) is True
 
     # with timezone
@@ -102,7 +102,7 @@ def test_xlsx_renderer(basic_export):
     response = renderers.PandasXlsxRenderer().render(
         data=FlatExport(df=df, filename="fn"), renderer_context={"response": Response()}
     )
-    df2 = read_excel(BytesIO(response))
+    df2 = pd.read_excel(BytesIO(response))
 
     # this should be incorrect initially without a timezone
     with pytest.raises(TypeError):
@@ -117,9 +117,9 @@ def test_xlsx_renderer(basic_export):
     response = renderers.PandasXlsxRenderer().render(
         data=FlatExport(df3, "name"), renderer_context={"response": resp_obj}
     )
-    df2 = read_excel(BytesIO(response))
+    df2 = pd.read_excel(BytesIO(response))
     assert df2.to_dict(orient="records") == [{"test": "test--test"}]
-    assert resp_obj["Content-Disposition"] == "attachment; filename=fn.xlsx"
+    assert resp_obj["Content-Disposition"] == "attachment; filename=test.xlsx"
 
 
 def test_xlsx_response_error(basic_export):


### PR DESCRIPTION
Updated excel exporter to check if an IllegalCharacterException is thrown, and if so, clean string data in the data frame so it should be able to be exported.

Also updated to the latest version of related packages, since they didn't appear to cause any issues:

- [pandas](https://pandas.pydata.org/docs/whatsnew/index.html): 1.4.1 -> 1.4.3
- [openpyxl](https://openpyxl.readthedocs.io/en/stable/changes.html): 3.0.9 -> 3.0.10

Also removed our custom `read_excel` method since it did what is now the [pandas default](https://pandas.pydata.org/docs/reference/api/pandas.read_excel.html) of using openpyxl

Fixes #644 