### PR TITLE
add Tableau filters to embedded Visuals

### DIFF
--- a/frontend/summary/summary/ExternalSiteVisual.js
+++ b/frontend/summary/summary/ExternalSiteVisual.js
@@ -22,6 +22,7 @@ class ExternalWebsite extends BaseVisual {
                     hostUrl={settings.external_url_hostname}
                     path={settings.external_url_path}
                     queryArgs={settings.external_url_query_args}
+                    filters={settings.filters}
                 />,
                 el
             );

--- a/frontend/summary/summary/TableauDashboard.js
+++ b/frontend/summary/summary/TableauDashboard.js
@@ -47,7 +47,9 @@ TableauDashboard.propTypes = {
     hostUrl: PropTypes.string.isRequired,
     path: PropTypes.string.isRequired,
     queryArgs: PropTypes.arrayOf(PropTypes.string),
-    filters: PropTypes.arrayOf({field: PropTypes.string, value: PropTypes.string}),
+    filters: PropTypes.arrayOf(
+        PropTypes.shape({field: PropTypes.string.isRequired, value: PropTypes.string.isRequired})
+    ),
 };
 
 export default TableauDashboard;

--- a/frontend/summary/summary/TableauDashboard.js
+++ b/frontend/summary/summary/TableauDashboard.js
@@ -22,7 +22,7 @@ class TableauDashboard extends Component {
     }
 
     render() {
-        const {hostUrl, path, queryArgs} = this.props,
+        const {hostUrl, path, queryArgs, filters} = this.props,
             contentSize = h.getHawcContentSize(),
             MIN_HEIGHT = 600,
             MIN_WIDTH = 700,
@@ -31,7 +31,15 @@ class TableauDashboard extends Component {
 
         let fullPath = queryArgs && queryArgs.length > 0 ? `${path}?${queryArgs.join("&")}` : path;
 
-        return <tableau-viz src={hostUrl + fullPath} height={height} width={width}></tableau-viz>;
+        return (
+            <tableau-viz src={hostUrl + fullPath} height={height} width={width}>
+                {filters.map((filter, i) => {
+                    return (
+                        <viz-filter key={i} field={filter.field} value={filter.value}></viz-filter>
+                    );
+                })}
+            </tableau-viz>
+        );
     }
 }
 
@@ -39,6 +47,7 @@ TableauDashboard.propTypes = {
     hostUrl: PropTypes.string.isRequired,
     path: PropTypes.string.isRequired,
     queryArgs: PropTypes.arrayOf(PropTypes.string),
+    filters: PropTypes.arrayOf({field: PropTypes.string, value: PropTypes.string}),
 };
 
 export default TableauDashboard;

--- a/hawc/apps/common/validators.py
+++ b/hawc/apps/common/validators.py
@@ -183,12 +183,29 @@ class NumericTextValidator(RegexValidator):
     message = "Must be number-like, including {<,≤,≥,>,LOD,LOQ} (ex: 3.4, 1.2E-5, < LOD)"
 
 
-def _pydantic_json_validator(value: str, Model: type[BaseModel]):
+def _validate_json_pydantic(value: str, Model: type[BaseModel]):
+    """Validate a JSON string to ensure it conforms to a pydantic model
+
+    Args:
+        value (str): an input string
+        Model (type[BaseModel]): A matching pydantic schema
+
+    Raises:
+        django.core.exceptions.ValidationError: If data do not conform
+    """
     try:
         Model.parse_raw(value)
     except PydanticValidationError as err:
         raise ValidationError(err.json())
 
 
-def pydantic_json_validator(Model: type[BaseModel]) -> Callable:
-    return partial(_pydantic_json_validator, Model=Model)
+def validate_json_pydantic(Model: type[BaseModel]) -> Callable:
+    """Create a django validator function to validate JSON in a string field
+
+    Args:
+        Model (type[BaseModel]): A Pydantic model class
+
+    Returns:
+        Callable: A django validator function to be used in a form or model
+    """
+    return partial(_validate_json_pydantic, Model=Model)

--- a/hawc/apps/summary/constants.py
+++ b/hawc/apps/summary/constants.py
@@ -1,4 +1,5 @@
 from django.db import models
+from pydantic import BaseModel
 
 
 class StudyType(models.IntegerChoices):
@@ -33,3 +34,12 @@ class SortOrder(models.TextChoices):
 class ExportStyle(models.IntegerChoices):
     EXPORT_GROUP = 0, "One row per Endpoint-group/Result-group"
     EXPORT_ENDPOINT = 1, "One row per Endpoint/Result"
+
+
+class TableauFilter(BaseModel):
+    field: str
+    value: str
+
+
+class TableauFilterList(BaseModel):
+    __root__: list[TableauFilter]

--- a/hawc/apps/summary/forms.py
+++ b/hawc/apps/summary/forms.py
@@ -13,7 +13,7 @@ from ..assessment.models import DoseUnits, EffectTag
 from ..common import validators
 from ..common.autocomplete import AutocompleteChoiceField
 from ..common.forms import BaseFormHelper, check_unique_for_assessment
-from ..common.validators import pydantic_json_validator
+from ..common.validators import validate_json_pydantic
 from ..epi.models import Outcome
 from ..invitro.models import IVChemical, IVEndpointCategory
 from ..lit.models import ReferenceFilterTag
@@ -834,7 +834,7 @@ class ExternalSiteForm(VisualForm):
     filters = forms.CharField(
         label="Data filters",
         initial="[]",
-        validators=[pydantic_json_validator(constants.TableauFilterList)],
+        validators=[validate_json_pydantic(constants.TableauFilterList)],
         help_text="""<p class="form-text text-muted">
         Data are expected to be in JSON format, where the each key is a filter name and value is a filter value.
         For more details, view the <a href="https://help.tableau.com/current/api/embedding_api/en-us/docs/embedding_api_filter.html">Tableau documentation</a>. For example: <code>[{"field": "Category", "value": "Technology"}, {"field": "State", "value": "North Carolina,Virginia"}]</code>. To remove filters, set string to <code>[]</code>.

--- a/hawc/apps/summary/migrations/0040_tableau_filters.py
+++ b/hawc/apps/summary/migrations/0040_tableau_filters.py
@@ -1,0 +1,44 @@
+import json
+
+from django.db import migrations
+
+
+def forwards(apps, schema_editor):
+    Visual = apps.get_model("summary", "visual")
+    updates = []
+    for visual in Visual.objects.filter(visual_type=5):
+        try:
+            settings = json.loads(visual.settings)
+        except json.JSONDecodeError:
+            continue
+        settings["filters"] = []
+        visual.settings = json.dumps(settings)
+        updates.append(visual)
+    if updates:
+        Visual.objects.bulk_update(updates, ["settings"])
+
+
+def backwards(apps, schema_editor):
+    Visual = apps.get_model("summary", "visual")
+    updates = []
+    for visual in Visual.objects.filter(visual_type=5):
+        try:
+            settings = json.loads(visual.settings)
+        except json.JSONDecodeError:
+            continue
+        settings.pop("filters")
+        visual.settings = json.dumps(settings)
+        updates.append(visual)
+    if updates:
+        Visual.objects.bulk_update(updates, ["settings"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("summary", "0039_update_rob_legend"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, reverse_code=backwards),
+    ]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -24,7 +24,7 @@ pytest-playwright==0.3.0
 # distribution tools
 build==0.8.0
 twine==4.0.1
-wheel==0.37.1
+wheel==0.38.4
 
 # hawc; save in editable mode so it doesn't copy to venv
 # but instead stays in place

--- a/tests/data/api/api-visual-embedded-tableau.json
+++ b/tests/data/api/api-visual-embedded-tableau.json
@@ -17,7 +17,8 @@
     "external_url_query_args": [
       ":showVizHome=no",
       ":embed=y"
-    ]
+    ],
+    "filters": []
   },
   "slug": "embedded-tableau",
   "sort_order": "short_citation",

--- a/tests/data/fixtures/db.yaml
+++ b/tests/data/fixtures/db.yaml
@@ -6086,7 +6086,7 @@
     settings: '{"external_url": "https://public.tableau.com/views/Iris_15675445278420/Iris-Actual",
       "external_url_hostname": "https://public.tableau.com", "external_url_path":
       "/views/Iris_15675445278420/Iris-Actual", "external_url_query_args": [":showVizHome=no",
-      ":embed=y"]}'
+      ":embed=y"], "filters": []}'
     caption: <p>iris (flowers)</p>
     published: true
     sort_order: short_citation

--- a/tests/hawc/apps/summary/test_forms.py
+++ b/tests/hawc/apps/summary/test_forms.py
@@ -15,6 +15,7 @@ def test_ExternalSiteForm(db_keys):
         slug="slug",
         description="hi",
         external_url="https://public.tableau.com/views/foo1/foo2?:display_count=y&:origin=viz_share_link",
+        filters="[]",
     )
 
     # demo what success looks like
@@ -33,6 +34,7 @@ def test_ExternalSiteForm(db_keys):
         "external_url_hostname": "https://public.tableau.com",
         "external_url_path": "/views/foo1/foo2",
         "external_url_query_args": [":showVizHome=no", ":embed=y"],
+        "filters": "[]",
     }
 
     # make sure our site allowlist works

--- a/tests/hawc/apps/summary/test_forms.py
+++ b/tests/hawc/apps/summary/test_forms.py
@@ -6,54 +6,78 @@ from hawc.apps.summary.forms import ExternalSiteForm
 
 
 @pytest.mark.django_db
-def test_ExternalSiteForm(db_keys):
-    assessment = Assessment.objects.get(id=db_keys.assessment_working)
-    visual_type = VisualType.EXTERNAL_SITE
+class TestExternalSiteForm:
+    def valid_data(self):
+        return dict(
+            title="title",
+            slug="slug",
+            description="hi",
+            external_url="https://public.tableau.com/views/foo1/foo2?:display_count=y&:origin=viz_share_link",
+            filters="[]",
+        )
 
-    data = dict(
-        title="title",
-        slug="slug",
-        description="hi",
-        external_url="https://public.tableau.com/views/foo1/foo2?:display_count=y&:origin=viz_share_link",
-        filters="[]",
-    )
+    def test_success(self, db_keys):
+        assessment = Assessment.objects.get(id=db_keys.assessment_working)
+        visual_type = VisualType.EXTERNAL_SITE
 
-    # demo what success looks like
-    form = ExternalSiteForm(
-        data=data,
-        parent=assessment,
-        visual_type=visual_type,
-    )
-    assert form.is_valid()
-    assert form.cleaned_data == {
-        "title": "title",
-        "slug": "slug",
-        "caption": "",
-        "published": False,
-        "external_url": "https://public.tableau.com/views/foo1/foo2",
-        "external_url_hostname": "https://public.tableau.com",
-        "external_url_path": "/views/foo1/foo2",
-        "external_url_query_args": [":showVizHome=no", ":embed=y"],
-        "filters": "[]",
-    }
+        data = self.valid_data()
+        form = ExternalSiteForm(
+            data=data,
+            parent=assessment,
+            visual_type=visual_type,
+        )
+        assert form.is_valid()
+        assert form.cleaned_data == {
+            "title": "title",
+            "slug": "slug",
+            "caption": "",
+            "published": False,
+            "external_url": "https://public.tableau.com/views/foo1/foo2",
+            "external_url_hostname": "https://public.tableau.com",
+            "external_url_path": "/views/foo1/foo2",
+            "external_url_query_args": [":showVizHome=no", ":embed=y"],
+            "filters": "[]",
+        }
 
-    # make sure our site allowlist works
-    for url in [
-        "google.com",
-        "http://google.com",
-        "https://google.com",
-    ]:
-        data["external_url"] = url
-        form = ExternalSiteForm(data=data, parent=assessment, visual_type=visual_type)
-        assert form.is_valid() is False
-        assert "not on the list of accepted domains" in form.errors["external_url"][0]
+    def test_urls(self, db_keys):
+        assessment = Assessment.objects.get(id=db_keys.assessment_working)
+        visual_type = VisualType.EXTERNAL_SITE
+        data = self.valid_data()
+        # make sure our site allowlist works
+        for url in [
+            "google.com",
+            "http://google.com",
+            "https://google.com",
+        ]:
+            data["external_url"] = url
+            form = ExternalSiteForm(data=data, parent=assessment, visual_type=visual_type)
+            assert form.is_valid() is False
+            assert "not on the list of accepted domains" in form.errors["external_url"][0]
 
-    # make sure our path check works
-    for url in [
-        "public.tableau.com",
-        "public.tableau.com/",
-    ]:
-        data["external_url"] = url
-        form = ExternalSiteForm(data=data, parent=assessment, visual_type=visual_type)
-        assert form.is_valid() is False
-        assert "A URL path must be specified." == form.errors["external_url"][0]
+        # make sure our path check works
+        for url in [
+            "public.tableau.com",
+            "public.tableau.com/",
+        ]:
+            data["external_url"] = url
+            form = ExternalSiteForm(data=data, parent=assessment, visual_type=visual_type)
+            assert form.is_valid() is False
+            assert "A URL path must be specified." == form.errors["external_url"][0]
+
+    def test_filters(self, db_keys):
+        assessment = Assessment.objects.get(id=db_keys.assessment_working)
+        visual_type = VisualType.EXTERNAL_SITE
+        data = self.valid_data()
+
+        # test valid filters
+        for filters in ["[]", '[{"field":"hi", "value":"ho"}]']:
+            data["filters"] = filters
+            form = ExternalSiteForm(data=data, parent=assessment, visual_type=visual_type)
+            assert form.is_valid() is True
+
+        # test invalid filters
+        for filters in ["[123]", '[{"field":"hi"}]']:
+            data["filters"] = filters
+            form = ExternalSiteForm(data=data, parent=assessment, visual_type=visual_type)
+            assert form.is_valid() is False
+            assert "filters" in form.errors


### PR DESCRIPTION
Add the ability to filter Tableau data via the API. The screenshots below just copy and pasted the help-text examples. Examples were taken from the latest Tableau embedding documentation: https://help.tableau.com/current/api/embedding_api/en-us/docs/embedding_api_filter.html#filtering-example

![image](https://user-images.githubusercontent.com/999952/210443216-3a507dd2-48f9-440c-af60-8071fdaa472d.png)

Only shows two states:
![image](https://user-images.githubusercontent.com/999952/210443361-d03d2628-c539-4793-9ef7-b14ce55d24d8.png)

---

Also updated `wheel`, which had a [CVE](https://nvd.nist.gov/vuln/detail/CVE-2022-40898), though it's not installed in production so we don't anticipate this to be an issue in production.
