### PR TITLE
hotfix - dose-group count in data pivot

### DIFF
--- a/hawc/apps/animal/exports.py
+++ b/hawc/apps/animal/exports.py
@@ -593,6 +593,8 @@ class EndpointFlatDataPivot(EndpointGroupFlatDataPivot):
             tres = [dose["treatment_effect"] for dose in ser["groups"]]
             tres.extend([None] * (self.num_doses - len(tres)))
             row.extend(tres)
+            if len(tres) != len(dose_list):
+                raise ValueError("TODO - fix")
 
             row.extend(
                 [self.rob_data[(ser["id"], metric_id)] for metric_id in self.rob_headers.keys()]


### PR DESCRIPTION
Fixed a rare edge case where the number of dose-groups for a given tabular set may be greater than the total number of dose groups for a visual, for endpoints with many dose groups but no data are extracted. This change made the code more confusing, so a comment was added to describe why it's required.