### PR TITLE
fix bulk-copy permissions bugs

### DIFF
--- a/hawc/apps/assessment/api/serializers.py
+++ b/hawc/apps/assessment/api/serializers.py
@@ -1,0 +1,55 @@
+from rest_framework import serializers
+
+
+class AssessmentRootedSerializer(serializers.ModelSerializer):
+    """
+    Base serializer used with AssessmentRootedTagTree model.
+    """
+
+    NO_PARENT = -1
+
+    def get_parent(self, assessment_id, validated_data, canSelectRoot):
+        parent_id = validated_data.pop("parent", self.NO_PARENT)
+
+        parent = None
+        if parent_id == self.NO_PARENT and canSelectRoot:
+            parent = self.Meta.model.get_assessment_root(assessment_id)
+        elif parent_id > 0:
+            checkParent = self.Meta.model.objects.filter(id=parent_id).first()
+            if (
+                checkParent
+                and checkParent.get_root().name
+                == self.Meta.model.get_assessment_root_name(assessment_id)
+            ):
+                parent = checkParent
+
+        return parent
+
+    def create(self, validated_data):
+        parent = self.get_parent(self.assessment.id, validated_data, canSelectRoot=False)
+        parent_id = parent.id if parent else None
+        return self.Meta.model.create_tag(self.assessment.id, parent_id=parent_id, **validated_data)
+
+    def update(self, instance, validated_data):
+        assessment = self.instance.get_assessment()
+        parent = self.get_parent(assessment.id, validated_data, canSelectRoot=True)
+
+        for attr, value in list(validated_data.items()):
+            setattr(instance, attr, value)
+        instance.save()
+
+        # check the following before moving:
+        #   1) parent exists
+        #   2) parent != self
+        #   3) new parent != old parent
+        #   4) new parent != descendant of self
+        if (
+            parent
+            and instance.id != parent.id
+            and parent.id != instance.get_parent().id
+            and parent.id not in instance.get_descendants().values_list("id", flat=True)
+        ):
+
+            instance.move(parent, pos="last-child")
+
+        return instance

--- a/hawc/apps/assessment/api/viewsets.py
+++ b/hawc/apps/assessment/api/viewsets.py
@@ -22,6 +22,7 @@ from .. import models, serializers
 from ..actions.audit import AssessmentAuditSerializer
 from ..constants import AssessmentViewSetPermissions
 from .filters import InAssessmentFilter
+from .helper import get_assessment_from_query
 from .permissions import AssessmentLevelPermissions, CleanupFieldsPermissions, user_can_edit_object
 
 # all http methods except PUT
@@ -184,11 +185,10 @@ class AssessmentViewset(mixins.RetrieveModelMixin, mixins.ListModelMixin, BaseAs
 
 class AssessmentRootedTagTreeViewset(viewsets.ModelViewSet):
     """
-    Base viewset used with utils/models/AssessmentRootedTagTree subclasses
+    Base ViewSet used with AssessmentRootedTagTree model.
     """
 
     http_method_names = METHODS_NO_PUT
-
     lookup_value_regex = re_digits
     permission_classes = (AssessmentLevelPermissions,)
     action_perms = {}
@@ -203,11 +203,15 @@ class AssessmentRootedTagTreeViewset(viewsets.ModelViewSet):
 
     @transaction.atomic
     def perform_create(self, serializer):
+        # set assessment to serializer; needed to create and check permissions
+        serializer.assessment = get_assessment_from_query(self.request)
+        if not serializer.assessment.user_is_project_manager_or_higher(self.request.user):
+            raise PermissionDenied()
         super().perform_create(serializer)
         create_object_log(
             "Created",
             serializer.instance,
-            serializer.instance.get_assessment().id,
+            serializer.assessment.id,
             self.request.user.id,
         )
 

--- a/hawc/apps/assessment/serializers.py
+++ b/hawc/apps/assessment/serializers.py
@@ -59,59 +59,6 @@ class DoseUnitsSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
-class AssessmentRootedSerializer(serializers.ModelSerializer):
-
-    NO_PARENT = -1
-
-    def get_parent(self, assessment_id, validated_data, canSelectRoot):
-        parent_id = validated_data.pop("parent", self.NO_PARENT)
-
-        parent = None
-        if parent_id == self.NO_PARENT and canSelectRoot:
-            parent = self.Meta.model.get_assessment_root(assessment_id)
-        elif parent_id > 0:
-            checkParent = self.Meta.model.objects.filter(id=parent_id).first()
-            if (
-                checkParent
-                and checkParent.get_root().name
-                == self.Meta.model.get_assessment_root_name(assessment_id)
-            ):
-                parent = checkParent
-
-        return parent
-
-    def create(self, validated_data):
-        assessment = self.root.context["view"].assessment
-        parent = self.get_parent(assessment.id, validated_data, canSelectRoot=False)
-        parent_id = parent.id if parent else None
-
-        return self.Meta.model.create_tag(assessment.id, parent_id=parent_id, **validated_data)
-
-    def update(self, instance, validated_data):
-        assessment = self.root.context["view"].assessment
-        parent = self.get_parent(assessment.id, validated_data, canSelectRoot=True)
-
-        for attr, value in list(validated_data.items()):
-            setattr(instance, attr, value)
-        instance.save()
-
-        # check the following before moving:
-        #   1) parent exists
-        #   2) parent != self
-        #   3) new parent != old parent
-        #   4) new parent != descendant of self
-        if (
-            parent
-            and instance.id != parent.id
-            and parent.id != instance.get_parent().id
-            and parent.id not in instance.get_descendants().values_list("id", flat=True)
-        ):
-
-            instance.move(parent, pos="last-child")
-
-        return instance
-
-
 class GrowthPlotSerializer(serializers.Serializer):
     model = serializers.ChoiceField(choices=["user", "assessment", "study"])
     grouper = serializers.ChoiceField(choices=["A", "Q", "M"])

--- a/hawc/apps/invitro/serializers.py
+++ b/hawc/apps/invitro/serializers.py
@@ -2,11 +2,8 @@ import json
 
 from rest_framework import serializers
 
-from ..assessment.serializers import (
-    AssessmentRootedSerializer,
-    DSSToxSerializer,
-    EffectTagsSerializer,
-)
+from ..assessment.api.serializers import AssessmentRootedSerializer
+from ..assessment.serializers import DSSToxSerializer, EffectTagsSerializer
 from ..common.api import DynamicFieldsMixin
 from ..common.helper import SerializerHelper
 from ..study.serializers import StudySerializer

--- a/hawc/apps/lit/forms.py
+++ b/hawc/apps/lit/forms.py
@@ -527,7 +527,7 @@ class TagsCopyForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         user = kwargs.pop("user", None)
-        self.assessment = kwargs.pop("assessment", None)
+        self.assessment = kwargs.pop("instance")
         super().__init__(*args, **kwargs)
         self.fields["assessment"].widget.attrs["class"] = "col-md-12"
         self.fields["assessment"].queryset = Assessment.objects.get_viewable_assessments(

--- a/hawc/apps/lit/forms.py
+++ b/hawc/apps/lit/forms.py
@@ -300,6 +300,7 @@ class SearchSelectorForm(forms.Form):
     )
 
     def __init__(self, *args, **kwargs):
+        kwargs.pop("instance")
         self.user = kwargs.pop("user")
         self.assessment = kwargs.pop("assessment")
         super().__init__(*args, **kwargs)
@@ -311,7 +312,7 @@ class SearchSelectorForm(forms.Form):
             self.fields["searches"]
             .queryset.filter(assessment__in=assessment_pks)
             .exclude(title="Manual import")
-            .order_by("assessment_id")
+            .order_by("assessment_id", "title")
         )
 
     @property

--- a/hawc/apps/lit/serializers.py
+++ b/hawc/apps/lit/serializers.py
@@ -15,7 +15,7 @@ from pydantic import Field, root_validator, validator
 from rest_framework import exceptions, serializers
 from rest_framework.exceptions import ParseError
 
-from ..assessment.serializers import AssessmentRootedSerializer
+from ..assessment.api.serializers import AssessmentRootedSerializer
 from ..common.api import DynamicFieldsMixin
 from ..common.forms import ASSESSMENT_UNIQUE_MESSAGE
 from ..common.serializers import PydanticDrfSerializer, validate_jsonschema

--- a/hawc/apps/lit/templates/lit/search_copy_selector.html
+++ b/hawc/apps/lit/templates/lit/search_copy_selector.html
@@ -1,6 +1,5 @@
 {% extends 'assessment-rooted.html' %}
 
-{% load add_class %}
 {% load crispy_forms_tags %}
 
 {% block content %}

--- a/hawc/apps/lit/views.py
+++ b/hawc/apps/lit/views.py
@@ -69,7 +69,7 @@ class LitOverview(BaseList):
         return context
 
 
-class SearchCopyAsNewSelector(BaseDetail):
+class SearchCopyAsNewSelector(BaseUpdate):
     """
     Select an existing search and copy-as-new
     """
@@ -87,10 +87,9 @@ class SearchCopyAsNewSelector(BaseDetail):
         return context
 
     def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        kwargs["user"] = self.request.user
-        kwargs["assessment"] = self.assessment
-        return kwargs
+        kw = super().get_form_kwargs()
+        kw.update(user=self.request.user, assessment=self.assessment)
+        return kw
 
     def form_valid(self, form):
         return HttpResponseRedirect(form.get_success_url())

--- a/hawc/apps/summary/forms.py
+++ b/hawc/apps/summary/forms.py
@@ -507,6 +507,7 @@ class SummaryTableCopySelectorForm(forms.Form):
     )
 
     def __init__(self, *args, **kwargs):
+        kwargs.pop("instance")
         self.cancel_url = kwargs.pop("cancel_url")
         self.assessment_id = kwargs.pop("assessment_id")
         self.queryset = kwargs.pop("queryset")
@@ -616,6 +617,7 @@ class VisualSelectorForm(forms.Form):
     visual = VisualModelChoiceField(label="Visualization", queryset=models.Visual.objects.all())
 
     def __init__(self, *args, **kwargs):
+        kwargs.pop('instance')
         self.cancel_url = kwargs.pop("cancel_url")
         self.assessment_id = kwargs.pop("assessment_id")
         self.queryset = kwargs.pop("queryset")
@@ -1104,6 +1106,7 @@ class DataPivotSelectorForm(forms.Form):
     )
 
     def __init__(self, *args, **kwargs):
+        kwargs.pop("instance")
         user = kwargs.pop("user")
         self.cancel_url = kwargs.pop("cancel_url")
         super().__init__(*args, **kwargs)

--- a/hawc/apps/summary/views.py
+++ b/hawc/apps/summary/views.py
@@ -440,6 +440,7 @@ class VisualizationCopySelector(BaseDetail):
     model = Assessment
     template_name = "summary/visual_selector.html"
     breadcrumb_active_name = "Visualization selector"
+    assessment_permission = AssessmentViewPermissions.TEAM_MEMBER
 
     def get_context_data(self, **kwargs):
         kwargs.update(


### PR DESCRIPTION
Fixed a few regressions in #732. 

Many of the non-standard bulk-copy pages were relying on getting the assessment for various functionalities. This PR fixes some 500 errors which occurred as a result of the refactorings:

- Fixed lit.Search copy
- Fixed lit.ReferenceTag creation
- Fixed lit.TagTree copy across assessment
- Fixed summary.SummaryTable copy
- Fixed summary.Visual copy
- Fixed summary.DataPivot copy

A full refactoring is being written in #799, but this will fix the immediate errors