### PR TITLE
Enable deletion of resolved reference tags

### DIFF
--- a/frontend/lit/Reference.js
+++ b/frontend/lit/Reference.js
@@ -8,7 +8,7 @@ class Reference {
         this.data = data;
         this._quickSearchText = `${data.title}-${data.year}-${data.authors}-${data.authors_short}`.toLowerCase();
         this.tags = data.tags.map(tagId => tagtree.dict[tagId]);
-        this.userTags = data.user_tags ? data.user_tags.map(tagId => tagtree.dict[tagId]) : [];
+        this.userTags = data.user_tags ? data.user_tags.map(tagId => tagtree.dict[tagId]) : null;
     }
 
     static get_detail_url(id, subtype) {

--- a/frontend/lit/TagReferences/Main.js
+++ b/frontend/lit/TagReferences/Main.js
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import {toJS} from "mobx";
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
@@ -145,22 +144,14 @@ class TagReferencesMain extends Component {
                                         }
                                         className={
                                             store.config.conflict_resolution
-                                                ? _.find(
-                                                      selectedReferenceUserTags,
-                                                      e => e.data.pk == tag.data.pk
-                                                  )
+                                                ? store.hasTag(selectedReferenceUserTags, tag)
                                                     ? "refTag refTagEditing"
                                                     : "refTag refUserTagDiff refTagEditing"
                                                 : "refTag refTagEditing"
                                         }
                                         onClick={
                                             store.config.conflict_resolution
-                                                ? _.find(
-                                                      selectedReferenceUserTags,
-                                                      e => e.data.pk == tag.data.pk
-                                                  )
-                                                    ? () => store.removeTag(tag)
-                                                    : () => store.addTag(tag)
+                                                ? () => store.toggleTag(tag)
                                                 : () => store.removeTag(tag)
                                         }>
                                         {this.state.showFullTag
@@ -169,13 +160,7 @@ class TagReferencesMain extends Component {
                                     </span>
                                 ))}
                                 {selectedReferenceUserTags
-                                    .filter(
-                                        tag =>
-                                            !_.find(
-                                                selectedReferenceTags,
-                                                e => e.data.pk == tag.data.pk
-                                            )
-                                    )
+                                    .filter(tag => !store.hasTag(selectedReferenceTags, tag))
                                     .map((tag, i) => (
                                         <span
                                             key={i}

--- a/frontend/lit/TagReferences/Main.js
+++ b/frontend/lit/TagReferences/Main.js
@@ -20,7 +20,7 @@ class ReferenceListItem extends Component {
             title = store.config.conflict_resolution ? "has resolved tag(s)" : "tagged";
 
         return (
-            <div className={divClass} onClick={() => store.changeSelectedReference(reference)}>
+            <div className={divClass} onClick={() => store.setReference(reference)}>
                 <p className="mb-0 pr-1">{reference.shortCitation()}</p>
                 {reference.tags.length > 0 ? (
                     <i className="fa fa-fw fa-tags mx-1" title={title} aria-hidden="true"></i>
@@ -62,11 +62,8 @@ class TagReferencesMain extends Component {
     }
     render() {
         const {store} = this.props,
-            selectedReferencePk = store.selectedReference ? store.selectedReference.data.pk : null,
-            selectedReferenceTags = store.selectedReferenceTags ? store.selectedReferenceTags : [],
-            selectedReferenceUserTags = store.selectedReferenceUserTags
-                ? store.selectedReferenceUserTags
-                : [];
+            {hasReference, reference, referenceTags, referenceUserTags} = store,
+            selectedReferencePk = hasReference ? reference.data.pk : -1; // -1 will never match
         return (
             <div className="row">
                 <div className={store.filterClass} id="refFilter">
@@ -94,7 +91,7 @@ class TagReferencesMain extends Component {
                     </div>
                 </div>
                 <div className={store.filterClass} id="taggingCol">
-                    {store.selectedReference ? (
+                    {store.hasReference ? (
                         <div>
                             <div className="d-flex justify-content-between">
                                 <h4 className="my-0">
@@ -134,43 +131,33 @@ class TagReferencesMain extends Component {
                                 </button>
                             </div>
                             <div className="well" style={{minHeight: "50px"}}>
-                                {selectedReferenceTags.map((tag, i) => (
+                                {referenceTags.map((tag, i) => (
                                     <span
                                         key={i}
                                         title={
                                             store.config.conflict_resolution
-                                                ? "Resolved Tag: ".concat(tag.get_full_name())
+                                                ? "Tag: ".concat(tag.get_full_name())
                                                 : tag.get_full_name()
                                         }
                                         className={
-                                            store.config.conflict_resolution
-                                                ? store.hasTag(selectedReferenceUserTags, tag)
-                                                    ? "refTag cursor-pointer"
-                                                    : "refTag refUserTagRemove cursor-pointer"
-                                                : "refTag cursor-pointer"
+                                            store.hasTag(referenceUserTags, tag)
+                                                ? "refTag cursor-pointer"
+                                                : "refTag refUserTagRemove cursor-pointer"
                                         }
-                                        onClick={
-                                            store.config.conflict_resolution
-                                                ? () => store.toggleTag(tag)
-                                                : () => store.removeTag(tag)
-                                        }>
+                                        onClick={() => store.toggleTag(tag)}>
                                         {this.state.showFullTag
                                             ? tag.get_full_name()
                                             : tag.data.name}
                                     </span>
                                 ))}
-                                {selectedReferenceUserTags
-                                    .filter(tag => !store.hasTag(selectedReferenceTags, tag))
+                                {referenceUserTags
+                                    .filter(tag => !store.hasTag(referenceTags, tag))
                                     .map((tag, i) => (
                                         <span
                                             key={i}
-                                            title={tag.get_full_name()}
+                                            title={"Proposed: ".concat(tag.get_full_name())}
                                             className="refTag refUserTag cursor-pointer"
-                                            onClick={
-                                                store.config.conflict_resolution
-                                                    ? () => store.removeTag(tag)
-                                                    : null
-                                            }>
+                                            onClick={() => store.removeTag(tag)}>
                                             {this.state.showFullTag
                                                 ? tag.get_full_name()
                                                 : tag.data.name}
@@ -184,7 +171,7 @@ class TagReferencesMain extends Component {
                                 </div>
                             ) : null}
                             <Reference
-                                reference={store.selectedReference}
+                                reference={reference}
                                 keywordDict={store.config.keywords}
                                 showActions={false}
                                 showHr={false}

--- a/frontend/lit/TagReferences/Main.js
+++ b/frontend/lit/TagReferences/Main.js
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import {toJS} from "mobx";
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
@@ -142,10 +143,24 @@ class TagReferencesMain extends Component {
                                                 ? "Resolved Tag: ".concat(tag.get_full_name())
                                                 : tag.get_full_name()
                                         }
-                                        className="refTag refTagEditing"
+                                        className={
+                                            store.config.conflict_resolution
+                                                ? _.find(
+                                                      selectedReferenceUserTags,
+                                                      e => e.data.pk == tag.data.pk
+                                                  )
+                                                    ? "refTag refTagEditing"
+                                                    : "refTag refUserTagDiff refTagEditing"
+                                                : "refTag refTagEditing"
+                                        }
                                         onClick={
                                             store.config.conflict_resolution
-                                                ? null
+                                                ? _.find(
+                                                      selectedReferenceUserTags,
+                                                      e => e.data.pk == tag.data.pk
+                                                  )
+                                                    ? () => store.removeTag(tag)
+                                                    : () => store.addTag(tag)
                                                 : () => store.removeTag(tag)
                                         }>
                                         {this.state.showFullTag
@@ -153,21 +168,29 @@ class TagReferencesMain extends Component {
                                             : tag.data.name}
                                     </span>
                                 ))}
-                                {selectedReferenceUserTags.map((tag, i) => (
-                                    <span
-                                        key={i}
-                                        title={tag.get_full_name()}
-                                        className="refTag refUserTag refTagEditing"
-                                        onClick={
-                                            store.config.conflict_resolution
-                                                ? () => store.removeTag(tag)
-                                                : null
-                                        }>
-                                        {this.state.showFullTag
-                                            ? tag.get_full_name()
-                                            : tag.data.name}
-                                    </span>
-                                ))}
+                                {selectedReferenceUserTags
+                                    .filter(
+                                        tag =>
+                                            !_.find(
+                                                selectedReferenceTags,
+                                                e => e.data.pk == tag.data.pk
+                                            )
+                                    )
+                                    .map((tag, i) => (
+                                        <span
+                                            key={i}
+                                            title={tag.get_full_name()}
+                                            className="refTag refUserTag refTagEditing"
+                                            onClick={
+                                                store.config.conflict_resolution
+                                                    ? () => store.removeTag(tag)
+                                                    : null
+                                            }>
+                                            {this.state.showFullTag
+                                                ? tag.get_full_name()
+                                                : tag.data.name}
+                                        </span>
+                                    ))}
                             </div>
                             {store.errorOnSave ? (
                                 <div className="alert alert-danger">

--- a/frontend/lit/TagReferences/Main.js
+++ b/frontend/lit/TagReferences/Main.js
@@ -145,9 +145,9 @@ class TagReferencesMain extends Component {
                                         className={
                                             store.config.conflict_resolution
                                                 ? store.hasTag(selectedReferenceUserTags, tag)
-                                                    ? "refTag refTagEditing"
-                                                    : "refTag refUserTagDiff refTagEditing"
-                                                : "refTag refTagEditing"
+                                                    ? "refTag cursor-pointer"
+                                                    : "refTag refUserTagRemove cursor-pointer"
+                                                : "refTag cursor-pointer"
                                         }
                                         onClick={
                                             store.config.conflict_resolution
@@ -165,7 +165,7 @@ class TagReferencesMain extends Component {
                                         <span
                                             key={i}
                                             title={tag.get_full_name()}
-                                            className="refTag refUserTag refTagEditing"
+                                            className="refTag refUserTag cursor-pointer"
                                             onClick={
                                                 store.config.conflict_resolution
                                                     ? () => store.removeTag(tag)

--- a/frontend/lit/TagReferences/store.js
+++ b/frontend/lit/TagReferences/store.js
@@ -30,7 +30,11 @@ class Store {
     @action.bound changeSelectedReference(reference) {
         this.selectedReference = reference;
         this.selectedReferenceTags = reference.tags.slice(0); // shallow copy
-        this.selectedReferenceUserTags = reference.userTags.slice(0);
+        if (!reference.userTags) {
+            this.selectedReferenceUserTags = reference.tags.slice(0);
+        } else {
+            this.selectedReferenceUserTags = reference.userTags.slice(0);
+        }
     }
     @action.bound addTag(tag) {
         if (

--- a/frontend/lit/TagReferences/store.js
+++ b/frontend/lit/TagReferences/store.js
@@ -10,9 +10,9 @@ class Store {
     saveIndicatorElement = null;
     @observable tagtree = null;
     @observable references = [];
-    @observable selectedReference = null;
-    @observable selectedReferenceTags = null;
-    @observable selectedReferenceUserTags = null;
+    @observable reference = null;
+    @observable referenceTags = null;
+    @observable referenceUserTags = null;
     @observable errorOnSave = false;
     @observable filterClass = "";
     @observable showInstructionsModal = false;
@@ -23,49 +23,47 @@ class Store {
         this.references = Reference.array(config.refs, this.tagtree);
         // set first reference
         if (this.references.length > 0) {
-            this.changeSelectedReference(this.references[0]);
+            this.setReference(this.references[0]);
         }
     }
-
-    @computed get workingTags() {
-        return this.config.conflict_resolution
-            ? this.selectedReferenceUserTags
-            : this.selectedReferenceTags;
+    @computed get hasReference() {
+        return this.reference !== null;
     }
-    @action.bound changeSelectedReference(reference) {
-        this.selectedReference = reference;
-        this.selectedReferenceTags = reference.tags.slice(0); // shallow copy
-        // user tags should default to the current consensus tags
-        if (!reference.userTags) {
-            this.selectedReferenceUserTags = reference.tags.slice(0);
-        } else {
-            this.selectedReferenceUserTags = reference.userTags.slice(0);
-        }
+    @action.bound setReference(reference) {
+        this.reference = reference;
+        this.referenceTags = reference.tags.slice(0); // shallow copy
+        this.referenceUserTags = reference.userTags
+            ? reference.userTags.slice(0)
+            : reference.tags.slice(0);
     }
     hasTag(tags, tag) {
         return !!_.find(tags, e => e.data.pk == tag.data.pk);
     }
     @action.bound addTag(tag) {
-        if (this.selectedReference && !_.find(this.workingTags, el => el.data.pk === tag.data.pk)) {
-            this.workingTags.push(tag);
+        if (
+            this.hasReference &&
+            !_.find(this.referenceUserTags, el => el.data.pk === tag.data.pk)
+        ) {
+            this.referenceUserTags.push(tag);
         }
     }
     @action.bound removeTag(tag) {
-        _.remove(this.workingTags, el => el.data.pk === tag.data.pk);
+        _.remove(this.referenceUserTags, el => el.data.pk === tag.data.pk);
     }
     @action.bound toggleTag(tag) {
-        return this.hasTag(this.workingTags, tag) ? this.removeTag(tag) : this.addTag(tag);
+        return this.hasTag(this.referenceUserTags, tag) ? this.removeTag(tag) : this.addTag(tag);
     }
     @action.bound saveAndNext() {
         const payload = {
-                pk: this.selectedReference.data.pk,
-                tags: this.workingTags.map(tag => tag.data.pk),
+                pk: this.reference.data.pk,
+                tags: this.referenceUserTags.map(tag => tag.data.pk),
             },
+            url = `/lit/api/reference/${this.reference.data.pk}/tag/`,
             success = () => {
                 const $el = $(this.saveIndicatorElement),
                     index = _.findIndex(
                         this.references,
-                        ref => ref.data.pk === this.selectedReference.data.pk
+                        ref => ref.data.pk === this.reference.data.pk
                     );
 
                 if ($el.length !== 1) {
@@ -75,17 +73,13 @@ class Store {
                 this.errorOnSave = false;
                 $el.fadeIn().fadeOut({
                     complete: () => {
-                        this.selectedReference.tags = toJS(this.selectedReferenceTags);
-                        this.selectedReference.userTags = toJS(this.selectedReferenceUserTags);
-                        this.references.splice(index, 1, toJS(this.selectedReference));
-                        this.selectedReference = null;
-                        this.selectedReferenceTags = null;
-                        this.selectedReferenceUserTags = null;
-                        if (this.references.length > index + 1) {
-                            this.changeSelectedReference(this.references[index + 1]);
-                        } else {
-                            this.changeSelectedReference(this.references[0]);
+                        this.reference.userTags = toJS(this.referenceUserTags);
+                        if (!this.config.conflict_resolution) {
+                            this.reference.tags = toJS(this.referenceUserTags);
                         }
+                        const nextIndex = this.references.length > index + 1 ? index + 1 : 0,
+                            reference = this.references[nextIndex];
+                        this.setReference(reference);
                     },
                 });
             },
@@ -93,26 +87,20 @@ class Store {
                 console.error(data);
                 this.errorOnSave = true;
             };
-
-        $.post(`/lit/api/reference/${this.selectedReference.data.pk}/tag/`, payload, v =>
-            v.status === "success" ? success() : failure()
-        ).fail(failure);
+        $.post(url, payload, v => (v.status === "success" ? success() : failure())).fail(failure);
     }
     @action.bound removeAllTags() {
-        this.workingTags.length = 0;
+        this.referenceUserTags = [];
     }
     @action.bound setSaveIndicatorElement(el) {
         this.saveIndicatorElement = el;
     }
-
     @action.bound sortReferences(sortBy) {
         this.references = sortReferences(this.references, sortBy);
     }
-
     @action.bound toggleSlideAway() {
         this.filterClass = this.filterClass == "" ? "slideAway" : "";
     }
-
     @action.bound setInstructionsModal(input) {
         this.showInstructionsModal = input;
     }

--- a/hawc/apps/lit/models.py
+++ b/hawc/apps/lit/models.py
@@ -1176,16 +1176,15 @@ class UserReferenceTag(models.Model):
     def assessment_id(self) -> int:
         return self.reference.assessment_id
 
-    def get_tags_diff(self):
-        all_tags = set(self.reference.tags.all())
-        for user_tag in self.reference.user_tags.all():
-            if user_tag.id == self.id:
-                continue
-            all_tags.update(set(user_tag.tags.all()))
+    def consensus_diff(self):
+        # returns set operations done against consensus tags
+        consensus_tags = set(self.reference.tags.all())
         self_tags = set(self.tags.all())
-        tags_diff = self_tags.difference(all_tags)
-        tags_same = self_tags.intersection(all_tags)
-        return dict(diff=tags_diff, same=tags_same)
+        return dict(
+            intersection=self_tags.intersection(consensus_tags),
+            difference=self_tags.difference(consensus_tags),
+            reverse_difference=consensus_tags.difference(self_tags),
+        )
 
 
 reversion.register(LiteratureAssessment)

--- a/hawc/apps/lit/templates/lit/_reference_tag_conflict.html
+++ b/hawc/apps/lit/templates/lit/_reference_tag_conflict.html
@@ -29,7 +29,7 @@
                         <b class="mb-0">{{user_tag.user.get_full_name}}</b> <i class="m-0 small">{{user_tag.user.email}}</i>
                         <input name="user_tag_id" value={{user_tag.pk}} class="hidden">
                     </div>
-                    {% with user_tag.consensus_diff as diff%}
+                    {% with user_tag.consensus_diff as diff %}
                         {% for tag in ref.tags.all %}
                             {% if tag in diff.intersection %}
                                 {% include 'lit/_nested_tag.html' with tag=tag extra_classes='' %}

--- a/hawc/apps/lit/templates/lit/_reference_tag_conflict.html
+++ b/hawc/apps/lit/templates/lit/_reference_tag_conflict.html
@@ -29,12 +29,16 @@
                         <b class="mb-0">{{user_tag.user.get_full_name}}</b> <i class="m-0 small">{{user_tag.user.email}}</i>
                         <input name="user_tag_id" value={{user_tag.pk}} class="hidden">
                     </div>
-                    {% with user_tag.get_tags_diff as tags%}
-                        {% for tag in tags.same %}
-                            {% include 'lit/_nested_tag.html' with tag=tag extra_classes='refUserTag' %}
+                    {% with user_tag.consensus_diff as diff%}
+                        {% for tag in ref.tags.all %}
+                            {% if tag in diff.intersection %}
+                                {% include 'lit/_nested_tag.html' with tag=tag extra_classes='' %}
+                            {% else %}
+                                {% include 'lit/_nested_tag.html' with tag=tag extra_classes='refUserTagDiff' %}
+                            {% endif %}
                         {% endfor %}
-                        {% for tag in tags.diff %}
-                            {% include 'lit/_nested_tag.html' with tag=tag extra_classes='refUserTagDiff' %}
+                        {% for tag in diff.difference %}
+                            {% include 'lit/_nested_tag.html' with tag=tag extra_classes='refUserTag' %}
                         {% endfor %}
                     {% endwith %}
                 </form>

--- a/hawc/apps/lit/templates/lit/_reference_tag_conflict.html
+++ b/hawc/apps/lit/templates/lit/_reference_tag_conflict.html
@@ -34,7 +34,7 @@
                             {% if tag in diff.intersection %}
                                 {% include 'lit/_nested_tag.html' with tag=tag extra_classes='' %}
                             {% else %}
-                                {% include 'lit/_nested_tag.html' with tag=tag extra_classes='refUserTagDiff' %}
+                                {% include 'lit/_nested_tag.html' with tag=tag extra_classes='refUserTagRemove' %}
                             {% endif %}
                         {% endfor %}
                         {% for tag in diff.difference %}

--- a/hawc/apps/lit/views.py
+++ b/hawc/apps/lit/views.py
@@ -306,7 +306,7 @@ class TagReferences(BaseFilterList):
         references = [ref.to_dict() for ref in context["object_list"]]
         ref_tags = context["object_list"].user_tags(user_id=self.request.user.id)
         for reference in references:
-            reference["user_tags"] = ref_tags.get(reference["pk"], [])
+            reference["user_tags"] = ref_tags.get(reference["pk"])
         return WebappConfig(
             app="litStartup",
             page="startupTagReferences",

--- a/hawc/static/css/hawc.css
+++ b/hawc/static/css/hawc.css
@@ -477,9 +477,10 @@ div.smart-tag.active {
 }
 
 .refUserTagDiff {
-    color: #ffffff;
-    background-color: maroon;
-    border: 0.15rem dotted #ffffff;
+    color: maroon;
+    background-color: #ffffff;
+    border: 0.15rem dotted maroon;
+    text-decoration: line-through;
 }
 
 .refTagSame {

--- a/hawc/static/css/hawc.css
+++ b/hawc/static/css/hawc.css
@@ -345,9 +345,6 @@ div.smart-tag.active {
     text-align: left;
     white-space: pre-wrap;
 }
-.refTagEditing {
-    cursor: pointer;
-}
 .abstract_label {
     font-weight: bold;
 }
@@ -476,7 +473,7 @@ div.smart-tag.active {
     display: inline-block;
 }
 
-.refUserTagDiff {
+.refUserTagRemove {
     color: rgb(128,0,0);
     background-color: #ffffff;
     border: 0.15rem dotted rgb(128,0,0);

--- a/hawc/static/css/hawc.css
+++ b/hawc/static/css/hawc.css
@@ -477,10 +477,10 @@ div.smart-tag.active {
 }
 
 .refUserTagDiff {
-    color: maroon;
+    color: rgb(128,0,0);
     background-color: #ffffff;
-    border: 0.15rem dotted maroon;
-    text-decoration: line-through;
+    border: 0.15rem dotted rgb(128,0,0);
+    text-decoration: line-through rgba(128,0,0,0.5);
 }
 
 .refTagSame {


### PR DESCRIPTION
This is an example of how we can handle deleting resolved tags when conflict resolution is enabled.

When user tags don't exist for a reference, the resolved tags are added by default:
> ![image](https://user-images.githubusercontent.com/46504563/204598400-89bf4c17-7232-461c-87c4-e79beb130500.png)

From here, a user can add additional tags and also remove resolved tags:
> ![image](https://user-images.githubusercontent.com/46504563/204598581-ebe9f4b9-6a82-4826-8825-156afbe6282a.png)

If a resolved tag is removed, it is still displayed with a strikethrough. Clicking on it again will reapply it.