### PR TITLE
hotfix-  duplicate rows when filtering by dose-units

### DIFF
--- a/hawc/apps/animal/filterset.py
+++ b/hawc/apps/animal/filterset.py
@@ -134,6 +134,7 @@ class EndpointFilterSet(BaseFilterSet):
         field_name="animal_group__dosing_regime__doses__dose_units",
         label="Dose units",
         queryset=DoseUnits.objects.all(),
+        distinct=True,
     )
     order_by = df.OrderingFilter(
         fields=(


### PR DESCRIPTION
After filterset rewrite, when filtering on a dose-units on `/ani/assessment/:id/endpoints/`, duplicate endpoints were created for each dose-units. This PR removes the duplicate rows for the same endpoint.