### PR TITLE
Correctly populate vocabulary terms on animal endpoint form

### DIFF
--- a/hawc/apps/animal/models.py
+++ b/hawc/apps/animal/models.py
@@ -1008,16 +1008,19 @@ class Endpoint(BaseEndpoint):
                 "vocabulary": assessment.vocabulary,
                 "vocabulary_display": assessment.get_vocabulary_display(),
                 "object": {
-                    "system": form.initial.get("system", ""),
-                    "organ": form.initial.get("organ", ""),
-                    "effect": form.initial.get("effect", ""),
-                    "effect_subtype": form.initial.get("effect_subtype", ""),
-                    "name": form.initial.get("name", ""),
-                    "system_term_id": form.initial.get("system_term", None),
-                    "organ_term_id": form.initial.get("organ_term", None),
-                    "effect_term_id": form.initial.get("effect_term", None),
-                    "effect_subtype_term_id": form.initial.get("effect_subtype_term", None),
-                    "name_term_id": form.initial.get("name_term", None),
+                    field: form[field].value()
+                    for field in [
+                        "system",
+                        "organ",
+                        "effect",
+                        "effect_subtype",
+                        "name",
+                        "system_term_id",
+                        "organ_term_id",
+                        "effect_term_id",
+                        "effect_subtype_term_id",
+                        "name_term_id",
+                    ]
                 },
             }
         )

--- a/hawc/apps/animal/models.py
+++ b/hawc/apps/animal/models.py
@@ -1008,19 +1008,16 @@ class Endpoint(BaseEndpoint):
                 "vocabulary": assessment.vocabulary,
                 "vocabulary_display": assessment.get_vocabulary_display(),
                 "object": {
-                    field: form[field].value()
-                    for field in [
-                        "system",
-                        "organ",
-                        "effect",
-                        "effect_subtype",
-                        "name",
-                        "system_term_id",
-                        "organ_term_id",
-                        "effect_term_id",
-                        "effect_subtype_term_id",
-                        "name_term_id",
-                    ]
+                    "system": form["system"].value(),
+                    "organ": form["organ"].value(),
+                    "effect": form["effect"].value(),
+                    "effect_subtype": form["effect_subtype"].value(),
+                    "name": form["name"].value(),
+                    "system_term_id": form["system_term"].value(),
+                    "organ_term_id": form["organ_term"].value(),
+                    "effect_term_id": form["effect_term"].value(),
+                    "effect_subtype_term_id": form["effect_subtype_term"].value(),
+                    "name_term_id": form["name_term"].value(),
                 },
             }
         )


### PR DESCRIPTION
When validation fails on endpoint create, the previous vocabulary terms put into the form were lost. This is because it was relying on values from `form.initial` instead of `form.data`!

This fix uses the `BoundField` value instead of values from `form.initial` when rendering the form; this will get the correct value since it takes into account whether the form is bound or not.