### PR TITLE
implement epiv2 api

### DIFF
--- a/hawc/apps/common/serializers.py
+++ b/hawc/apps/common/serializers.py
@@ -5,6 +5,7 @@ import jsonschema
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
 from pydantic import BaseModel
 from pydantic import ValidationError as PydanticError
 from rest_framework import serializers
@@ -160,6 +161,59 @@ class FlexibleChoiceField(serializers.ChoiceField):
                 return key
 
         self.fail("invalid_choice", input=data)
+
+
+class ArrayedFlexibleChoiceField(serializers.ChoiceField):
+    """
+    like FlexibleChoiceField; accepts either the raw choice value OR a case-insensitive
+    display value when supplying data, intended for choice fields wrapped in an ArrayField
+    """
+
+    # dupe invalid_choice in ChoiceField, and create a new one that we'll use
+    default_error_messages = {
+        "invalid_choice": _('"{input}" is not a valid choice.'),
+        "full_custom": _("{input}"),
+    }
+
+    def to_representation(self, obj):
+        if len(obj) == 0 and self.allow_blank:
+            return obj
+        return [self._choices[x] for x in obj]
+
+    def to_internal_value(self, data):
+        if (data is None or len(data) == 0) and self.allow_blank:
+            return []
+        else:
+            converted_values = []
+            invalid_values = []
+            for x in data:
+                element_handled = False
+                # Look for an exact match of either key or val
+                for key, val in self._choices.items():
+                    if key == x or val == x:
+                        converted_values.append(key)
+                        element_handled = True
+                        break
+
+                if not element_handled:
+                    # No exact match; if a string was passed in let's try case-insensitive value match
+                    if type(x) is str:
+                        key = get_id_from_choices(self._choices.items(), x)
+                        if key is not None:
+                            converted_values.append(key)
+                            element_handled = True
+
+                if not element_handled:
+                    invalid_values.append(x)
+
+            if len(invalid_values) == 0:
+                return converted_values
+            else:
+                invalid_summary = ", ".join([f"'{x}'" for x in invalid_values])
+                self.fail(
+                    "full_custom",
+                    input=f"input {data} contained invalid value(s): {invalid_summary}.",
+                )
 
 
 class FlexibleDBLinkedChoiceField(FlexibleChoiceField):

--- a/hawc/apps/epiv2/api.py
+++ b/hawc/apps/epiv2/api.py
@@ -47,3 +47,45 @@ class Design(EditPermissionsCheckMixin, AssessmentEditViewset):
 class Metadata(viewsets.ViewSet):
     def list(self, request):
         return EpiV2Metadata.handle_request(request)
+
+
+class Chemical(EditPermissionsCheckMixin, AssessmentEditViewset):
+    edit_check_keys = ["design"]
+    assessment_filter_args = "design__study__assessment"
+    model = models.Chemical
+    serializer_class = serializers.ChemicalSerializer
+
+
+class Exposure(EditPermissionsCheckMixin, AssessmentEditViewset):
+    edit_check_keys = ["design"]
+    assessment_filter_args = "design__study__assessment"
+    model = models.Exposure
+    serializer_class = serializers.ExposureSerializer
+
+
+class ExposureLevel(EditPermissionsCheckMixin, AssessmentEditViewset):
+    edit_check_keys = ["design"]
+    assessment_filter_args = "design__study__assessment"
+    model = models.ExposureLevel
+    serializer_class = serializers.ExposureLevelSerializer
+
+
+class Outcome(EditPermissionsCheckMixin, AssessmentEditViewset):
+    edit_check_keys = ["design"]
+    assessment_filter_args = "design__study__assessment"
+    model = models.Outcome
+    serializer_class = serializers.OutcomeSerializer
+
+
+class AdjustmentFactor(EditPermissionsCheckMixin, AssessmentEditViewset):
+    edit_check_keys = ["design"]
+    assessment_filter_args = "design__study__assessment"
+    model = models.AdjustmentFactor
+    serializer_class = serializers.AdjustmentFactorSerializer
+
+
+class DataExtraction(EditPermissionsCheckMixin, AssessmentEditViewset):
+    edit_check_keys = ["design"]
+    assessment_filter_args = "design__study__assessment"
+    model = models.DataExtraction
+    serializer_class = serializers.DataExtractionSerializer

--- a/hawc/apps/epiv2/mixins.py
+++ b/hawc/apps/epiv2/mixins.py
@@ -1,0 +1,69 @@
+from rest_framework import exceptions, serializers
+
+from .models import Design
+
+
+class BelongsToSameDesignMixin:
+    """
+    ex: when updating an ExposureLevel, there's a related Chemical and Exposure sometimes passed into the payload as
+    "chemical_id" and "exposure_level_id". Basic DRF functionality verifies that the supplied values are valid
+    items in the database, but it's a common requirement that they also belong to the same parent object; in this
+    case, the same design. This mixin performs that type of validation logic.
+
+    Could potentially generalize this even further (so that it's not just useful for "Design"); this type of
+    relationship is not uncommon.
+    """
+
+    def validate(self, data):
+        fields_to_check = []
+        try:
+            fields_to_check = self.belongs_to_same_design_fields
+
+            # first off - were any of the parameters we're concerned with in the payload? If not, there's
+            # no need to perform any custom validation.
+            perform_custom_validation = False
+            for field_to_check in fields_to_check:
+                param_name = field_to_check[0]
+                if param_name in self.initial_data:
+                    perform_custom_validation = True
+                    break
+
+            if perform_custom_validation is True:
+                # figure out what design we're concerned with...
+                if "design" in self.initial_data:
+                    # load from the supplied payload...
+                    design_id = self.initial_data.get("design")
+                    design = Design.objects.get(id=design_id)
+                else:
+                    # load from the previously saved state; the APIException here should never happen but just in case...
+                    if self.instance is not None:
+                        design = self.instance.design
+                    else:
+                        raise exceptions.APIException(
+                            "validation failed; could not determine relevant design id"
+                        )
+
+            invalid_fields = []
+            for field_to_check in fields_to_check:
+                param_name = field_to_check[0]
+                model_klass = field_to_check[1]
+
+                if param_name in self.initial_data:
+                    candidate_id = self.initial_data.get(param_name)
+                    candidate_obj = model_klass.objects.get(id=candidate_id)
+
+                    if candidate_obj.design.id != design.id:
+                        invalid_fields.append(
+                            (
+                                param_name,
+                                f"object with id={candidate_id} does not belong to the correct design.",
+                            )
+                        )
+            if len(invalid_fields) > 0:
+                raise serializers.ValidationError({x[0]: x[1] for x in invalid_fields})
+        except AttributeError:
+            raise Exception(
+                f"{type(self).__name__} is configured to mixin BelongsToSameDesignMixin but lacks a properly configured property 'belongs_to_same_design_fields'"
+            )
+
+        return super().validate(data)

--- a/hawc/apps/epiv2/serializers.py
+++ b/hawc/apps/epiv2/serializers.py
@@ -1,77 +1,168 @@
 from django.db import transaction
 from rest_framework import serializers
 
-from ..common.serializers import FlexibleChoiceField, IdLookupMixin
+from ..assessment.models import DSSTox
+from ..assessment.serializers import DSSToxSerializer
+from ..common.serializers import ArrayedFlexibleChoiceField, FlexibleChoiceField, IdLookupMixin
 from ..epi.serializers import StudyPopulationCountrySerializer
+from ..study.models import Study
 from ..study.serializers import StudySerializer
-from . import constants, models
+from . import constants, mixins, models
 
 
 class ChemicalSerializer(serializers.ModelSerializer):
+    dsstox_id = serializers.PrimaryKeyRelatedField(
+        write_only=True,
+        source="dsstox",
+        queryset=DSSTox.objects.all(),
+        required=False,
+        allow_null=True,
+    )
+    dsstox = DSSToxSerializer(read_only=True)
+
     class Meta:
         model = models.Chemical
-        fields = ["id", "name", "dsstox"]
+        fields = ["id", "design", "name", "dsstox_id", "dsstox"]
 
 
 class ExposureSerializer(serializers.ModelSerializer):
     exposure_route = FlexibleChoiceField(choices=constants.ExposureRoute.choices)
+    biomonitoring_matrix = FlexibleChoiceField(
+        choices=constants.BiomonitoringMatrix.choices, allow_blank=True
+    )
+    biomonitoring_source = FlexibleChoiceField(
+        choices=constants.BiomonitoringSource.choices, allow_blank=True
+    )
 
     class Meta:
         model = models.Exposure
-        exclude = ["design", "created", "last_updated"]
+        exclude = ["created", "last_updated"]
 
 
-class ExposureLevelSerializer(serializers.ModelSerializer):
+class ExposureLevelSerializer(mixins.BelongsToSameDesignMixin, serializers.ModelSerializer):
+    variance_type = FlexibleChoiceField(choices=constants.VarianceType.choices)
+    ci_type = FlexibleChoiceField(choices=constants.ConfidenceIntervalType.choices)
+
+    belongs_to_same_design_fields = [
+        ("chemical_id", models.Chemical),
+        ("exposure_measurement_id", models.Exposure),
+    ]
+
+    chemical_id = serializers.PrimaryKeyRelatedField(
+        write_only=True,
+        source="chemical",
+        queryset=models.Chemical.objects.all(),
+        required=True,
+        allow_null=False,
+    )
+    chemical = ChemicalSerializer(read_only=True)
+    exposure_measurement_id = serializers.PrimaryKeyRelatedField(
+        write_only=True,
+        source="exposure_measurement",
+        queryset=models.Exposure.objects.all(),
+        required=True,
+        allow_null=False,
+    )
+    exposure_measurement = ExposureSerializer(read_only=True)
+
     class Meta:
         model = models.ExposureLevel
-        exclude = ["design", "created", "last_updated"]
+        exclude = ["created", "last_updated"]
 
 
 class OutcomeSerializer(serializers.ModelSerializer):
+    system = FlexibleChoiceField(choices=constants.HealthOutcomeSystem.choices)
+
     class Meta:
         model = models.Outcome
-        exclude = ["design", "created", "last_updated"]
+        exclude = ["created", "last_updated"]
 
 
 class AdjustmentFactorSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.AdjustmentFactor
-        exclude = ["design", "created", "last_updated"]
+        exclude = ["created", "last_updated"]
 
 
-class DataExtractionSerializer(serializers.ModelSerializer):
+class DataExtractionSerializer(mixins.BelongsToSameDesignMixin, serializers.ModelSerializer):
+    ci_type = FlexibleChoiceField(choices=constants.ConfidenceIntervalType.choices)
+    variance_type = FlexibleChoiceField(choices=constants.VarianceType.choices)
+    significant = FlexibleChoiceField(choices=constants.Significant.choices)
+
+    belongs_to_same_design_fields = [
+        ("outcome_id", models.Outcome),
+        ("exposure_level_id", models.ExposureLevel),
+        ("factors_id", models.AdjustmentFactor),
+    ]
+
+    outcome_id = serializers.PrimaryKeyRelatedField(
+        write_only=True,
+        source="outcome",
+        queryset=models.Outcome.objects.all(),
+        required=True,
+        allow_null=False,
+    )
+    outcome = OutcomeSerializer(read_only=True)
+
+    exposure_level_id = serializers.PrimaryKeyRelatedField(
+        write_only=True,
+        source="exposure_level",
+        queryset=models.ExposureLevel.objects.all(),
+        required=True,
+        allow_null=False,
+    )
+    exposure_level = ExposureLevelSerializer(read_only=True)
+
+    factors_id = serializers.PrimaryKeyRelatedField(
+        write_only=True,
+        source="factors",
+        queryset=models.AdjustmentFactor.objects.all(),
+        required=False,
+        allow_null=True,
+    )
+    factors = AdjustmentFactorSerializer(read_only=True)
+
     class Meta:
         model = models.DataExtraction
-        exclude = ["design", "created", "last_updated"]
+        exclude = ["created", "last_updated"]
 
 
 class DesignSerializer(IdLookupMixin, serializers.ModelSerializer):
-    study = StudySerializer()
+    study_id = serializers.PrimaryKeyRelatedField(
+        write_only=True,
+        source="study",
+        queryset=Study.objects.all(),
+        required=True,
+        allow_null=False,
+    )
+    study = StudySerializer(read_only=True)
+
     study_design = FlexibleChoiceField(choices=constants.StudyDesign.choices)
+    age_profile = ArrayedFlexibleChoiceField(choices=constants.AgeProfile.choices)
     source = FlexibleChoiceField(choices=constants.Source.choices)
     sex = FlexibleChoiceField(choices=constants.Sex.choices)
     countries = StudyPopulationCountrySerializer(many=True)
     chemicals = ChemicalSerializer(many=True, read_only=True)
-    exposure = ExposureSerializer(many=True, read_only=True)
+    exposures = ExposureSerializer(many=True, read_only=True)
     exposure_levels = ExposureLevelSerializer(many=True, read_only=True)
     outcomes = OutcomeSerializer(many=True, read_only=True)
     adjustment_factors = AdjustmentFactorSerializer(many=True, read_only=True)
     data_extractions = DataExtractionSerializer(many=True, read_only=True)
     url = serializers.CharField(source="get_absolute_url", read_only=True)
 
+    nested_models = [
+        "countries",
+    ]
+
     @transaction.atomic
     def create(self, validated_data):
-        nested_models = [
-            "countries",
-        ]
-
         if "age_profile" not in validated_data:
             validated_data["age_profile"] = []
 
         nested_validated_data = {}
 
         # remove nested models from validated_data
-        for model in nested_models:
+        for model in self.nested_models:
             data = validated_data.pop(model, None)
             nested_validated_data.update({model: data})
 
@@ -84,6 +175,24 @@ class DesignSerializer(IdLookupMixin, serializers.ModelSerializer):
 
         return instance
 
+    @transaction.atomic
+    def update(self, instance, validated_data):
+        nested_validated_data = {}
+
+        # remove nested models from validated_data
+        for model in self.nested_models:
+            data = validated_data.pop(model, None)
+            nested_validated_data.update({model: data})
+
+        # execute inherited create method
+        instance = super().update(instance, validated_data)
+
+        # add nested models to the instance
+        if countries := nested_validated_data.get("countries"):
+            instance.countries.set(countries)
+
+        return instance
+
     class Meta:
         model = models.Design
-        fields = "__all__"
+        exclude = ["created", "last_updated"]

--- a/hawc/apps/epiv2/urls.py
+++ b/hawc/apps/epiv2/urls.py
@@ -7,6 +7,12 @@ router = SimpleRouter()
 router.register(r"assessment", api.EpiAssessmentViewset, basename="assessment")
 router.register(r"design", api.Design, basename="design")
 router.register(r"metadata", api.Metadata, basename="metadata")
+router.register(r"chemical", api.Chemical, basename="chemical")
+router.register(r"exposure", api.Exposure, basename="exposure")
+router.register(r"exposurelevel", api.ExposureLevel, basename="exposurelevel")
+router.register(r"outcome", api.Outcome, basename="outcome")
+router.register(r"adjustmentfactor", api.AdjustmentFactor, basename="adjustmentfactor")
+router.register(r"dataextraction", api.DataExtraction, basename="dataextraction")
 
 app_name = "epiv2"
 urlpatterns = [

--- a/tests/hawc/apps/bmd/test_models.py
+++ b/tests/hawc/apps/bmd/test_models.py
@@ -1,11 +1,16 @@
+import os
+
 import pytest
 
 from hawc.apps.animal.models import Endpoint
 from hawc.apps.bmd.constants import SelectedModel
 from hawc.apps.bmd.models import Session
 
+SKIP_BMDS_TESTS = os.environ.get("SKIP_BMDS_TESTS", "0") == "1"
+
 
 @pytest.mark.django_db
+@pytest.mark.skipif(SKIP_BMDS_TESTS is True, reason="skippyjon")
 class TestBmdSession:
     def test_dichotomous(self):
         # create new session w/ inputs

--- a/tests/hawc/apps/epiv2/test_api.py
+++ b/tests/hawc/apps/epiv2/test_api.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 from django.core.exceptions import ObjectDoesNotExist
+from django.db.models import Q
 from django.urls import reverse
 from rest_framework.test import APIClient
 
@@ -36,7 +37,7 @@ class TestDesignApi:
     def test_permissions(self, db_keys):
         url = reverse("epiv2:api:design-list")
         data = {
-            "study": db_keys.study_working,
+            "study_id": db_keys.study_working,
             "study_design": "CC",
             "source": "GP",
             "age_description": "10-15 yrs",
@@ -58,7 +59,7 @@ class TestDesignApi:
         assert client.login(username="team@hawcproject.org", password="pw") is True
 
         data = {
-            "study": db_keys.study_working,
+            "study_id": db_keys.study_working,
             "study_design": "CC",
             "source": "GP",
             "age_description": "10-15 yrs",
@@ -126,6 +127,14 @@ class TestDesignApi:
                 "method": "PATCH",
                 "post_request_test": altered_design_test,
             },
+            {
+                "desc": "countries and age profiles update",
+                "expected_code": 200,
+                "expected_keys": {"id"},
+                "data": {"countries": ["JP", "DK"], "age_profile": ["AD", "other"]},
+                "method": "PATCH",
+                "post_request_test": altered_design_test,
+            },
         )
         url = f"{url}{just_created_design_id}/"
         generic_test_scenarios(client, url, update_scenarios)
@@ -149,16 +158,52 @@ class TestDesignApi:
             {
                 "desc": "empty payload doesn't crash",
                 "expected_code": 400,
-                "expected_keys": {"study"},
+                "expected_keys": {"study_id"},
                 "data": {},
             },
             {
                 "desc": "valid study id req'd",
                 "expected_code": 400,
-                "expected_keys": {"study"},
+                "expected_keys": {"study_id"},
                 "data": {"study": -1},
             },
+            {
+                "desc": "invalid country",
+                "expected_code": 400,
+                "expected_keys": {"countries"},
+                "expected_content": "is not a country",
+                "data": {"countries": ["XX"]},
+            },
+            {
+                "desc": "invalid study_design",
+                "expected_code": 400,
+                "expected_keys": {"study_design"},
+                "expected_content": "not a valid choice",
+                "data": {"study_design": "XX"},
+            },
+            {
+                "desc": "invalid age_profile",
+                "expected_code": 400,
+                "expected_keys": {"age_profile"},
+                "expected_content": "contained invalid value(s)",
+                "data": {"age_profile": ["XX", "xx"]},
+            },
+            {
+                "desc": "invalid source",
+                "expected_code": 400,
+                "expected_keys": {"source"},
+                "expected_content": "not a valid choice",
+                "data": {"source": "XX"},
+            },
+            {
+                "desc": "invalid sex",
+                "expected_code": 400,
+                "expected_keys": {"sex"},
+                "expected_content": "not a valid choice",
+                "data": {"sex": "XX"},
+            },
         )
+
         generic_test_scenarios(client, url, scenarios)
 
 
@@ -172,40 +217,44 @@ def check_details_of_last_log_entry(obj_id: int, start_of_msg: str):
 
 def generic_test_scenarios(client, url, scenarios):
     for scenario in scenarios:
-        method = scenario.get("method", "POST")
-        if "data" in scenario:
-            pass
+        generic_test_scenario(client, url, scenario)
+
+
+def generic_test_scenario(client, url, scenario):
+    method = scenario.get("method", "POST")
+    if "data" in scenario:
+        pass
+    if method.upper() == "POST":
+        response = client.post(url, scenario["data"], format="json")
+    elif method.upper() == "PATCH":
+        response = client.patch(url, scenario["data"], format="json")
+    elif method.upper() == "DELETE":
+        response = client.delete(url)
+    else:
+        return
+
+    if "expected_code" in scenario:
+        assert response.status_code == scenario["expected_code"]
+
+    if "expected_keys" in scenario:
+        assert (scenario["expected_keys"]).issubset(response.data.keys())
+
+    if "expected_content" in scenario:
+        assert str(response.data).lower().find(scenario["expected_content"].lower()) != -1
+
+    if "post_request_test" in scenario:
+        scenario["post_request_test"](response)
+
+    # make sure the audit/log table is getting updated while we're at it
+    if response.status_code in [200, 201, 204]:  # successful create/update/delete:
         if method.upper() == "POST":
-            response = client.post(url, scenario["data"], format="json")
+            check_details_of_last_log_entry(response.data["id"], "Created")
         elif method.upper() == "PATCH":
-            response = client.patch(url, scenario["data"], format="json")
+            check_details_of_last_log_entry(response.data["id"], "Updated")
         elif method.upper() == "DELETE":
-            response = client.delete(url)
-        else:
-            return
-
-        if "expected_code" in scenario:
-            assert response.status_code == scenario["expected_code"]
-
-        if "expected_keys" in scenario:
-            assert (scenario["expected_keys"]).issubset(response.data.keys())
-
-        if "expected_content" in scenario:
-            assert str(response.data).lower().find(scenario["expected_content"].lower()) != -1
-
-        if "post_request_test" in scenario:
-            scenario["post_request_test"](response)
-
-        # make sure the audit/log table is getting updated while we're at it
-        if response.status_code in [200, 201, 204]:  # successful create/update/delete:
-            if method.upper() == "POST":
-                check_details_of_last_log_entry(response.data["id"], "Created")
-            elif method.upper() == "PATCH":
-                check_details_of_last_log_entry(response.data["id"], "Updated")
-            elif method.upper() == "DELETE":
-                # get the id from the url, e.g. "/epi/api/study-population/2/"
-                deleted_id = url.strip("/").split("/")[-1]
-                check_details_of_last_log_entry(deleted_id, "Deleted")
+            # get the id from the url, e.g. "/epi/api/study-population/2/"
+            deleted_id = url.strip("/").split("/")[-1]
+            check_details_of_last_log_entry(deleted_id, "Deleted")
 
 
 def generic_perm_tester(url, data):
@@ -213,11 +262,13 @@ def generic_perm_tester(url, data):
     client = APIClient()
     assert client.login(username="reviewer@hawcproject.org", password="pw") is True
     response = client.post(url, data, format="json")
+
     assert response.status_code == 403
 
     # Public shouldn't be able to create
     client = APIClient()
     response = client.post(url, data, format="json")
+
     assert response.status_code == 403
 
 
@@ -248,3 +299,929 @@ class TestMetadataApi:
             path.write_text(json.dumps(data, indent=2, sort_keys=True))
 
         assert data == json.loads(path.read_text())
+
+
+@pytest.mark.django_db
+class TestChemicalApi:
+    def get_upload_data(self, overrides=None):
+        design = generic_get_any(models.Design)
+
+        data = {
+            "design": design.id,
+            "name": "sample chemical via api",
+            "dsstox_id": "DTXSID6026296",
+        }
+
+        if overrides is not None:
+            data.update(overrides)
+
+        return data
+
+    def test_permissions(self, db_keys):
+        url = reverse("epiv2:api:chemical-list")
+        generic_perm_tester(url, self.get_upload_data())
+
+    def test_bad_requests(self, db_keys):
+        url = reverse("epiv2:api:chemical-list")
+        client = APIClient()
+        assert client.login(username="admin@hawcproject.org", password="pw") is True
+
+        scenarios = (
+            {"desc": "empty payload doesn't crash", "expected_code": 400, "data": {}},
+            {
+                "desc": "non-legal value for dsstox",
+                "expected_code": 400,
+                "expected_content": "object does not exist",
+                "data": self.get_upload_data({"dsstox_id": "invalid_id"}),
+            },
+            {
+                "desc": "missing design",
+                "expected_code": 400,
+                "expected_content": "may not be null",
+                "data": self.get_upload_data({"design": None}),
+            },
+        )
+
+        generic_test_scenarios(client, url, scenarios)
+
+    def test_valid_requests(self, db_keys):
+        url = reverse("epiv2:api:chemical-list")
+        client = APIClient()
+        assert client.login(username="admin@hawcproject.org", password="pw") is True
+
+        just_created_chemical_id = None
+        base_data = self.get_upload_data()
+
+        def chemical_lookup_test(resp):
+            nonlocal just_created_chemical_id
+
+            chem_id = resp.json()["id"]
+            chemical = models.Chemical.objects.get(id=chem_id)
+            assert chemical.name == base_data["name"]
+
+            if just_created_chemical_id is None:
+                just_created_chemical_id = chem_id
+
+        def altered_chemical_name_test(resp):
+            nonlocal just_created_chemical_id
+
+            chem_id = resp.json()["id"]
+            chemical = models.Chemical.objects.get(id=chem_id)
+            assert chemical.name == "updated"
+            assert chem_id == just_created_chemical_id
+
+        def altered_chemical_dtxsid_test(resp):
+            chem_id = resp.json()["id"]
+            chemical = models.Chemical.objects.get(id=chem_id)
+            assert chemical.dsstox.dtxsid == "DTXSID7020970"
+
+        def deleted_chemical_test(resp):
+            nonlocal just_created_chemical_id
+
+            assert resp.data is None
+
+            with pytest.raises(ObjectDoesNotExist):
+                models.Chemical.objects.get(id=just_created_chemical_id)
+
+        create_scenarios = (
+            {
+                "desc": "basic chemical creation",
+                "expected_code": 201,
+                "expected_keys": {"id"},
+                "data": self.get_upload_data(),
+                "post_request_test": chemical_lookup_test,
+            },
+        )
+        generic_test_scenarios(client, url, create_scenarios)
+
+        url = f"{url}{just_created_chemical_id}/"
+        update_scenarios = (
+            {
+                "desc": "name update",
+                "expected_code": 200,
+                "expected_keys": {"id"},
+                "data": {"name": "updated"},
+                "method": "PATCH",
+                "post_request_test": altered_chemical_name_test,
+            },
+            {
+                "desc": "dtxsid update",
+                "expected_code": 200,
+                "expected_keys": {"id"},
+                "data": {"dsstox_id": "DTXSID7020970"},
+                "method": "PATCH",
+                "post_request_test": altered_chemical_dtxsid_test,
+            },
+        )
+        generic_test_scenarios(client, url, update_scenarios)
+
+        delete_scenarios = (
+            {
+                "desc": "chemical delete",
+                "expected_code": 204,
+                "method": "DELETE",
+                "post_request_test": deleted_chemical_test,
+            },
+        )
+        generic_test_scenarios(client, url, delete_scenarios)
+
+
+@pytest.mark.django_db
+class TestExposureApi:
+    def get_upload_data(self, overrides=None):
+        design = generic_get_any(models.Design)
+
+        data = {
+            "design": design.id,
+            "exposure_route": "IH",
+            "name": "sample expo via api",
+            "measurement_type": ["Questionnaire", "Modeled"],
+            "biomonitoring_matrix": "UR",
+            "biomonitoring_source": "ML",
+            "measurement_timing": "cross-sectional",
+            "measurement_method": "test case method details here",
+            "comments": "test case comments here",
+        }
+
+        if overrides is not None:
+            data.update(overrides)
+
+        return data
+
+    def test_permissions(self, db_keys):
+        url = reverse("epiv2:api:exposure-list")
+        generic_perm_tester(url, self.get_upload_data())
+
+    def test_bad_requests(self, db_keys):
+        url = reverse("epiv2:api:exposure-list")
+        client = APIClient()
+        assert client.login(username="admin@hawcproject.org", password="pw") is True
+
+        scenarios = (
+            {"desc": "empty payload doesn't crash", "expected_code": 400, "data": {}},
+            {
+                "desc": "non-legal value for biomonitoring matrix",
+                "expected_code": 400,
+                "expected_keys": {"biomonitoring_matrix"},
+                "data": self.get_upload_data({"biomonitoring_matrix": "XX"}),
+            },
+            {
+                "desc": "non-legal value for exposure route",
+                "expected_code": 400,
+                "expected_keys": {"exposure_route"},
+                "data": self.get_upload_data({"exposure_route": "XX"}),
+            },
+            {
+                "desc": "design must be valid",
+                "expected_code": 400,
+                "expected_keys": {"design"},
+                "expected_content": "object does not exist",
+                "data": self.get_upload_data({"design": 999}),
+            },
+            {
+                "desc": "missing design",
+                "expected_code": 400,
+                "expected_content": "may not be null",
+                "data": self.get_upload_data({"design": None}),
+            },
+        )
+
+        generic_test_scenarios(client, url, scenarios)
+
+    def test_valid_requests(self, db_keys):
+        url = reverse("epiv2:api:exposure-list")
+        client = APIClient()
+        assert client.login(username="admin@hawcproject.org", password="pw") is True
+
+        just_created_exposure_id = None
+        base_data = self.get_upload_data()
+
+        def exposure_lookup_test(resp):
+            nonlocal just_created_exposure_id
+
+            exposure_id = resp.json()["id"]
+            exposure = models.Exposure.objects.get(id=exposure_id)
+            assert exposure.name == base_data["name"]
+
+            if just_created_exposure_id is None:
+                just_created_exposure_id = exposure_id
+
+        def altered_exposure_test(resp):
+            nonlocal just_created_exposure_id
+
+            exposure_id = resp.json()["id"]
+            exposure = models.Exposure.objects.get(id=exposure_id)
+            assert exposure.name == "updated"
+            assert exposure_id == just_created_exposure_id
+
+        def deleted_exposure_test(resp):
+            nonlocal just_created_exposure_id
+
+            assert resp.data is None
+
+            with pytest.raises(ObjectDoesNotExist):
+                models.Exposure.objects.get(id=just_created_exposure_id)
+
+        create_scenarios = (
+            {
+                "desc": "basic exposure creation",
+                "expected_code": 201,
+                "expected_keys": {"id"},
+                "data": self.get_upload_data(),
+                "post_request_test": exposure_lookup_test,
+            },
+        )
+        generic_test_scenarios(client, url, create_scenarios)
+
+        url = f"{url}{just_created_exposure_id}/"
+        update_scenarios = (
+            {
+                "desc": "basic exposure update",
+                "expected_code": 200,
+                "expected_keys": {"id"},
+                "data": {"name": "updated"},
+                "method": "PATCH",
+                "post_request_test": altered_exposure_test,
+            },
+            {
+                "desc": "case-insensitive readable values instead of enum codes",
+                "expected_code": 200,
+                "expected_keys": {"id"},
+                "data": {
+                    "exposure_route": "DeRmAl",
+                    "biomonitoring_matrix": "SALIVA",
+                    "biomonitoring_source": "matERNAL",
+                },
+                "method": "PATCH",
+            },
+        )
+        generic_test_scenarios(client, url, update_scenarios)
+
+        delete_scenarios = (
+            {
+                "desc": "exposure delete",
+                "expected_code": 204,
+                "method": "DELETE",
+                "post_request_test": deleted_exposure_test,
+            },
+        )
+        generic_test_scenarios(client, url, delete_scenarios)
+
+
+@pytest.mark.django_db
+class TestExposureLevelApi:
+    def get_upload_data(self, overrides=None):
+        design = generic_get_any(models.Design)
+        chemical = models.Chemical.objects.filter(design=design.id).first()
+        exposure = models.Exposure.objects.filter(design=design.id).first()
+
+        data = {
+            "name": "test exposure level creation",
+            "sub_population": "test subpop",
+            "median": 1,
+            "mean": 2,
+            "variance": 3,
+            "variance_type": 1,
+            "units": "ng",
+            "ci_lcl": "4",
+            "percentile_25": "5",
+            "percentile_75": "6",
+            "ci_ucl": "7",
+            "ci_type": "Rng",
+            "negligible_exposure": "8",
+            "data_location": "99",
+            "comments": "expolev comments a",
+            "design": design.id,
+            "chemical_id": chemical.id,
+            "exposure_measurement_id": exposure.id,
+        }
+
+        if overrides is not None:
+            data.update(overrides)
+
+        return data
+
+    def test_permissions(self, db_keys):
+        url = reverse("epiv2:api:exposurelevel-list")
+        generic_perm_tester(url, self.get_upload_data())
+
+    def test_bad_requests(self, db_keys):
+        url = reverse("epiv2:api:exposurelevel-list")
+        client = APIClient()
+        assert client.login(username="admin@hawcproject.org", password="pw") is True
+
+        base_data = self.get_upload_data()
+        base_data_design_id = base_data["design"]
+        non_design_chemical = models.Chemical.objects.filter(~Q(design=base_data_design_id)).first()
+        non_design_exposure = models.Exposure.objects.filter(~Q(design=base_data_design_id)).first()
+
+        scenarios = (
+            {"desc": "empty payload doesn't crash", "expected_code": 400, "data": {}},
+            {
+                "desc": "non-existent value for chemical",
+                "expected_code": 400,
+                "expected_content": "object does not exist",
+                "data": self.get_upload_data({"chemical_id": -1}),
+            },
+            {
+                "desc": "non-existent value for exposure",
+                "expected_code": 400,
+                "expected_content": "object does not exist",
+                "data": self.get_upload_data({"exposure_measurement_id": -1}),
+            },
+            {
+                "desc": "chemical that exists but is not part of this design",
+                "expected_code": 400,
+                "expected_content": "does not belong to the correct design",
+                "data": self.get_upload_data({"chemical_id": non_design_chemical.id}),
+            },
+            {
+                "desc": "exposure that exists but is not part of this design",
+                "expected_code": 400,
+                "expected_content": "does not belong to the correct design",
+                "data": self.get_upload_data({"exposure_measurement_id": non_design_exposure.id}),
+            },
+            {
+                "desc": "illegal variance_type",
+                "expected_code": 400,
+                "expected_content": "not a valid choice",
+                "data": self.get_upload_data({"variance_type": -1}),
+            },
+            {
+                "desc": "illegal lower/upper interval type",
+                "expected_code": 400,
+                "expected_content": "not a valid choice",
+                "data": self.get_upload_data({"ci_type": "xyz"}),
+            },
+            {
+                "desc": "missing design",
+                "expected_code": 400,
+                "expected_content": "may not be null",
+                "data": self.get_upload_data({"design": None}),
+            },
+        )
+
+        generic_test_scenarios(client, url, scenarios)
+
+    def test_valid_requests(self, db_keys):
+        url = reverse("epiv2:api:exposurelevel-list")
+        client = APIClient()
+        assert client.login(username="admin@hawcproject.org", password="pw") is True
+
+        just_created_expolev_id = None
+        base_data = self.get_upload_data()
+
+        base_data_design_id = base_data["design"]
+        other_design = models.Design.objects.filter(~Q(id=base_data_design_id)).first()
+        other_chem = models.Chemical.objects.filter(design=other_design.id).first()
+        other_exposure = models.Exposure.objects.filter(design=other_design.id).first()
+
+        def expolevel_lookup_test(resp):
+            nonlocal just_created_expolev_id
+
+            expolev_id = resp.json()["id"]
+            expolevel = models.ExposureLevel.objects.get(id=expolev_id)
+            assert expolevel.name == base_data["name"]
+
+            if just_created_expolev_id is None:
+                just_created_expolev_id = expolev_id
+
+        def altered_expolevel_name_test(resp):
+            nonlocal just_created_expolev_id
+
+            expolev_id = resp.json()["id"]
+            expolevel = models.ExposureLevel.objects.get(id=expolev_id)
+            assert expolevel.name == "updated expolev"
+            assert expolev_id == just_created_expolev_id
+
+        def deleted_expolevel_test(resp):
+            nonlocal just_created_expolev_id
+
+            assert resp.data is None
+
+            with pytest.raises(ObjectDoesNotExist):
+                models.ExposureLevel.objects.get(id=just_created_expolev_id)
+
+        create_scenarios = (
+            {
+                "desc": "basic expolevel creation",
+                "expected_code": 201,
+                "expected_keys": {"id"},
+                "data": self.get_upload_data(),
+                "post_request_test": expolevel_lookup_test,
+            },
+        )
+        generic_test_scenarios(client, url, create_scenarios)
+
+        url = f"{url}{just_created_expolev_id}/"
+        update_scenarios = (
+            {
+                "desc": "name update",
+                "expected_code": 200,
+                "expected_keys": {"id"},
+                "data": {"name": "updated expolev"},
+                "method": "PATCH",
+                "post_request_test": altered_expolevel_name_test,
+            },
+            {
+                "desc": "design/chemical/exposuremeasurement legal update",
+                "expected_code": 200,
+                "expected_keys": {"id"},
+                "data": {
+                    "design": other_design.id,
+                    "chemical_id": other_chem.id,
+                    "exposure_measurement_id": other_exposure.id,
+                },
+                "method": "PATCH",
+            },
+            {
+                "desc": "legal variance/ci type modifications",
+                "expected_code": 200,
+                "expected_keys": {"id"},
+                "data": {"ci_type": "P90", "variance_type": 5},
+                "method": "PATCH",
+            },
+            {
+                "desc": "case-insensitive readable values instead of enum codes",
+                "expected_code": 200,
+                "expected_keys": {"id"},
+                "data": {"variance_type": "GsD", "ci_type": "10th/90th percentile"},
+                "method": "PATCH",
+            },
+        )
+        generic_test_scenarios(client, url, update_scenarios)
+
+        delete_scenarios = (
+            {
+                "desc": "expolevel delete",
+                "expected_code": 204,
+                "method": "DELETE",
+                "post_request_test": deleted_expolevel_test,
+            },
+        )
+        generic_test_scenarios(client, url, delete_scenarios)
+
+
+@pytest.mark.django_db
+class TestOutcomeApi:
+    def get_upload_data(self, overrides=None):
+        design = generic_get_any(models.Design)
+
+        data = {
+            "system": "OC",
+            "effect": "eye stuff",
+            "effect_detail": "eye detail here",
+            "endpoint": "eye endpoint here",
+            "comments": "comments here",
+            "design": design.id,
+        }
+
+        if overrides is not None:
+            data.update(overrides)
+
+        return data
+
+    def test_permissions(self, db_keys):
+        url = reverse("epiv2:api:outcome-list")
+        generic_perm_tester(url, self.get_upload_data())
+
+    def test_bad_requests(self, db_keys):
+        url = reverse("epiv2:api:outcome-list")
+        client = APIClient()
+        assert client.login(username="admin@hawcproject.org", password="pw") is True
+
+        scenarios = (
+            {"desc": "empty payload doesn't crash", "expected_code": 400, "data": {}},
+            {
+                "desc": "invalid system",
+                "expected_code": 400,
+                "expected_content": "not a valid choice",
+                "data": self.get_upload_data({"system": "bad system"}),
+            },
+            {
+                "desc": "missing design",
+                "expected_code": 400,
+                "expected_content": "may not be null",
+                "data": self.get_upload_data({"design": None}),
+            },
+        )
+
+        generic_test_scenarios(client, url, scenarios)
+
+    def test_valid_requests(self, db_keys):
+        url = reverse("epiv2:api:outcome-list")
+        client = APIClient()
+        assert client.login(username="admin@hawcproject.org", password="pw") is True
+
+        just_created_outcome_id = None
+        base_data = self.get_upload_data()
+
+        def outcome_lookup_test(resp):
+            nonlocal just_created_outcome_id
+
+            outcome_id = resp.json()["id"]
+            outcome = models.Outcome.objects.get(id=outcome_id)
+            assert outcome.effect_detail == base_data["effect_detail"]
+
+            if just_created_outcome_id is None:
+                just_created_outcome_id = outcome_id
+
+        def altered_outcome_test(resp):
+            nonlocal just_created_outcome_id
+
+            outcome_id = resp.json()["id"]
+            outcome = models.Outcome.objects.get(id=outcome_id)
+            assert outcome.effect_detail == "altered detail"
+            assert outcome_id == just_created_outcome_id
+
+        def deleted_outcome_test(resp):
+            nonlocal just_created_outcome_id
+
+            assert resp.data is None
+
+            with pytest.raises(ObjectDoesNotExist):
+                models.Outcome.objects.get(id=just_created_outcome_id)
+
+        create_scenarios = (
+            {
+                "desc": "basic outcome creation",
+                "expected_code": 201,
+                "expected_keys": {"id"},
+                "data": self.get_upload_data(),
+                "post_request_test": outcome_lookup_test,
+            },
+        )
+        generic_test_scenarios(client, url, create_scenarios)
+
+        url = f"{url}{just_created_outcome_id}/"
+        update_scenarios = (
+            {
+                "desc": "name update",
+                "expected_code": 200,
+                "expected_keys": {"id"},
+                "data": {"effect_detail": "altered detail"},
+                "method": "PATCH",
+                "post_request_test": altered_outcome_test,
+            },
+            {
+                "desc": "valid system update",
+                "expected_code": 200,
+                "expected_keys": {"id"},
+                "data": {
+                    "system": "CA",
+                },
+                "method": "PATCH",
+            },
+            {
+                "desc": "case-insensitive readable values instead of enum codes",
+                "expected_code": 200,
+                "expected_keys": {"id"},
+                "data": {"system": "mEtAbOlIc"},
+                "method": "PATCH",
+            },
+        )
+        generic_test_scenarios(client, url, update_scenarios)
+
+        delete_scenarios = (
+            {
+                "desc": "outcome delete",
+                "expected_code": 204,
+                "method": "DELETE",
+                "post_request_test": deleted_outcome_test,
+            },
+        )
+        generic_test_scenarios(client, url, delete_scenarios)
+
+
+@pytest.mark.django_db
+class TestAdjustmentFactorApi:
+    def get_upload_data(self, overrides=None):
+        design = generic_get_any(models.Design)
+
+        data = {
+            "name": "test name for adjfac",
+            "description": "test description for adjfac",
+            "comments": "test comments made via api",
+            "design": design.id,
+        }
+
+        if overrides is not None:
+            data.update(overrides)
+
+        return data
+
+    def test_permissions(self, db_keys):
+        url = reverse("epiv2:api:adjustmentfactor-list")
+        generic_perm_tester(url, self.get_upload_data())
+
+    def test_bad_requests(self, db_keys):
+        url = reverse("epiv2:api:adjustmentfactor-list")
+        client = APIClient()
+        assert client.login(username="admin@hawcproject.org", password="pw") is True
+
+        scenarios = (
+            {"desc": "empty payload doesn't crash", "expected_code": 400, "data": {}},
+            {
+                "desc": "missing design",
+                "expected_code": 400,
+                "expected_content": "may not be null",
+                "data": self.get_upload_data({"design": None}),
+            },
+        )
+
+        generic_test_scenarios(client, url, scenarios)
+
+    def test_valid_requests(self, db_keys):
+        url = reverse("epiv2:api:adjustmentfactor-list")
+        client = APIClient()
+        assert client.login(username="admin@hawcproject.org", password="pw") is True
+
+        just_created_adjustment_factor_id = None
+        base_data = self.get_upload_data()
+
+        def adjustment_factor_lookup_test(resp):
+            nonlocal just_created_adjustment_factor_id
+
+            adjustment_factor_id = resp.json()["id"]
+            adjustment_factor = models.AdjustmentFactor.objects.get(id=adjustment_factor_id)
+            assert adjustment_factor.name == base_data["name"]
+
+            if just_created_adjustment_factor_id is None:
+                just_created_adjustment_factor_id = adjustment_factor_id
+
+        def altered_adjustment_factor_test(resp):
+            nonlocal just_created_adjustment_factor_id
+
+            adjustment_factor_id = resp.json()["id"]
+            adjustment_factor = models.AdjustmentFactor.objects.get(id=adjustment_factor_id)
+            assert adjustment_factor.name == "altered adjfac name"
+            assert adjustment_factor_id == just_created_adjustment_factor_id
+
+        def deleted_adjustment_factor_test(resp):
+            nonlocal just_created_adjustment_factor_id
+
+            assert resp.data is None
+
+            with pytest.raises(ObjectDoesNotExist):
+                models.AdjustmentFactor.objects.get(id=just_created_adjustment_factor_id)
+
+        create_scenarios = (
+            {
+                "desc": "basic adjustmentfactor creation",
+                "expected_code": 201,
+                "expected_keys": {"id"},
+                "data": self.get_upload_data(),
+                "post_request_test": adjustment_factor_lookup_test,
+            },
+        )
+        generic_test_scenarios(client, url, create_scenarios)
+
+        url = f"{url}{just_created_adjustment_factor_id}/"
+        update_scenarios = (
+            {
+                "desc": "name update",
+                "expected_code": 200,
+                "expected_keys": {"id"},
+                "data": {"name": "altered adjfac name"},
+                "method": "PATCH",
+                "post_request_test": altered_adjustment_factor_test,
+            },
+        )
+        generic_test_scenarios(client, url, update_scenarios)
+
+        delete_scenarios = (
+            {
+                "desc": "adjustmentfactor delete",
+                "expected_code": 204,
+                "method": "DELETE",
+                "post_request_test": deleted_adjustment_factor_test,
+            },
+        )
+        generic_test_scenarios(client, url, delete_scenarios)
+
+
+@pytest.mark.django_db
+class TestDataExtractionApi:
+    def get_upload_data(self, overrides=None):
+        design = generic_get_any(models.Design)
+        outcome = models.Outcome.objects.filter(design=design.id).first()
+        exposure_level = models.ExposureLevel.objects.filter(design=design.id).first()
+        adjustment_factor = models.AdjustmentFactor.objects.filter(design=design.id).first()
+
+        data = {
+            "outcome_id": outcome.id,
+            "exposure_level_id": exposure_level.id,
+            "factors_id": adjustment_factor.id,
+            "sub_population": "sub test",
+            "outcome_measurement_timing": "outcome timing test",
+            "effect_estimate_type": "Percent change",
+            "effect_estimate": 1.1,
+            "ci_lcl": 1.2,
+            "ci_ucl": 1.3,
+            "ci_type": "Rng",
+            "units": "units test",
+            "variance_type": 3,
+            "variance": 1.4,
+            "n": 999,
+            "p_value": "1.5",
+            "significant": 2,
+            "group": "rg test",
+            "exposure_rank": 1,
+            "exposure_transform": "log(x+1)",
+            "outcome_transform": "log10",
+            "confidence": "confidence test",
+            "data_location": "loc test",
+            "effect_description": "description test",
+            "statistical_method": "stat method test",
+            "comments": "comments test",
+            "design": design.id,
+        }
+
+        if overrides is not None:
+            data.update(overrides)
+
+        return data
+
+    def test_permissions(self, db_keys):
+        url = reverse("epiv2:api:dataextraction-list")
+        generic_perm_tester(url, self.get_upload_data())
+
+    def test_bad_requests(self, db_keys):
+        url = reverse("epiv2:api:dataextraction-list")
+        client = APIClient()
+        assert client.login(username="admin@hawcproject.org", password="pw") is True
+
+        base_data = self.get_upload_data()
+        base_data_design_id = base_data["design"]
+        non_design_outcome = models.Outcome.objects.filter(~Q(design=base_data_design_id)).first()
+        non_design_exposure_level = models.ExposureLevel.objects.filter(
+            ~Q(design=base_data_design_id)
+        ).first()
+        non_design_adjustment_factor = models.AdjustmentFactor.objects.filter(
+            ~Q(design=base_data_design_id)
+        ).first()
+
+        scenarios = (
+            {"desc": "empty payload doesn't crash", "expected_code": 400, "data": {}},
+            {
+                "desc": "missing design",
+                "expected_code": 400,
+                "expected_content": "may not be null",
+                "data": self.get_upload_data({"design": None}),
+            },
+            {
+                "desc": "missing outcome",
+                "expected_code": 400,
+                "expected_content": "may not be null",
+                "data": self.get_upload_data({"outcome_id": None}),
+            },
+            {
+                "desc": "missing exposure_level",
+                "expected_code": 400,
+                "expected_content": "may not be null",
+                "data": self.get_upload_data({"exposure_level_id": None}),
+            },
+            {
+                "desc": "outcome not part of design",
+                "expected_code": 400,
+                "expected_content": "does not belong to the correct design",
+                "data": self.get_upload_data({"outcome_id": non_design_outcome.id}),
+            },
+            {
+                "desc": "exposure_level not part of design",
+                "expected_code": 400,
+                "expected_content": "does not belong to the correct design",
+                "data": self.get_upload_data({"exposure_level_id": non_design_exposure_level.id}),
+            },
+            {
+                "desc": "adjustment factor not part of design",
+                "expected_code": 400,
+                "expected_content": "does not belong to the correct design",
+                "data": self.get_upload_data({"outcome_id": non_design_adjustment_factor.id}),
+            },
+            {
+                "desc": "invalid ci_type",
+                "expected_code": 400,
+                "expected_content": "not a valid choice",
+                "data": self.get_upload_data({"ci_type": "bad ci type"}),
+            },
+            {
+                "desc": "invalid variance type",
+                "expected_code": 400,
+                "expected_content": "not a valid choice",
+                "data": self.get_upload_data({"variance_type": "bad variance_type"}),
+            },
+            {
+                "desc": "invalid significant",
+                "expected_code": 400,
+                "expected_content": "not a valid choice",
+                "data": self.get_upload_data({"significant": "bad significant"}),
+            },
+        )
+
+        generic_test_scenarios(client, url, scenarios)
+
+    def test_valid_requests(self, db_keys):
+        url = reverse("epiv2:api:dataextraction-list")
+        client = APIClient()
+        assert client.login(username="admin@hawcproject.org", password="pw") is True
+
+        just_created_data_extraction_id = None
+        base_data = self.get_upload_data()
+        base_data_design_id = base_data["design"]
+        other_design = models.Design.objects.filter(~Q(id=base_data_design_id)).first()
+        other_outcome = models.Outcome.objects.filter(design=other_design.id).first()
+        other_exposure_level = models.ExposureLevel.objects.filter(design=other_design.id).first()
+        other_adjustment_factor = models.AdjustmentFactor.objects.filter(
+            design=other_design.id
+        ).first()
+
+        def data_extraction_lookup_test(resp):
+            nonlocal just_created_data_extraction_id
+
+            data_extraction_id = resp.json()["id"]
+            data_extraction = models.DataExtraction.objects.get(id=data_extraction_id)
+            assert data_extraction.comments == base_data["comments"]
+
+            if just_created_data_extraction_id is None:
+                just_created_data_extraction_id = data_extraction_id
+
+        def altered_data_extraction_test(resp):
+            nonlocal just_created_data_extraction_id
+
+            data_extraction_id = resp.json()["id"]
+            data_extraction = models.DataExtraction.objects.get(id=data_extraction_id)
+            assert data_extraction.comments == "altered data_extraction comments"
+            assert data_extraction_id == just_created_data_extraction_id
+
+        def deleted_data_extraction_test(resp):
+            nonlocal just_created_data_extraction_id
+
+            assert resp.data is None
+
+            with pytest.raises(ObjectDoesNotExist):
+                models.DataExtraction.objects.get(id=just_created_data_extraction_id)
+
+        create_scenarios = (
+            {
+                "desc": "basic dataextraction creation",
+                "expected_code": 201,
+                "expected_keys": {"id"},
+                "data": self.get_upload_data(),
+                "post_request_test": data_extraction_lookup_test,
+            },
+        )
+        generic_test_scenarios(client, url, create_scenarios)
+
+        url = f"{url}{just_created_data_extraction_id}/"
+        update_scenarios = (
+            {
+                "desc": "comments update",
+                "expected_code": 200,
+                "expected_keys": {"id"},
+                "data": {"comments": "altered data_extraction comments"},
+                "method": "PATCH",
+                "post_request_test": altered_data_extraction_test,
+            },
+            {
+                "desc": "update ci_type/variance_type/significant by enum vals",
+                "expected_code": 200,
+                "expected_keys": {"id"},
+                "data": {"ci_type": "P90", "variance_type": 5, "significant": 1},
+                "method": "PATCH",
+            },
+            {
+                "desc": "case-insensitive readable values instead of enum codes",
+                "expected_code": 200,
+                "expected_keys": {"id"},
+                "data": {
+                    "ci_type": "10TH/90TH PeRcEnTiLe",
+                    "variance_type": "IQR (INTERQUARTILE range)",
+                    "significant": "yEs",
+                },
+                "method": "PATCH",
+            },
+            {
+                "desc": "design/outcome/exposure_level/adjustment_factor legal update",
+                "expected_code": 200,
+                "expected_keys": {"id"},
+                "data": {
+                    "design": other_design.id,
+                    "outcome_id": other_outcome.id,
+                    "exposure_level_id": other_exposure_level.id,
+                    "adjustment_factor_id": other_adjustment_factor.id,
+                },
+                "method": "PATCH",
+            },
+        )
+        generic_test_scenarios(client, url, update_scenarios)
+
+        delete_scenarios = (
+            {
+                "desc": "dataextraction delete",
+                "expected_code": 204,
+                "method": "DELETE",
+                "post_request_test": deleted_data_extraction_test,
+            },
+        )
+        generic_test_scenarios(client, url, delete_scenarios)


### PR DESCRIPTION
* CRUD api endpoints for design, exposure measurements, chemicals, exposure_levels, outcomes, adjustment factors, data extraction

* test cases for all of the above

* a new ArrayedFlexibleChoiceField (plus tests), for FlexibleChoiceField-style behavior when the underlying field is wrapped in an ArrayField.

* new BelongsToSameDesign mixin to validate that related objects belong to same overall design, e.g. when associating a chemical with an exposure level.

* add environment variable (SKIP_BMDS_TESTS=1) to disable bmds testing.