### PR TITLE
Improvements to the Conflict Resolution View

### DIFF
--- a/hawc/apps/lit/api.py
+++ b/hawc/apps/lit/api.py
@@ -5,7 +5,7 @@ import plotly.express as px
 from django.conf import settings
 from django.core.cache import cache
 from django.db import transaction
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from rest_framework import exceptions, mixins, status, viewsets
 from rest_framework.decorators import action

--- a/hawc/apps/lit/api.py
+++ b/hawc/apps/lit/api.py
@@ -399,5 +399,10 @@ class ReferenceViewset(
         if not assessment.user_can_edit_object(self.request.user):
             raise PermissionDenied()
         reference.resolve_user_tag_conflicts(selected_user_tag)
-        create_object_log(f"Tag conflict resolved with user_tag {user_tag_id}", reference, assessment.pk, request.user.id)
+        create_object_log(
+            f"Tag conflict resolved with user_tag {user_tag_id}",
+            reference,
+            assessment.pk,
+            request.user.id,
+        )
         return render(request, "lit/_conflict_resolved.html", {"ref": reference})

--- a/hawc/apps/lit/api.py
+++ b/hawc/apps/lit/api.py
@@ -379,34 +379,28 @@ class ReferenceViewset(
     @action(detail=True, methods=("post",))
     def tag(self, request, pk):
         response = {"status": "fail"}
-        ref = self.get_object()
-        assessment = ref.assessment
+        instance = self.get_object()
+        assessment = instance.assessment
         if assessment.user_can_edit_object(self.request.user):
             try:
                 tags = [int(tag) for tag in self.request.data.get("tags", [])]
             except ValueError:
                 return Response({"tags": "Array of tags must be valid primary keys"}, status=400)
-            resolved = ref.update_tags(request.user, tags)
+            resolved = instance.update_tags(request.user, tags)
             response["status"] = "success"
             response["resolved"] = resolved
         return Response(response)
 
-    @transaction.atomic
     @action(detail=True, methods=("post",))
     def resolve_conflict(self, request, pk):
-        reference = self.get_object()
-        assessment = reference.assessment
-        user_tag_id = request.POST.get("user_tag_id")
-        selected_user_tag = get_object_or_404(
-            models.UserReferenceTag, id=user_tag_id, reference_id=reference.id
-        )
+        instance = self.get_object()
+        assessment = instance.assessment
         if not assessment.user_can_edit_object(self.request.user):
             raise PermissionDenied()
-        reference.resolve_user_tag_conflicts(selected_user_tag)
-        create_object_log(
-            f"Tag conflict resolved with user_tag {user_tag_id}",
-            reference,
-            assessment.pk,
-            request.user.id,
+        user_reference_tag = get_object_or_404(
+            models.UserReferenceTag,
+            reference_id=instance.id,
+            id=int(request.POST.get("user_tag_id", -1)),
         )
-        return render(request, "lit/_conflict_resolved.html", {"ref": reference})
+        instance.resolve_user_tag_conflicts(self.request.user.id, user_reference_tag)
+        return Response({"status": "ok"})

--- a/hawc/apps/lit/api.py
+++ b/hawc/apps/lit/api.py
@@ -387,14 +387,17 @@ class ReferenceViewset(
             response["status"] = "success"
         return Response(response)
 
+    @transaction.atomic
     @action(detail=True, methods=("post",))
     def resolve_conflict(self, request, pk):
         reference = self.get_object()
         assessment = reference.assessment
+        user_tag_id = request.POST.get("user_tag_id")
         selected_user_tag = get_object_or_404(
-            models.UserReferenceTag, id=request.POST.get("user_tag_id"), reference_id=reference.id
+            models.UserReferenceTag, id=user_tag_id, reference_id=reference.id
         )
         if not assessment.user_can_edit_object(self.request.user):
             raise PermissionDenied()
         reference.resolve_user_tag_conflicts(selected_user_tag)
+        create_object_log(f"Tag conflict resolved with user_tag {user_tag_id}", reference, assessment.pk, request.user.id)
         return render(request, "lit/_conflict_resolved.html", {"ref": reference})

--- a/hawc/apps/lit/models.py
+++ b/hawc/apps/lit/models.py
@@ -938,7 +938,7 @@ class Reference(models.Model):
     def resolve_user_tag_conflicts(self, user_id: int, user_tag: "UserReferenceTag"):
         tags = {tag.id for tag in user_tag.tags.all()}
         log_message = (
-            f'Update lit.Reference tags #{self.id}: use lit.UserReferenceTag #{user_tag.id}: {tags}'
+            f"Update lit.Reference tags #{self.id}: use lit.UserReferenceTag #{user_tag.id}: {tags}"
         )
         Log.objects.create(
             assessment_id=self.assessment_id,

--- a/hawc/apps/lit/models.py
+++ b/hawc/apps/lit/models.py
@@ -28,6 +28,7 @@ from ...refml import topics
 from ...services.nih import pubmed
 from ...services.utils import ris
 from ...services.utils.doi import get_doi_from_identifier, try_get_doi
+from ..assessment.models import Log
 from ..common.helper import SerializerHelper
 from ..common.models import (
     AssessmentRootMixin,
@@ -933,8 +934,19 @@ class Reference(models.Model):
     def has_user_tag_conflicts(self):
         return self.user_tags.filter(is_resolved=False).exists()
 
-    def resolve_user_tag_conflicts(self, user_tag: "UserReferenceTag"):
-        self.tags.set({tag.id for tag in user_tag.tags.all()})
+    @transaction.atomic
+    def resolve_user_tag_conflicts(self, user_id: int, user_tag: "UserReferenceTag"):
+        tags = {tag.id for tag in user_tag.tags.all()}
+        log_message = (
+            f'Update lit.Reference tags #{self.id}: use lit.UserReferenceTag #{user_tag.id}: {tags}'
+        )
+        Log.objects.create(
+            assessment_id=self.assessment_id,
+            user_id=user_id,
+            message=log_message,
+            content_object=self,
+        )
+        self.tags.set(tags)
         self.save()
         self.user_tags.update(is_resolved=True)
 

--- a/hawc/apps/lit/templates/lit/_conflict_resolved.html
+++ b/hawc/apps/lit/templates/lit/_conflict_resolved.html
@@ -1,5 +1,0 @@
-<div class="alert alert-success mt-3 mb-0 alert-dismissible fade show " role="alert">
-    <i aria-hidden="true" class="fa fa-check fa-fw"></i>&nbsp;
-        Conflicts resolved! Consensus tags updated.
-    <button type="button" class="close" data-dismiss="alert" aria-label="Close">&times;</button>
-</div>

--- a/hawc/apps/lit/templates/lit/_reference_tag_conflict.html
+++ b/hawc/apps/lit/templates/lit/_reference_tag_conflict.html
@@ -20,25 +20,27 @@
                 <span><i>&lt;none&gt;</i></span>
             {% endfor %}
             {% for user_tag in ref.user_tags.all %}
-            <div class="tag-conf-item {% if forloop.first %} mt-1 {% endif %}">
-                <form>
-                    <div>
-                        <button class="approve btn btn-sm btn-success mr-2 align-center mb-2 mt-1"
-                            hx-post="{% url 'lit:api:reference-resolve-conflict' ref.pk %}">
-                            <i class="fa fa-fw fa-check" aria-hidden="true"></i>&nbsp;Approve</button>
-                        <b class="mb-0">{{user_tag.user.get_full_name}}</b> <i class="m-0 small">{{user_tag.user.email}}</i>
-                        <input name="user_tag_id" value={{user_tag.pk}} class="hidden">
-                    </div>
-                    {% with user_tag.get_tags_diff as tags%}
-                        {% for tag in tags.same %}
-                            {% include 'lit/_nested_tag.html' with tag=tag extra_classes='refUserTag' %}
-                        {% endfor %}
-                        {% for tag in tags.diff %}
-                            {% include 'lit/_nested_tag.html' with tag=tag extra_classes='refUserTagDiff' %}
-                        {% endfor %}
-                    {% endwith %}
-                </form>
-            </div>
+                {% if not user_tag.is_resolved %}
+                <div class="tag-conf-item {% if forloop.first %} mt-1 {% endif %}">
+                    <form>
+                        <div>
+                            <button class="approve btn btn-sm btn-success mr-2 align-center mb-2 mt-1"
+                                hx-post="{% url 'lit:api:reference-resolve-conflict' ref.pk %}">
+                                <i class="fa fa-fw fa-check" aria-hidden="true"></i>&nbsp;Approve</button>
+                            <b class="mb-0">{{user_tag.user.get_full_name}}</b> <i class="m-0 small">{{user_tag.user.email}}</i>
+                            <input name="user_tag_id" value={{user_tag.pk}} class="hidden">
+                        </div>
+                        {% with user_tag.get_tags_diff as tags%}
+                            {% for tag in tags.same %}
+                                {% include 'lit/_nested_tag.html' with tag=tag extra_classes='refUserTag' %}
+                            {% endfor %}
+                            {% for tag in tags.diff %}
+                                {% include 'lit/_nested_tag.html' with tag=tag extra_classes='refUserTagDiff' %}
+                            {% endfor %}
+                        {% endwith %}
+                    </form>
+                </div>
+                {% endif %}
             {% endfor %}
         </div>
     </div>

--- a/hawc/apps/lit/templates/lit/_reference_tag_conflict.html
+++ b/hawc/apps/lit/templates/lit/_reference_tag_conflict.html
@@ -44,4 +44,5 @@
             {% endfor %}
         </div>
     </div>
+    <a href="{% url 'lit:tag' assessment.pk%}?id={{ref.pk}}" class="btn btn-primary">Tag it yourself</a>
 </li>

--- a/hawc/apps/lit/templates/lit/_reference_tag_conflict.html
+++ b/hawc/apps/lit/templates/lit/_reference_tag_conflict.html
@@ -2,6 +2,14 @@
     id="ref-form-{{ref.pk}}"
     hx-target="#ref-form-{{ref.pk}}"
     hx-swap="outerHTML">
+    <div class="dropdown btn-group float-right">
+        <a class="btn btn-sm btn-secondary dropdown-toggle" data-toggle="dropdown">Actions</a>
+        <div class="dropdown-menu dropdown-menu-right">
+            <a href="{% url 'lit:tag' assessment.pk%}?id={{ref.pk}}" class="dropdown-item" target="_blank" rel="noreferrer">Edit reference tags</a>
+            <a href="{% url 'lit:ref_edit' ref.pk%}" class="dropdown-item" target="_blank" rel="noreferrer">Edit reference</a>
+            <a href="{% url 'lit:tag-history' ref.pk%}" class="dropdown-item" target="_blank" rel="noreferrer">Tag history</a>
+        </div>
+    </div>
     <div class="ref_authors cursor-pointer ref_small mb-1">{{ref.authors}} {{ref.year}}</div>
     <div class="ref_title cursor-pointer m-0">{{ref.title}}</div>
     <div class="ref_small mb-1">
@@ -44,5 +52,4 @@
             {% endfor %}
         </div>
     </div>
-    <a href="{% url 'lit:tag' assessment.pk%}?id={{ref.pk}}" class="btn btn-primary" target="_blank" rel="noreferrer">Tag it yourself</a>
 </li>

--- a/hawc/apps/lit/templates/lit/_reference_tag_conflict.html
+++ b/hawc/apps/lit/templates/lit/_reference_tag_conflict.html
@@ -1,7 +1,7 @@
 <li class="list-group-item list-group-item-action conflict-reference-li {% if first %} pb-4 {% else %} py-4 {% endif %}"
     id="ref-form-{{ref.pk}}"
     hx-target="#ref-form-{{ref.pk}}"
-    hx-swap="outerHTML">
+    hx-swap="delete swap:1s">
     <div class="dropdown btn-group float-right">
         <a class="btn btn-sm btn-secondary dropdown-toggle" data-toggle="dropdown">Actions</a>
         <div class="dropdown-menu dropdown-menu-right">
@@ -21,15 +21,17 @@
     <p class="abstract abstract_collapsed cursor-pointer mb-1" title="Click to expand/collapse">{{ref.abstract|safe}}</p>
     <div class="row">
         <div class="col-md-12 pt-1">
-            <p class="mb-0"><i>Tags currently applied:</i></p>
-            {% for tag in ref.tags.all %}
-                {% include 'lit/_nested_tag.html' with tag=tag extra_classes='' %}
-            {% empty %}
-                <span><i>&lt;none&gt;</i></span>
-            {% endfor %}
+            {% with ref.tags.all as tags%}
+            {% if tags %}
+            <div class="tag-conflict">
+                <p class="mb-1"><b>Consensus tags:</b></p>
+                {% for tag in ref.tags.all %}{% include 'lit/_nested_tag.html' with tag=tag extra_classes='' %}{% endfor %}
+            </div>
+            {% endif %}
+            {% endwith %}
             {% for user_tag in ref.user_tags.all %}
                 {% if not user_tag.is_resolved %}
-                <div class="tag-conf-item {% if forloop.first %} mt-1 {% endif %}">
+                <div class="tag-conflict user-tag-conflict {% if forloop.first %} mt-1 {% endif %}">
                     <form>
                         <div>
                             <button class="approve btn btn-sm btn-success mr-2 align-center mb-2 mt-1"

--- a/hawc/apps/lit/templates/lit/_reference_tag_conflict.html
+++ b/hawc/apps/lit/templates/lit/_reference_tag_conflict.html
@@ -44,5 +44,5 @@
             {% endfor %}
         </div>
     </div>
-    <a href="{% url 'lit:tag' assessment.pk%}?id={{ref.pk}}" class="btn btn-primary">Tag it yourself</a>
+    <a href="{% url 'lit:tag' assessment.pk%}?id={{ref.pk}}" class="btn btn-primary" target="_blank" rel="noreferrer">Tag it yourself</a>
 </li>

--- a/hawc/apps/lit/templates/lit/conflict_resolution.html
+++ b/hawc/apps/lit/templates/lit/conflict_resolution.html
@@ -10,6 +10,7 @@
     <li class="list-group-item list-group-item-action my-3">No conflicts to resolve!</li>
     {% endfor %}
 </ul>
+{% include "includes/paginator.html" with plural_object_name="conflicts" %}
 {% endblock content %}
 
 {% block extrajs %}

--- a/hawc/apps/lit/templates/lit/conflict_resolution.html
+++ b/hawc/apps/lit/templates/lit/conflict_resolution.html
@@ -7,7 +7,7 @@
     {% for ref in object_list %}
     {% include 'lit/_reference_tag_conflict.html' with ref=ref first=forloop.first %}
     {% empty %}
-    <li class="list-group-item list-group-item-action my-3">No conflicts to resolve!</li>
+    <li class="list-group-item list-group-item-action my-3">No references with tag conflicts found.</li>
     {% endfor %}
 </ul>
 {% include "includes/paginator.html" with plural_object_name="conflicts" %}

--- a/hawc/apps/lit/views.py
+++ b/hawc/apps/lit/views.py
@@ -346,7 +346,7 @@ class ConflictResolution(BaseFilterList):
             ]
         },
     )
-    paginate_by = None
+    paginate_by = 100
 
     def get_queryset(self):
         n_unapplied_reviews = Count("user_tags", filter=Q(user_tags__is_resolved=False))

--- a/hawc/apps/lit/views.py
+++ b/hawc/apps/lit/views.py
@@ -349,12 +349,12 @@ class ConflictResolution(BaseFilterList):
     paginate_by = None
 
     def get_queryset(self):
-        num_unresolved = Count("user_tags", filter=Q(user_tags__is_resolved=False))
+        n_unapplied_reviews = Count("user_tags", filter=Q(user_tags__is_resolved=False))
         return (
             super()
             .get_queryset()
-            .annotate(num_unresolved=num_unresolved)
-            .filter(num_unresolved__gte=1)
+            .annotate(n_unapplied_reviews=n_unapplied_reviews)
+            .filter(n_unapplied_reviews__gt=1)
             .order_by("-last_updated")
             .prefetch_related("identifiers", "tags", "user_tags__user", "user_tags__tags")
         )

--- a/hawc/static/css/hawc.css
+++ b/hawc/static/css/hawc.css
@@ -450,11 +450,12 @@ div.smart-tag.active {
     white-space: unset;
     width: auto;
 }
-
-.tag-conf-item {
-    box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
-    padding: 16px;
+.tag-conflict {
+    padding: 5px 15px;
+}
+.user-tag-conflict {
     margin: 16px 0px;
+    box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
     border-radius: 5px;
     background-color: #ffffff;
 }

--- a/tests/data/fixtures/db.yaml
+++ b/tests/data/fixtures/db.yaml
@@ -2219,7 +2219,7 @@
     user:
     - team@hawcproject.org
     reference: 10
-    is_resolved: true
+    is_resolved: false
     created: 2022-10-27 21:09:01.953588+00:00
     last_updated: 2022-10-27 21:09:02.014507+00:00
 - model: lit.userreferencetag


### PR DESCRIPTION
 * On conflicts resolution page, filter to only show cases where the count of is_applied=False is > 1
 * Paginate conflict resolution page, 100 at a time
 * Add Actions button to references in the conflict page, with options to:
   * Tag any reference if you want to edit/create your own tags on that reference
   * Edit reference details
   * view reference tag history

![image](https://user-images.githubusercontent.com/16324404/206487049-3175922e-7b26-474f-b04f-3dfcaa75bcf9.png)

 * Add an Assesssment.Log for whenever conflicts are resolved, log the ref id, and tag id set which includes all includes and excludes