### PR TITLE
SVG rasterization fixes

### DIFF
--- a/frontend/shared/components/VisualToolbar.js
+++ b/frontend/shared/components/VisualToolbar.js
@@ -75,6 +75,12 @@ class VisualToolbar extends Component {
                         <a className="dropdown-item" href="#" onClick={() => rasterize(svg, "png")}>
                             <i className="fa fa-fw fa-picture-o"></i>&nbsp;Download PNG
                         </a>
+                        <a
+                            className="dropdown-item"
+                            href="#"
+                            onClick={() => rasterize(svg, "jpeg")}>
+                            <i className="fa fa-fw fa-picture-o"></i>&nbsp;Download JPEG
+                        </a>
                     </div>
                 </div>
             </div>

--- a/frontend/shared/utils/D3Plot.js
+++ b/frontend/shared/utils/D3Plot.js
@@ -548,7 +548,10 @@ class D3Plot {
                         ).on("click", () => handleClick("svg")),
                         $(
                             '<button class="dropdown-item"><i class="fa fa-fw fa-picture-o"></i>&nbsp;Download as a PNG</button>'
-                        ).on("click", () => handleClick("png"))
+                        ).on("click", () => handleClick("png")),
+                        $(
+                            '<button class="dropdown-item"><i class="fa fa-fw fa-picture-o"></i>&nbsp;Download as a JPEG</button>'
+                        ).on("click", () => handleClick("jpeg"))
                     )
                 )
             );

--- a/frontend/shared/utils/rasterize.js
+++ b/frontend/shared/utils/rasterize.js
@@ -3,6 +3,10 @@ import * as d3 from "d3";
 const URL_TEMPLATES = "/rasterize/",
     downloadBlob = (blob, contentDisposition) => {
         // https://stackoverflow.com/a/42274086/906385
+        if (!blob) {
+            alert("An error occurred; no download available.");
+            return;
+        }
         const url = window.URL.createObjectURL(blob),
             a = document.createElement("a"),
             filename = /filename="(.+?)"/.exec(contentDisposition);
@@ -49,15 +53,22 @@ const URL_TEMPLATES = "/rasterize/",
             downloadBlob(blob, 'attachment; filename="download.svg"');
         });
     },
-    toPng = svgElement => {
+    getScalingFactor = maxDim => {
+        // There is a maximum canvas size of 32767; we make sure we don't go beyond this
+        // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas#maximum_canvas_size
+        return maxDim * 5 > 32000 ? 32000 / maxDim : 5;
+    },
+    toRaster = (svgElement, mime) => {
         getSvgString(svgElement, svgStr => {
             const canvas = document.createElement("canvas"),
                 ctx = canvas.getContext("2d"),
-                bb = svgElement.getBBox(),
+                bb = svgElement.getBoundingClientRect(),
                 img = document.createElement("img"),
-                height = Math.ceil(bb.height * 5),
-                width = Math.ceil(bb.width * 5),
-                imgData = "data:image/svg+xml;base64," + btoa(unescape(encodeURIComponent(svgStr)));
+                scaling = getScalingFactor(Math.max(bb.height, bb.width)),
+                height = Math.ceil(bb.height * scaling),
+                width = Math.ceil(bb.width * scaling),
+                imgData = "data:image/svg+xml;base64," + btoa(unescape(encodeURIComponent(svgStr))),
+                extension = mime.slice(mime.match("/").index + 1);
 
             // set canvas size equal to the image plus a few extra pixels for border
             canvas.height = height + 3;
@@ -71,8 +82,9 @@ const URL_TEMPLATES = "/rasterize/",
                 ctx.drawImage(img, 0, 0, width, height);
                 drawBorder(ctx, width, height);
                 canvas.toBlob(
-                    blob => downloadBlob(blob, 'attachment; filename="download.png"'),
-                    "image/png"
+                    blob => downloadBlob(blob, `attachment; filename="download.${extension}"`),
+                    mime,
+                    0.95
                 );
             };
         });
@@ -83,7 +95,10 @@ const URL_TEMPLATES = "/rasterize/",
                 toSvg(svgElement);
                 break;
             case "png":
-                toPng(svgElement);
+                toRaster(svgElement, "image/png");
+                break;
+            case "jpeg":
+                toRaster(svgElement, "image/jpeg");
                 break;
             default:
                 throw `Invalid format ${format}`;


### PR DESCRIPTION
Add JPEG export format for downloading large visuals where compression is needed:

![image](https://user-images.githubusercontent.com/999952/197074288-363b475c-a8de-4cda-987d-6b030dbd968e.png)

Fixed two additional issues:

1. Fixed cases where the rasterized image was scaling incorrectly (use `getBoundingClientRect`)
2. Fixed cases where extremely large canvas (>32k pixel height/width) cannot be exported because of [browser limits](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas#maximum_canvas_size)
