### PR TITLE
Admin diagnostics API

### DIFF
--- a/hawc/apps/hawc_admin/api.py
+++ b/hawc/apps/hawc_admin/api.py
@@ -29,4 +29,4 @@ class DiagnosticViewset(viewsets.ViewSet):
     @action(detail=False, throttle_classes=(FivePerMinuteThrottle,))
     def throttle(self, request):
         throttle = self.get_throttles()[0]
-        return Response({"ident": throttle.get_ident(request)})
+        return Response({"identity": throttle.get_ident(request)})

--- a/hawc/apps/hawc_admin/api.py
+++ b/hawc/apps/hawc_admin/api.py
@@ -4,6 +4,7 @@ from rest_framework.decorators import action
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 
+from ..common.api import OncePerMinuteThrottle
 from ..common.diagnostics import worker_healthcheck
 from ..common.helper import FlatExport
 from ..common.renderers import PandasRenderers, SvgRenderer
@@ -48,3 +49,12 @@ class HealthcheckViewset(viewsets.ViewSet):
     @action(detail=False, url_path="worker-stats", permission_classes=(permissions.IsAdminUser,))
     def worker_stats(self, request):
         return Response(worker_healthcheck.stats())
+
+
+class DebugViewset(viewsets.ViewSet):
+    permission_classes = (permissions.IsAdminUser,)
+
+    @action(detail=False, throttle_classes=(OncePerMinuteThrottle,))
+    def throttle(self, request):
+        throttle = self.get_throttles()[0]
+        return Response({"ident": throttle.get_ident(request)})

--- a/hawc/apps/hawc_admin/urls.py
+++ b/hawc/apps/hawc_admin/urls.py
@@ -14,14 +14,15 @@ from . import api, schema, views
 
 def get_admin_urlpatterns(open_api_patterns) -> List:
     """Return a list of admin patterns for inclusion. If Admin is not included via a
-    django setting; healthchecks are still included, but nothing else.
+    django setting; healthchecks and debugging are still included, but nothing else.
     """
 
     admin_url = f"admin/{settings.ADMIN_URL_PREFIX}" if settings.ADMIN_URL_PREFIX else "admin"
 
-    # always include API for healthchecks
+    # always include API for healthchecks/debugging
     router = DefaultRouter()
     router.register(r"healthcheck", api.HealthcheckViewset, basename="healthcheck")
+    router.register(r"debug", api.DebugViewset, basename="debug")
     if settings.INCLUDE_ADMIN:
         router.register(r"dashboard", api.DashboardViewset, basename="admin_dashboard")
         open_api_patterns.append(path(f"{admin_url}/api/", include(router.urls)))

--- a/hawc/apps/hawc_admin/urls.py
+++ b/hawc/apps/hawc_admin/urls.py
@@ -14,7 +14,7 @@ from . import api, schema, views
 
 def get_admin_urlpatterns(open_api_patterns) -> List:
     """Return a list of admin patterns for inclusion. If Admin is not included via a
-    django setting; healthchecks and debugging are still included, but nothing else.
+    django setting; diagnostic endpoints are still included, but nothing else.
     """
 
     admin_url = f"admin/{settings.ADMIN_URL_PREFIX}" if settings.ADMIN_URL_PREFIX else "admin"

--- a/hawc/apps/hawc_admin/urls.py
+++ b/hawc/apps/hawc_admin/urls.py
@@ -21,7 +21,7 @@ def get_admin_urlpatterns(open_api_patterns) -> List:
 
     # always include API for diagnostics
     router = DefaultRouter()
-    router.register(r"diagnostic", api.DiagnosticViewset, basename="debug")
+    router.register(r"diagnostic", api.DiagnosticViewset, basename="diagnostic")
     if settings.INCLUDE_ADMIN:
         router.register(r"dashboard", api.DashboardViewset, basename="admin_dashboard")
         open_api_patterns.append(path(f"{admin_url}/api/", include(router.urls)))


### PR DESCRIPTION
Added a viewset for admin diagnostics purposes: the first being a throttle endpoint.

`/admin/api/diagnostic/throttle/`

You must be an admin in hawc to be able to access this read-only API.