### PR TITLE
Paginated tagging and updated save alerts

### DIFF
--- a/frontend/lit/TagReferences/Main.js
+++ b/frontend/lit/TagReferences/Main.js
@@ -2,12 +2,12 @@ import {toJS} from "mobx";
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
 import React, {Component} from "react";
+import Alert from "shared/components/Alert";
 import HelpTextPopup from "shared/components/HelpTextPopup";
 import Modal from "shared/components/Modal";
 import {LocalStorageBoolean} from "shared/utils/LocalStorage";
 
 import Reference from "../components/Reference";
-import ReferenceSortSelector from "../components/ReferenceSortSelector";
 import TagTree from "../components/TagTree";
 
 @inject("store")
@@ -48,17 +48,13 @@ class TagReferencesMain extends Component {
             pinInstructions: this.pinInstructions.value,
         };
     }
-    _setSaveIndicator() {
-        const el = this.savedPopup.current;
-        if (el) {
-            this.props.store.setSaveIndicatorElement(el);
-        }
-    }
-    componentDidMount() {
-        this._setSaveIndicator();
-    }
     componentDidUpdate() {
-        this._setSaveIndicator();
+        if (this.props.store.updateFromSave) {
+            $(this.savedPopup.current)
+                .fadeIn()
+                .fadeOut(this.props.store.lastResolved ? 1000 : 500);
+            this.props.store.updateFromSave = false;
+        }
     }
     render() {
         const {store} = this.props,
@@ -74,7 +70,6 @@ class TagReferencesMain extends Component {
                         className="row px-3 mb-2 justify-content-between"
                         style={{maxHeight: "1.9rem"}}>
                         <h4>References</h4>
-                        <ReferenceSortSelector onChange={store.sortReferences} />
                     </div>
                     <div className="card">
                         <div
@@ -120,18 +115,23 @@ class TagReferencesMain extends Component {
                                         content={"Click on a tag to remove"}
                                     />
                                 </h4>
-                                <span
-                                    ref={this.savedPopup}
-                                    className="bg-success text-white font-weight-bold px-2 rounded"
-                                    style={{display: "none"}}>
-                                    Saved!
-                                </span>
                                 <button
                                     className="btn btn-primary pt-1"
                                     title="Save and go to next reference"
                                     onClick={() => store.saveAndNext()}>
                                     <i className="fa fa-save"></i>&nbsp;Save and next
                                 </button>
+                            </div>
+                            <div ref={this.savedPopup} style={{display: "none"}}>
+                                <Alert
+                                    className="alert-success mt-2"
+                                    icon="fa-check-square"
+                                    message={
+                                        store.lastResolved
+                                            ? "Saved! Tags added with no conflict."
+                                            : "Saved!"
+                                    }
+                                />
                             </div>
                             <div className="well" style={{minHeight: "50px"}}>
                                 {selectedReferenceTags.map((tag, i) => (

--- a/frontend/lit/TagReferences/Main.js
+++ b/frontend/lit/TagReferences/Main.js
@@ -48,14 +48,6 @@ class TagReferencesMain extends Component {
             pinInstructions: this.pinInstructions.value,
         };
     }
-    componentDidUpdate() {
-        if (this.props.store.updateFromSave) {
-            $(this.savedPopup.current)
-                .fadeIn()
-                .fadeOut(this.props.store.lastResolved ? 1000 : 500);
-            this.props.store.updateFromSave = false;
-        }
-    }
     render() {
         const {store} = this.props,
             {hasReference, reference, referenceTags, referenceUserTags} = store,
@@ -119,17 +111,19 @@ class TagReferencesMain extends Component {
                                     <i className="fa fa-save"></i>&nbsp;Save and next
                                 </button>
                             </div>
-                            <div ref={this.savedPopup} style={{display: "none"}}>
+                            {store.successMessage ? (
                                 <Alert
                                     className="alert-success mt-2"
                                     icon="fa-check-square"
-                                    message={
-                                        store.lastResolved
-                                            ? "Saved! Tags added with no conflict."
-                                            : "Saved!"
-                                    }
+                                    message={store.successMessage}
                                 />
-                            </div>
+                            ) : null}
+                            {store.errorOnSave ? (
+                                <Alert
+                                    className="alert-danger mt-2"
+                                    message="An error occurred in saving; please wait a moment and retry. If the error persists please contact HAWC staff."
+                                />
+                            ) : null}
                             <div className="well" style={{minHeight: "50px"}}>
                                 {referenceTags.map((tag, i) => (
                                     <span
@@ -164,12 +158,6 @@ class TagReferencesMain extends Component {
                                         </span>
                                     ))}
                             </div>
-                            {store.errorOnSave ? (
-                                <div className="alert alert-danger">
-                                    An error occurred in saving; please wait a moment and retry. If
-                                    the error persists please contact HAWC staff.
-                                </div>
-                            ) : null}
                             <Reference
                                 reference={reference}
                                 keywordDict={store.config.keywords}

--- a/frontend/lit/TagReferences/Main.js
+++ b/frontend/lit/TagReferences/Main.js
@@ -40,7 +40,6 @@ ReferenceListItem.propTypes = {
 class TagReferencesMain extends Component {
     constructor(props) {
         super(props);
-        this.savedPopup = React.createRef();
         this.showFullTag = new LocalStorageBoolean("lit-showFullTag", true);
         this.pinInstructions = new LocalStorageBoolean("lit-pinInstructions", false);
         this.state = {
@@ -120,7 +119,7 @@ class TagReferencesMain extends Component {
                             <div className="well" style={{minHeight: "50px"}}>
                                 {store.successMessage ? (
                                     <Alert
-                                        className="alert-success"
+                                        className="alert-success fade-in-out"
                                         icon="fa-check-square"
                                         message={store.successMessage}
                                     />

--- a/frontend/lit/TagReferences/Main.js
+++ b/frontend/lit/TagReferences/Main.js
@@ -111,13 +111,6 @@ class TagReferencesMain extends Component {
                                     <i className="fa fa-save"></i>&nbsp;Save and next
                                 </button>
                             </div>
-                            {store.successMessage ? (
-                                <Alert
-                                    className="alert-success mt-2"
-                                    icon="fa-check-square"
-                                    message={store.successMessage}
-                                />
-                            ) : null}
                             {store.errorOnSave ? (
                                 <Alert
                                     className="alert-danger mt-2"
@@ -125,38 +118,48 @@ class TagReferencesMain extends Component {
                                 />
                             ) : null}
                             <div className="well" style={{minHeight: "50px"}}>
-                                {referenceTags.map((tag, i) => (
-                                    <span
-                                        key={i}
-                                        title={
-                                            store.config.conflict_resolution
-                                                ? "Tag: ".concat(tag.get_full_name())
-                                                : tag.get_full_name()
-                                        }
-                                        className={
-                                            store.hasTag(referenceUserTags, tag)
-                                                ? "refTag cursor-pointer"
-                                                : "refTag refUserTagRemove cursor-pointer"
-                                        }
-                                        onClick={() => store.toggleTag(tag)}>
-                                        {this.state.showFullTag
-                                            ? tag.get_full_name()
-                                            : tag.data.name}
-                                    </span>
-                                ))}
-                                {referenceUserTags
-                                    .filter(tag => !store.hasTag(referenceTags, tag))
-                                    .map((tag, i) => (
-                                        <span
-                                            key={i}
-                                            title={"Proposed: ".concat(tag.get_full_name())}
-                                            className="refTag refUserTag cursor-pointer"
-                                            onClick={() => store.removeTag(tag)}>
-                                            {this.state.showFullTag
-                                                ? tag.get_full_name()
-                                                : tag.data.name}
-                                        </span>
-                                    ))}
+                                {store.successMessage ? (
+                                    <Alert
+                                        className="alert-success"
+                                        icon="fa-check-square"
+                                        message={store.successMessage}
+                                    />
+                                ) : (
+                                    <>
+                                        {referenceTags.map((tag, i) => (
+                                            <span
+                                                key={i}
+                                                title={
+                                                    store.config.conflict_resolution
+                                                        ? "Tag: ".concat(tag.get_full_name())
+                                                        : tag.get_full_name()
+                                                }
+                                                className={
+                                                    store.hasTag(referenceUserTags, tag)
+                                                        ? "refTag cursor-pointer"
+                                                        : "refTag refUserTagRemove cursor-pointer"
+                                                }
+                                                onClick={() => store.toggleTag(tag)}>
+                                                {this.state.showFullTag
+                                                    ? tag.get_full_name()
+                                                    : tag.data.name}
+                                            </span>
+                                        ))}
+                                        {referenceUserTags
+                                            .filter(tag => !store.hasTag(referenceTags, tag))
+                                            .map((tag, i) => (
+                                                <span
+                                                    key={i}
+                                                    title={"Proposed: ".concat(tag.get_full_name())}
+                                                    className="refTag refUserTag cursor-pointer"
+                                                    onClick={() => store.removeTag(tag)}>
+                                                    {this.state.showFullTag
+                                                        ? tag.get_full_name()
+                                                        : tag.data.name}
+                                                </span>
+                                            ))}
+                                    </>
+                                )}
                             </div>
                             <Reference
                                 reference={reference}

--- a/frontend/lit/TagReferences/store.js
+++ b/frontend/lit/TagReferences/store.js
@@ -71,7 +71,7 @@ class Store {
                 this.successMessage = "";
                 this.setReference(reference);
             }),
-            resolved ? 1000 : 500
+            2000
         );
         this.successMessage = resolved ? "Saved! Tags added with no conflict." : "Saved!";
     }

--- a/frontend/lit/TagReferences/store.js
+++ b/frontend/lit/TagReferences/store.js
@@ -21,7 +21,7 @@ class Store {
     constructor(config) {
         this.config = config;
         this.tagtree = new TagTree(config.tags[0]);
-        this.references = Reference.array(config.refs, this.tagtree);
+        this.references = Reference.array(config.refs, this.tagtree, false);
         // set first reference
         if (this.references.length > 0) {
             this.setReference(this.references[0]);

--- a/frontend/lit/TagReferences/store.js
+++ b/frontend/lit/TagReferences/store.js
@@ -60,7 +60,6 @@ class Store {
                 tags: this.referenceUserTags.map(tag => tag.data.pk),
             },
             url = `/lit/api/reference/${this.reference.data.pk}/tag/`,
-
             // since the success function is a promise and makes a number of changes we need to
             // wrap it in a mobx action so that it doesn't count each individual change
             success = action(resolved => {
@@ -87,7 +86,9 @@ class Store {
                 this.errorOnSave = true;
             };
 
-        $.post(url, payload, v => (v.status === "success" ? success(v.resolved) : failure())).fail(failure);
+        $.post(url, payload, v => (v.status === "success" ? success(v.resolved) : failure())).fail(
+            failure
+        );
     }
     @action.bound removeAllTags() {
         this.referenceUserTags = [];

--- a/hawc/apps/lit/api.py
+++ b/hawc/apps/lit/api.py
@@ -382,7 +382,10 @@ class ReferenceViewset(
         ref = self.get_object()
         assessment = ref.assessment
         if assessment.user_can_edit_object(self.request.user):
-            tag_pks = self.request.POST.getlist("tags[]", [])
+            try:
+                tag_pks = [int(tag_pk) for tag_pk in self.request.POST.getlist("tags[]", [])]
+            except ValueError:
+                return Response({"tags": "Array of tags must be valid primary keys"}, status=400)
             resolved = ref.update_tags(request.user, tag_pks)
             response["status"] = "success"
             response["resolved"] = resolved

--- a/hawc/apps/lit/api.py
+++ b/hawc/apps/lit/api.py
@@ -383,8 +383,9 @@ class ReferenceViewset(
         assessment = ref.assessment
         if assessment.user_can_edit_object(self.request.user):
             tag_pks = self.request.POST.getlist("tags[]", [])
-            ref.update_tags(request.user, tag_pks)
+            resolved = ref.update_tags(request.user, tag_pks)
             response["status"] = "success"
+            response["resolved"] = resolved
         return Response(response)
 
     @action(detail=True, methods=("post",))

--- a/hawc/apps/lit/api.py
+++ b/hawc/apps/lit/api.py
@@ -383,10 +383,10 @@ class ReferenceViewset(
         assessment = ref.assessment
         if assessment.user_can_edit_object(self.request.user):
             try:
-                tag_pks = [int(tag_pk) for tag_pk in self.request.POST.getlist("tags[]", [])]
+                tags = [int(tag) for tag in self.request.data.get("tags", [])]
             except ValueError:
                 return Response({"tags": "Array of tags must be valid primary keys"}, status=400)
-            resolved = ref.update_tags(request.user, tag_pks)
+            resolved = ref.update_tags(request.user, tags)
             response["status"] = "success"
             response["resolved"] = resolved
         return Response(response)

--- a/hawc/apps/lit/managers.py
+++ b/hawc/apps/lit/managers.py
@@ -352,13 +352,13 @@ class ReferenceQuerySet(models.QuerySet):
         )
         return self.exclude(query).distinct("pk")
 
-    def user_tags(self, user_id: int) -> dict[int, list[int]]:
+    def unresolved_user_tags(self, user_id: int) -> dict[int, list[int]]:
         # Return a dictionary of reference_id: list[tag_ids] items for all references in a queryset
         # TODO - update to annotate queryset with Django 4.1?
         # https://docs.djangoproject.com/en/4.1/ref/contrib/postgres/expressions/#arraysubquery-expressions
         UserReferenceTag = apps.get_model("lit", "UserReferenceTag")
         user_qs = (
-            UserReferenceTag.objects.filter(reference__in=self, user=user_id)
+            UserReferenceTag.objects.filter(reference__in=self, user=user_id, is_resolved=False)
             .annotate(tag_ids=ArrayAgg("tags__id"))
             .values_list("reference_id", "tag_ids")
         )

--- a/hawc/apps/lit/templates/lit/reference_tag.html
+++ b/hawc/apps/lit/templates/lit/reference_tag.html
@@ -5,6 +5,7 @@
     {% include 'common/filter_list.html' with plural_object_name='references' %}
   </div>
   <div id="main"></div>
+  {% include "includes/paginator.html" with plural_object_name="references" %}
 {% endblock %}
 
 {% block extrajs %}

--- a/hawc/apps/lit/views.py
+++ b/hawc/apps/lit/views.py
@@ -254,6 +254,7 @@ class TagReferences(BaseFilterList):
             "title_abstract",
             "search",
             "id",
+            "order_by",
             "tag_choice",
             "tags",
             "include_descendants",
@@ -265,7 +266,16 @@ class TagReferences(BaseFilterList):
                     "columns": [
                         {
                             "width": 6,
-                            "rows": [{"columns": [{"width": 12}, {"width": 12}, {"width": 12}]}],
+                            "rows": [
+                                {
+                                    "columns": [
+                                        {"width": 12},
+                                        {"width": 12},
+                                        {"width": 12},
+                                        {"width": 12},
+                                    ]
+                                }
+                            ],
                         },
                         {
                             "width": 6,
@@ -285,7 +295,7 @@ class TagReferences(BaseFilterList):
             ]
         },
     )
-    paginate_by = None
+    paginate_by = 100
 
     def get_queryset(self):
         return (

--- a/hawc/apps/lit/views.py
+++ b/hawc/apps/lit/views.py
@@ -314,7 +314,7 @@ class TagReferences(BaseFilterList):
 
     def get_app_config(self, context) -> WebappConfig:
         references = [ref.to_dict() for ref in context["object_list"]]
-        ref_tags = context["object_list"].user_tags(user_id=self.request.user.id)
+        ref_tags = context["object_list"].unresolved_user_tags(user_id=self.request.user.id)
         for reference in references:
             reference["user_tags"] = ref_tags.get(reference["pk"], [])
         return WebappConfig(

--- a/hawc/static/css/hawc.css
+++ b/hawc/static/css/hawc.css
@@ -638,6 +638,15 @@ table.bordered td {
     transition: opacity 1s ease-out;
 }
 
+/* fade in/out */
+.fade-in-out {
+    animation: fadeInOutKeyFrame 2s linear;
+}
+@keyframes fadeInOutKeyFrame {
+    0%,100% { opacity: 0 }
+    20%,80% { opacity: 1 }
+}
+
 /* quill */
 .ql-editor {
     background-color: white !important;


### PR DESCRIPTION
# Paginated tagging view

Limited the tagging view to only show 100 references at a time

>![image](https://user-images.githubusercontent.com/46504563/206247091-a5882f5f-9f77-42e6-8731-b4a5823dcb5b.png)


# Updated save alerts

## Standard save alert

The save alert has been updated and moved from beside the "Save and next" button to right below that header. It fades in and then out whenever tags are saved.

![Screenshot 2022-12-08 at 10 31 19 PM](https://user-images.githubusercontent.com/999952/206618106-5abb8646-9a22-44d4-9c02-ea8387c17aa4.jpg)


## Autoresolution save alert

A custom save alert pops up if tags where automatically resolved when saved. For example:

The only unresolved user tag here is from Project Manager (Exclusion -> Tier I)

>![image](https://user-images.githubusercontent.com/46504563/206244462-371cf6ab-c423-4a26-ad19-86bd8beb7579.png)

If another user goes to the tagging view, applies the same tags as the other unresolved user tags, and clicks "Save and next"...

>![image](https://user-images.githubusercontent.com/46504563/206244870-11e922ee-1f45-41f1-b38d-8652cb9fb93a.png)

Then the tags are automatically resolved and added as consensus tags, and the user is notified as such

>![image](https://user-images.githubusercontent.com/46504563/206245172-b0cbcc86-20d7-47e4-a6c5-cfc352b8081f.png)





# Other changes
- Removed js ordering and added to the form
- Fixed tag autoresolution
- Changed tagging view so that only unresolved user tags are used
  - This makes sure that old user tags aren't the default after a resolution; instead it will be the resolved tags