### PR TITLE
Add Conflict Resolution Tests

### DIFF
--- a/hawc/apps/lit/api.py
+++ b/hawc/apps/lit/api.py
@@ -384,9 +384,9 @@ class ReferenceViewset(
         if assessment.user_can_edit_object(self.request.user):
             try:
                 tags = [int(tag) for tag in self.request.data.get("tags", [])]
+                resolved = instance.update_tags(request.user, tags)
             except ValueError:
                 return Response({"tags": "Array of tags must be valid primary keys"}, status=400)
-            resolved = instance.update_tags(request.user, tags)
             response["status"] = "success"
             response["resolved"] = resolved
         return Response(response)

--- a/hawc/apps/lit/managers.py
+++ b/hawc/apps/lit/managers.py
@@ -49,6 +49,9 @@ class _ReferenceFilterTagManager(_TaggableManager):
         full_taglist = self.through.tag_model().get_descendants_pks(self.instance.assessment_id)
         selected_tags = set(tag_pks).intersection(full_taglist)
 
+        if len(selected_tags) < len(tag_pks):
+            raise ValueError("At least one of the given tags belongs to a different assessment.")
+
         tagrefs = []
         for tag_id in selected_tags:
             tagrefs.append(self.through(tag_id=tag_id, content_object=self.instance))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ class Keys:
         self.reference_unlinked = 3
 
         self.reference_untagged = 9
-        self.reference_tag_confict = 10
+        self.reference_tag_conflict = 10
         self.reference_tagged = 11
 
         self.animal_group_working = 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ class Keys:
         self.assessment_final = 2
         self.assessment_client = 3
         self.assessment_keys = [1, 2]
+        self.assessment_conflict_resolution = 4
 
         self.dataset_final = 2
         self.dataset_working = 1
@@ -35,6 +36,10 @@ class Keys:
 
         self.reference_linked = 1
         self.reference_unlinked = 3
+
+        self.reference_untagged = 9
+        self.reference_tag_confict = 10
+        self.reference_tagged = 11
 
         self.animal_group_working = 1
         self.endpoint_working = 1

--- a/tests/hawc/apps/lit/test_api.py
+++ b/tests/hawc/apps/lit/test_api.py
@@ -679,7 +679,7 @@ class TestReferenceConflictResApi:
         # reviewers can't update tags or resolve conflicts
         client = APIClient()
         assert client.login(username="reviewer@hawcproject.org", password="pw") is True
-        response = client.post(update_tags_url, data={"tags[]": [32, 33]})
+        response = client.post(update_tags_url, data={"tags": [32, 33]}, format="json")
         ref.refresh_from_db()
 
         assert response.status_code == 403
@@ -714,10 +714,10 @@ class TestReferenceConflictResApi:
 
         # create a conflict by applying different tags as two different users
         assert client.login(email=tm.email, password="pw") is True
-        client.post(update_tags_url, data={"tags[]": tm_tags})
+        client.post(update_tags_url, data={"tags": tm_tags}, format="json")
         client.logout()
         assert client.login(email=pm.email, password="pw") is True
-        client.post(update_tags_url, data={"tags[]": pm_tags})
+        client.post(update_tags_url, data={"tags": pm_tags}, format="json")
         ref.refresh_from_db()
         assert ref.user_tags.count() == 2
         assert ref.has_user_tag_conflicts() is True

--- a/tests/hawc/apps/lit/test_api.py
+++ b/tests/hawc/apps/lit/test_api.py
@@ -581,8 +581,8 @@ class TestReferenceDestroyApi:
 
 
 @pytest.mark.django_db
-class TestReferenceUpdateApi:
-    def test_permissions(self, db_keys):
+class TestReferenceViewset:
+    def test_update_permissions(self, db_keys):
 
         url = reverse("lit:api:reference-detail", args=(db_keys.reference_linked,))
         data = {"title": "TestReferenceUpdateApi test"}
@@ -606,7 +606,7 @@ class TestReferenceUpdateApi:
         # make sure the object hasn't changed
         assert post_ref == pre_ref
 
-    def test_bad_requests(self, db_keys):
+    def test_update_bad_requests(self, db_keys):
         # test bad id
         url = reverse("lit:api:reference-detail", args=(-1,))
         data = {"title": "TestReferenceUpdateApi test"}
@@ -624,7 +624,7 @@ class TestReferenceUpdateApi:
         assert response.status_code == 400
         assert response.json() == {"tags": ["All tag ids are not from this assessment"]}
 
-    def test_valid_requests(self, db_keys):
+    def test_update_valid_requests(self, db_keys):
         url = reverse("lit:api:reference-detail", args=(db_keys.reference_linked,))
         client = APIClient()
         assert client.login(username="team@hawcproject.org", password="pw") is True
@@ -663,10 +663,7 @@ class TestReferenceUpdateApi:
         for id in tags:
             assert updated_reference.tags.filter(id=id).exists()
 
-
-@pytest.mark.django_db
-class TestReferenceConflictResApi:
-    def test_permissions(self, db_keys):
+    def test_tag_permissions(self, db_keys):
         ref: models.Reference = models.Reference.objects.get(id=db_keys.reference_tag_conflict)
         update_tags_url = reverse("lit:api:reference-tag", args=(ref.pk,))
         resolve_conflict_url = reverse("lit:api:reference-resolve-conflict", args=(ref.pk,))
@@ -680,23 +677,23 @@ class TestReferenceConflictResApi:
         client = APIClient()
         assert client.login(username="reviewer@hawcproject.org", password="pw") is True
         response = client.post(update_tags_url, data={"tags": [32, 33]}, format="json")
-        ref.refresh_from_db()
-
         assert response.status_code == 403
+
         # no user tag was created
+        ref.refresh_from_db()
         assert ref.user_tags.count() == 2
         assert ref.user_tags.filter(user__email="reviewer@hawcproject.org").exists() is False
 
         user_tag_id = ref.user_tags.first().pk
         response = client.post(resolve_conflict_url, data={"user_tag_id": user_tag_id})
-        ref.refresh_from_db()
-
         assert response.status_code == 403
+
         # tags were not added to the reference/conflict was not resolved
+        ref.refresh_from_db()
         assert ref.tags.count() == 0
         assert ref.has_user_tag_conflicts() is True
 
-    def test_valid_requests(self, db_keys):
+    def test_conflict_valid(self, db_keys):
         ref: models.Reference = models.Reference.objects.get(id=db_keys.reference_untagged)
         pm = HAWCUser.objects.get(email="pm@hawcproject.org")
         tm = HAWCUser.objects.get(email="team@hawcproject.org")
@@ -736,6 +733,11 @@ class TestReferenceConflictResApi:
         assert ref.has_user_tag_conflicts() is False
         assert list(ref.tags.values_list("id", flat=True)) == pm_tags
 
+    def test_tagging_valid(self, db_keys):
+        ref: models.Reference = models.Reference.objects.get(id=db_keys.reference_untagged)
+        client = APIClient()
+        assert client.login(email="pm@hawcproject.org", password="pw") is True
+
         # test applying tags w/o conflict resolution
         ref = models.Reference.objects.get(id=db_keys.reference_linked)
         update_tags_url = reverse("lit:api:reference-tag", args=(ref.pk,))
@@ -748,14 +750,13 @@ class TestReferenceConflictResApi:
         assert list(ref.tags.values_list("id", flat=True)) == tags
         assert ref.has_user_tag_conflicts() is False
 
-    def test_bad_requests(self, db_keys):
-        # Tagging API
-        # test bad id
-        url = reverse("lit:api:reference-tag", args=(-1,))
-        data = {"tags": [2, 3]}
-
+    def test_tagging_invalid(self, db_keys):
         client = APIClient()
         assert client.login(username="team@hawcproject.org", password="pw") is True
+        url = reverse("lit:api:reference-tag", args=(-1,))
+
+        # test bad id
+        data = {"tags": [2, 3]}
         response = client.post(url, data, format="json")
         assert response.status_code == 404
 
@@ -766,9 +767,12 @@ class TestReferenceConflictResApi:
         assert response.status_code == 400
         assert response.json() == {"tags": "Array of tags must be valid primary keys"}
 
-        # Resolve Conflict API
-        # test bad ref id
+    def test_conflict_invalid(self, db_keys):
+        client = APIClient()
+        assert client.login(username="team@hawcproject.org", password="pw") is True
         url = reverse("lit:api:reference-resolve-conflict", args=(-1,))
+
+        # test bad ref id
         data = {"user_tag_id": 1}
         response = client.post(url, data, format="json")
         assert response.status_code == 404

--- a/tests/integration/test_lit.py
+++ b/tests/integration/test_lit.py
@@ -47,3 +47,12 @@ class TestLiterature(PlaywrightTestCase):
         expect(
             page.locator("text=Select an Excel file (.xlsx) to load and process.")
         ).to_be_visible()
+
+    def test_conflict_resolution(self):
+        page = self.page
+        page.goto(self.live_server_url)
+
+        # /lit/assessment/:id/
+        self.login_and_goto_url(
+            page, f"{self.live_server_url}/lit/assessment/4/", "pm@hawcproject.org"
+        )

--- a/tests/integration/test_lit.py
+++ b/tests/integration/test_lit.py
@@ -54,5 +54,18 @@ class TestLiterature(PlaywrightTestCase):
 
         # /lit/assessment/:id/
         self.login_and_goto_url(
-            page, f"{self.live_server_url}/lit/assessment/4/", "pm@hawcproject.org"
+            page,
+            f"{self.live_server_url}/lit/assessment/4/reference-tag-conflicts/",
+            "pm@hawcproject.org",
         )
+
+        expect(page.locator(".user-tag-conflict")).to_have_count(2)
+        expect(page.locator(".conflict-reference-li")).to_have_count(1)
+
+        page.locator("text=Approve Team Member team@hawcproject.org >> button").click()
+
+        expect(page.locator(".conflict-reference-li")).not_to_be_visible()
+
+        page.goto("http://localhost:8000/lit/assessment/4/references/")
+
+        expect(page.locator("text=Inclusion ➤ Animal Study")).to_be_visible()

--- a/tests/integration/test_lit.py
+++ b/tests/integration/test_lit.py
@@ -1,4 +1,5 @@
 import re
+
 from playwright.sync_api import expect
 
 from .common import PlaywrightTestCase

--- a/tests/integration/test_lit.py
+++ b/tests/integration/test_lit.py
@@ -60,14 +60,27 @@ class TestLiterature(PlaywrightTestCase):
             "pm@hawcproject.org",
         )
 
+        expect(
+            page.locator(
+                "text=Nutrient content of fish powder from low value fish and fish byproducts."
+            )
+        ).to_be_visible()
         expect(page.locator(".user-tag-conflict")).to_have_count(2)
         expect(page.locator(".conflict-reference-li")).to_have_count(1)
 
-        with page.expect_response(re.compile(r"resolve_conflict")):
+        with page.expect_response(re.compile(r"resolve_conflict")) as response_info:
             page.locator("text=Approve Team Member team@hawcproject.org >> button").click()
+            response = response_info.value
+            assert response.ok
 
+        # hides reference now that conflict is resolved
         expect(page.locator(".conflict-reference-li")).not_to_be_visible()
 
-        page.goto("http://localhost:8000/lit/assessment/4/references/")
-
-        expect(page.locator("text=Inclusion ➤ Animal Study")).to_be_visible()
+        # check that selected tag has been applied
+        page.goto(f"{self.live_server_url}/lit/assessment/4/references/")
+        page.locator("text=Animal Study (1)").click()
+        expect(
+            page.locator(
+                "text=Nutrient content of fish powder from low value fish and fish byproducts."
+            )
+        ).to_be_visible()

--- a/tests/integration/test_lit.py
+++ b/tests/integration/test_lit.py
@@ -1,3 +1,4 @@
+import re
 from playwright.sync_api import expect
 
 from .common import PlaywrightTestCase
@@ -62,7 +63,8 @@ class TestLiterature(PlaywrightTestCase):
         expect(page.locator(".user-tag-conflict")).to_have_count(2)
         expect(page.locator(".conflict-reference-li")).to_have_count(1)
 
-        page.locator("text=Approve Team Member team@hawcproject.org >> button").click()
+        with page.expect_response(re.compile(r"resolve_conflict")):
+            page.locator("text=Approve Team Member team@hawcproject.org >> button").click()
 
         expect(page.locator(".conflict-reference-li")).not_to_be_visible()
 


### PR DESCRIPTION
* adds tests for api both `/lit/api/reference/:id/tag/` and `/lit/api/reference/:id/resolve-conflicts/`
  * checks permissions
  * checks functionality
  * tests assessments with conflict resolution enabled and disabled
* adds integration tests for new conflict resolution view
  * checks that the new pages load
  * checks that text highlights, etc.