### PR TITLE
Configurable session cookies

### DIFF
--- a/hawc/main/settings/base.py
+++ b/hawc/main/settings/base.py
@@ -187,6 +187,8 @@ AUTH_USER_MODEL = "myuser.HAWCUser"
 AUTH_PROVIDERS = {AuthProvider(p) for p in os.getenv("HAWC_AUTH_PROVIDERS", "django").split("|")}
 PASSWORD_RESET_TIMEOUT = 259200  # 3 days, in seconds
 SESSION_COOKIE_AGE = int(os.getenv("HAWC_SESSION_DURATION", "604800"))  # 1 week
+SESSION_COOKIE_DOMAIN = os.getenv("HAWC_SESSION_COOKIE_DOMAIN", None)
+SESSION_COOKIE_NAME = os.getenv("HAWC_SESSION_COOKIE_NAME", "sessionid")
 SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 SESSION_CACHE_ALIAS = "default"
 INCLUDE_ADMIN = bool(os.environ.get("HAWC_INCLUDE_ADMIN", "True") == "True")


### PR DESCRIPTION
Make cookie domain/name configurable via environment variables. Use the django defaults by default

- [Session Cookie Domain](https://docs.djangoproject.com/en/4.1/ref/settings/#session-cookie-domain) - defaults to None; a standard domain cookie (django default)
- [Session Cookie Name](https://docs.djangoproject.com/en/4.1/ref/settings/#session-cookie-name) - defaults to `sessionid` (django default)

