### PR TITLE
Make unique id for select2 components more robust

### DIFF
--- a/hawc/static/patched/dal/3.9.4/js/autocomplete_light.js
+++ b/hawc/static/patched/dal/3.9.4/js/autocomplete_light.js
@@ -13,7 +13,7 @@ var yl = yl || {};
  * Also add a global counter for initialized select2 components.
  */
 yl.functions = yl.functions || {};
-yl.counter = yl.counter || 0
+yl.idCounter = yl.idCounter || 0;
 /* HAWC CHANGES END */
 
 /**
@@ -167,7 +167,7 @@ window.addEventListener("load", function () {
        */
       $(element).attr(
         "data-select2-id",
-        `select2-data-${element.id}-${++yl.counter}-${Math.floor(Math.random() * 1000) + 1}`
+        `select2-data-${element.id}-${++yl.idCounter}-${Math.floor(Math.random() * 10000) + 1}`
       );
       /* HAWC CHANGES END */
 

--- a/hawc/static/patched/dal/3.9.4/js/autocomplete_light.js
+++ b/hawc/static/patched/dal/3.9.4/js/autocomplete_light.js
@@ -10,8 +10,10 @@ var yl = yl || {};
  * HAWC CHANGES START
  *
  * Functions shouldn't be lost if this script is loaded again.
+ * Also add a global counter for initialized select2 components.
  */
 yl.functions = yl.functions || {};
+yl.counter = yl.counter || 0
 /* HAWC CHANGES END */
 
 /**
@@ -163,7 +165,10 @@ window.addEventListener("load", function () {
        *
        * Add a unique identifier to element; needed if element id is not unique
        */
-      $(element).attr("data-select2-id", Math.floor(Math.random() * 1000) + 1);
+      $(element).attr(
+        "data-select2-id",
+        `select2-data-${element.id}-${++yl.counter}-${Math.floor(Math.random() * 1000) + 1}`
+      );
       /* HAWC CHANGES END */
 
       // The DAL function to execute.


### PR DESCRIPTION
Adds a global counter that increments when a select2 component is initialized. This is used in combination with the input element's id and a randomly generated number to create a more robust unique id for each select2 component.