### PR TITLE
fix image download redirect bug

### DIFF
--- a/frontend/shared/utils/rasterize.js
+++ b/frontend/shared/utils/rasterize.js
@@ -9,6 +9,7 @@ const URL_TEMPLATES = "/rasterize/",
         a.href = url;
         a.download = filename ? filename[1] : "download.txt";
         a.className = "hidden";
+        a.target = "_blank";
         document.body.appendChild(a);
         a.click();
         a.remove();


### PR DESCRIPTION
Fixes a bug where downloading a visual as a PNG or SVG on the live site would instead redirect to a new page.

Related fix: https://stackoverflow.com/questions/62828321/

It looks like it's related to the google tag manager, which is only enabled in produciton.