### PR TITLE
Update to tableau API v3

### DIFF
--- a/frontend/summary/summary/TableauDashboard.js
+++ b/frontend/summary/summary/TableauDashboard.js
@@ -6,14 +6,18 @@ class TableauDashboard extends Component {
     /*
     Use the recommended approach for embedding a tableau dashboard into an application. For
     developer documentation, see:
-        https://help.tableau.com/current/pro/desktop/en-us/embed_list.htm
+        https://help.tableau.com/current/api/embedding_api/en-us/index.html
     */
     componentDidMount() {
         // inject tableau script
         const head = document.querySelector("head"),
             script = document.createElement("script");
 
-        script.setAttribute("src", "https://public.tableau.com/javascripts/api/viz_v1.js");
+        script.setAttribute(
+            "src",
+            "https://public.tableau.com/javascripts/api/tableau.embedding.3.latest.min.js"
+        );
+        script.setAttribute("type", "module");
         head.appendChild(script);
     }
 
@@ -27,18 +31,7 @@ class TableauDashboard extends Component {
 
         let fullPath = queryArgs && queryArgs.length > 0 ? `${path}?${queryArgs.join("&")}` : path;
 
-        return (
-            <object
-                className="tableauViz"
-                height={`${height}px`}
-                width={`${width}px`}
-                style={{display: "none"}}>
-                <param name="host_url" value={hostUrl} />
-                <param name="path" value={fullPath} />
-                <param name="toolbar" value="yes" />
-                <param name="display_spinner" value="yes" />
-            </object>
-        );
+        return <tableau-viz src={hostUrl + fullPath} height={height} width={width}></tableau-viz>;
     }
 }
 

--- a/tests/integration/test_summary.py
+++ b/tests/integration/test_summary.py
@@ -97,7 +97,7 @@ class TestSummary(PlaywrightTestCase):
 
         page.goto(self.live_server_url + "/summary/visual/assessment/2/embedded-tableau/")
         expect(page.locator("h2:has-text('embedded-tableau')")).to_be_visible()
-        expect(page.locator(".tableauPlaceholder >> iframe")).to_be_visible()
+        expect(page.locator("tableau-viz >> iframe")).to_be_visible()
         expect(page.locator("iframe")).not_to_have_count(0)
 
         page.goto(self.live_server_url + "/summary/visual/assessment/2/rob-heatmap/")


### PR DESCRIPTION
Updates TableauDashboard component to use the current API v3 instead of the API v1.

This is a cherry pick of #757 to merge on the main branch instead of next; work originally done by @munnsmunns 