### PR TITLE
hotfix - prevent copy tag form submission on click

### DIFF
--- a/frontend/lit/components/TagTree.js
+++ b/frontend/lit/components/TagTree.js
@@ -31,7 +31,8 @@ class TagNode extends Component {
                         {hasChildren ? (
                             <button
                                 className="float-right btn btn-sm px-2"
-                                onClick={toggleExpander}>
+                                onClick={toggleExpander}
+                                type="button">
                                 <i className={`fa ${expanderIcon}`}></i>
                             </button>
                         ) : null}

--- a/hawc/apps/lit/templates/lit/tags_copy.html
+++ b/hawc/apps/lit/templates/lit/tags_copy.html
@@ -30,7 +30,7 @@
     <div id="tags">
       <p>
         Loading, please wait...&nbsp;
-        <span className="fa fa-spin fa-spinner" />
+        <span className="fa fa-spin fa-spinner"></span>
       </p>
     </div>
 


### PR DESCRIPTION
A user reported an unintentional copy of tags because the button in the tagtree did not have a default type, so it defaults to a form `submit` button. This has been fixed to change the default to a type of `button`, so expanding/collapsing tags does not unintentionally trigger a clone.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type