### PR TITLE
Prevent exploratory heatmaps that are too large from rendering

### DIFF
--- a/frontend/summary/summary/ExploreHeatmap.js
+++ b/frontend/summary/summary/ExploreHeatmap.js
@@ -17,16 +17,28 @@ import {NULL_VALUE} from "./constants";
 import HeatmapDatastore from "./heatmap/HeatmapDatastore";
 
 const startupHeatmapAppRender = function(el, settings, datastore, options) {
-        const store = new HeatmapDatastore(settings, datastore, options);
-        try {
+        const store = new HeatmapDatastore(settings, datastore),
+            cols = store.scales.x.filter((d, i) =>
+                settings.compress_x ? store.totals.x[i] > 0 : true
+            ).length,
+            rows = store.scales.y.filter((d, i) =>
+                settings.compress_y ? store.totals.y[i] > 0 : true
+            ).length;
+        if (cols * rows > 1000) {
+            ReactDOM.render(
+                <div className="alert alert-danger" role="alert">
+                    <i className="fa fa-exclamation-circle"></i>&nbsp;Table too large
+                </div>,
+                el
+            );
+        } else {
+            store.initialize();
             ReactDOM.render(
                 <Provider store={store}>
                     <ExploreHeatmapComponent options={options} />
                 </Provider>,
                 el
             );
-        } catch (err) {
-            ReactDOM.render(<p>An error occurred</p>, el);
         }
     },
     getErrorDiv = function() {

--- a/frontend/summary/summary/ExploreHeatmap.js
+++ b/frontend/summary/summary/ExploreHeatmap.js
@@ -59,7 +59,7 @@ class ExploreHeatmapComponent extends Component {
         if (!store.hasDataset) {
             return (
                 <div className="alert alert-danger">
-                    <p className="pb-0">
+                    <p className="mb-0">
                         <i className="fa fa-exclamation-circle"></i>&nbsp;No data are available.
                     </p>
                 </div>
@@ -70,7 +70,7 @@ class ExploreHeatmapComponent extends Component {
             const {n_rows, n_cols, n_cells, maxCells} = this.props.store;
             return (
                 <div className="alert alert-danger" role="alert">
-                    <p className="pb-0">
+                    <p className="mb-0">
                         <i className="fa fa-exclamation-circle"></i>&nbsp;This heatmap is too large
                         and cannot be rendered. Using the settings specified, the current heatmap
                         will have {n_rows} rows, {n_cols} columns, and {n_cells} cells. Please

--- a/frontend/summary/summary/heatmap/HeatmapDatastore.js
+++ b/frontend/summary/summary/heatmap/HeatmapDatastore.js
@@ -27,8 +27,7 @@ class HeatmapDatastore {
     @observable tableDataFilters = new Set();
 
     constructor(settings, dataset) {
-        this.getDetailUrl = this.getDetailUrl.bind(this);
-        this.modal = new HAWCModal();
+        // basic initialization, enough for bound checking
         this.settings = settings;
         this.dataset = applyRowFilters(
             dataset,
@@ -36,11 +35,17 @@ class HeatmapDatastore {
             settings.filtersLogic,
             settings.filtersQuery
         );
-        this.dpe = new DataPivotExtension();
         this.intersection = this.setIntersection();
-        this.filterWidgetState = this.setFilterWidgetState();
         this.scales = this.setScales();
         this.totals = this.setTotals();
+    }
+
+    initialize() {
+        // further initialization for full store use
+        this.getDetailUrl = this.getDetailUrl.bind(this);
+        this.modal = new HAWCModal();
+        this.dpe = new DataPivotExtension();
+        this.filterWidgetState = this.setFilterWidgetState();
         this.extensions = this.setDataExtensions();
         this.setColorScale();
     }

--- a/frontend/summary/summary/heatmap/HeatmapDatastore.js
+++ b/frontend/summary/summary/heatmap/HeatmapDatastore.js
@@ -19,6 +19,7 @@ class HeatmapDatastore {
     colorScale = null;
     maxValue = null;
     extensions = null;
+    maxCells = 3000;
 
     @observable dataset = null;
     @observable settings = null;
@@ -228,13 +229,42 @@ class HeatmapDatastore {
             .range(this.settings.color_range);
     }
 
-    @computed
-    get getFilterHash() {
+    @computed get settingsHash() {
+        return h.hashString(JSON.stringify(this.settings));
+    }
+
+    @computed get hasDataset() {
+        return this.dataset !== null && this.dataset.length > 0;
+    }
+
+    @computed get n_rows() {
+        return this.scales.y.filter((d, i) =>
+            this.settings.compress_y ? this.totals.y[i] > 0 : true
+        ).length;
+    }
+
+    @computed get n_cols() {
+        return this.scales.x.filter((d, i) =>
+            this.settings.compress_x ? this.totals.x[i] > 0 : true
+        ).length;
+    }
+
+    @computed get n_cells() {
+        return this.n_rows * this.n_cols;
+    }
+
+    @computed get withinRenderableBounds() {
+        // ensure that the heatmap being generate is of a reasonable size that it could
+        // potentially be calculated. In some cases users may configure settings that generate
+        // a heatmap so large it becomes too large to reasonably compute.
+        return this.n_cells <= this.maxCells;
+    }
+
+    @computed get getFilterHash() {
         return h.hashString(JSON.stringify(toJS(this.filterWidgetState)));
     }
 
-    @computed
-    get rowsRemovedByFilters() {
+    @computed get rowsRemovedByFilters() {
         // returns a Set of row indexes to remove
         let removedRows = [];
         const {intersection} = this;
@@ -253,8 +283,7 @@ class HeatmapDatastore {
         return new Set(removedRows);
     }
 
-    @computed
-    get usableRows() {
+    @computed get usableRows() {
         /*
         Return a Set of row indices which should be presented in heatmap.
         If `settings.show_null`, use all row indices. If false, filter rows which are non-null for
@@ -279,8 +308,7 @@ class HeatmapDatastore {
         }
     }
 
-    @computed
-    get matrixDataset() {
+    @computed get matrixDataset() {
         // build the dataset required to generate the matrix
         const hash = this.getFilterHash;
         if (this.matrixDatasetCache[hash]) {
@@ -374,8 +402,7 @@ class HeatmapDatastore {
         return xy_map;
     }
 
-    @computed
-    get getTableData() {
+    @computed get getTableData() {
         let rows, data;
         if (this.tableDataFilters.size > 0) {
             let filtered_rows = [...this.tableDataFilters].map(

--- a/frontend/summary/summaryForms/heatmap/VisualCustomizationPanel.js
+++ b/frontend/summary/summaryForms/heatmap/VisualCustomizationPanel.js
@@ -99,14 +99,14 @@ class VisualCustomizationPanel extends Component {
 
                 <div className="card">
                     <div className="card-body">
-                        <h4 className="card-title">X fields</h4>
+                        <h4 className="card-title">Columns</h4>
                         <AxisLabelTable settingsKey={"x_fields"} />
                     </div>
                 </div>
 
                 <div className="card">
                     <div className="card-body">
-                        <h4 className="card-title">Y fields</h4>
+                        <h4 className="card-title">Rows</h4>
                         <AxisLabelTable settingsKey={"y_fields"} />
                     </div>
                 </div>


### PR DESCRIPTION
The computed `matrixDataset` is the first hurdle when it comes to rendering large heatmaps: the fix here is to split the `HeatmapDatastore` constructor so that a few properties set in the constructor are used to determine if the heatmap is too large, while the `initialize` method continues the computation intensive initialization.

![image](https://user-images.githubusercontent.com/999952/180880118-4b23a841-e5ae-46fd-845e-839892888361.png)


Note:
- It still hangs a little to perform the basic calculations to determine table size when the table is REALLY large, but it should not freeze the page.