### PR TITLE
Swapped EPT position of increase/decrease factors

### DIFF
--- a/frontend/summary/summaryTable/evidenceProfileTable/EvidenceForm.js
+++ b/frontend/summary/summaryTable/evidenceProfileTable/EvidenceForm.js
@@ -69,17 +69,17 @@ const EvidenceForm = observer(props => {
                                     />
                                 </th>
                                 <th>
-                                    Factors that increase certainty
-                                    <HelpTextPopup
-                                        title="Help-text"
-                                        content={`${HELP_TEXT.IRIS_HANDBOOK} For entries with a free text option,  summarize the evidence supporting the selected factor(s) in a few words (required). Note any other factors that increased certainty`}
-                                    />
-                                </th>
-                                <th>
                                     Factors that decrease certainty
                                     <HelpTextPopup
                                         title="Help-text"
                                         content={`${HELP_TEXT.IRIS_HANDBOOK} For entries with a free text option,  summarize the evidence supporting the selected factor(s) in a few words (required). Note any other factors that decreased certainty`}
+                                    />
+                                </th>
+                                <th>
+                                    Factors that increase certainty
+                                    <HelpTextPopup
+                                        title="Help-text"
+                                        content={`${HELP_TEXT.IRIS_HANDBOOK} For entries with a free text option,  summarize the evidence supporting the selected factor(s) in a few words (required). Note any other factors that increased certainty`}
                                     />
                                 </th>
                                 <th>
@@ -159,17 +159,17 @@ const EvidenceForm = observer(props => {
                 <td>
                     <FactorsForm
                         store={store}
-                        updateKey={`${contentType}.rows[${index}].certain_factors`}
-                        content={row.certain_factors}
-                        isIncreasing={true}
+                        updateKey={`${contentType}.rows[${index}].uncertain_factors`}
+                        content={row.uncertain_factors}
+                        isIncreasing={false}
                     />
                 </td>
                 <td>
                     <FactorsForm
                         store={store}
-                        updateKey={`${contentType}.rows[${index}].uncertain_factors`}
-                        content={row.uncertain_factors}
-                        isIncreasing={false}
+                        updateKey={`${contentType}.rows[${index}].certain_factors`}
+                        content={row.certain_factors}
+                        isIncreasing={true}
                     />
                 </td>
                 <td>

--- a/frontend/summary/summaryTable/evidenceProfileTable/Table.js
+++ b/frontend/summary/summaryTable/evidenceProfileTable/Table.js
@@ -27,8 +27,8 @@ const subTitleStyle = {backgroundColor: "#f5f5f5"},
                 <td>
                     <div dangerouslySetInnerHTML={{__html: row.summary.findings}}></div>
                 </td>
-                <FactorsCell content={row.certain_factors} isIncreasing={true} />
                 <FactorsCell content={row.uncertain_factors} isIncreasing={false} />
+                <FactorsCell content={row.certain_factors} isIncreasing={true} />
                 {index == 0 || rowSpan == 1 ? (
                     <td rowSpan={rowSpan > 1 ? rowSpan : null}>
                         <Judgement
@@ -273,8 +273,8 @@ class Table extends Component {
                         <tr>
                             <th>Studies</th>
                             <th>Summary of key findings</th>
-                            <th>Factors that increase certainty</th>
                             <th>Factors that decrease certainty</th>
+                            <th>Factors that increase certainty</th>
                             <th>Evidence Synthesis Judgment(s)</th>
                             {summary_judgement.hide_content ? null : <SummaryCell store={store} />}
                         </tr>

--- a/hawc/tools/tables/ept.py
+++ b/hawc/tools/tables/ept.py
@@ -326,8 +326,8 @@ class EvidenceRow(BaseCellGroup):
         self.cells = [
             self.evidence,
             self.summary,
-            self.certain_factors,
             self.uncertain_factors,
+            self.certain_factors,
             self.judgement,
         ]
 
@@ -438,10 +438,10 @@ class EvidenceProfileTable(BaseTable):
                 True, 1, 1, 1, 1, tag_wrapper("Summary of key findings", "p", "strong")
             ),
             GenericCell.parse_args(
-                True, 1, 2, 1, 1, tag_wrapper("Factors that increase certainty", "p", "strong")
+                True, 1, 3, 1, 1, tag_wrapper("Factors that decrease certainty", "p", "strong")
             ),
             GenericCell.parse_args(
-                True, 1, 3, 1, 1, tag_wrapper("Factors that decrease certainty", "p", "strong")
+                True, 1, 2, 1, 1, tag_wrapper("Factors that increase certainty", "p", "strong")
             ),
             GenericCell.parse_args(
                 True, 1, 4, 1, 1, tag_wrapper("Evidence Synthesis Judgment(s)", "p", "strong")

--- a/hawc/tools/tables/ept.py
+++ b/hawc/tools/tables/ept.py
@@ -234,7 +234,7 @@ class FactorsCell(BaseCell):
 
 
 class CertainFactorsCell(FactorsCell):
-    column: int = 2
+    column: int = 3
 
     @property
     def factor_types(self):
@@ -242,7 +242,7 @@ class CertainFactorsCell(FactorsCell):
 
 
 class UncertainFactorsCell(FactorsCell):
-    column: int = 3
+    column: int = 2
 
     @property
     def factor_types(self):
@@ -438,10 +438,10 @@ class EvidenceProfileTable(BaseTable):
                 True, 1, 1, 1, 1, tag_wrapper("Summary of key findings", "p", "strong")
             ),
             GenericCell.parse_args(
-                True, 1, 3, 1, 1, tag_wrapper("Factors that decrease certainty", "p", "strong")
+                True, 1, 2, 1, 1, tag_wrapper("Factors that decrease certainty", "p", "strong")
             ),
             GenericCell.parse_args(
-                True, 1, 2, 1, 1, tag_wrapper("Factors that increase certainty", "p", "strong")
+                True, 1, 3, 1, 1, tag_wrapper("Factors that increase certainty", "p", "strong")
             ),
             GenericCell.parse_args(
                 True, 1, 4, 1, 1, tag_wrapper("Evidence Synthesis Judgment(s)", "p", "strong")

--- a/tests/data/fixtures/db.yaml
+++ b/tests/data/fixtures/db.yaml
@@ -5910,6 +5910,8 @@
         description: <p>Water hydrates individuals who drink it.</p>
         susceptibility: <p>No additionally susceptible groups.</p>
         human_relevance: <p>Humans require water as well.</p>
+        plausibility: <p></p>
+        other: <p></p>
         custom_judgement_icon: ''
         cross_stream_coherence: <p>Observed in multiple evidence streams.</p>
         custom_judgement_label: ''


### PR DESCRIPTION
Swapped the positions of increased/decreased certainty factors in evidence profile tables.

---

**EPT form**

![image](https://user-images.githubusercontent.com/46504563/204856834-06c17b7d-92da-462a-9a08-e99378d9651a.png)

---

**EPT web report**

![image](https://user-images.githubusercontent.com/46504563/204856520-e39991b0-cce9-4203-8a13-45c7b3c4a91a.png)

---

**EPT word report**

![image](https://user-images.githubusercontent.com/46504563/204863416-a315d701-4afb-438f-b1d8-3cb4d53a7019.png)
