### PR TITLE
Better message when there is no study type

### DIFF
--- a/hawc/apps/riskofbias/serializers.py
+++ b/hawc/apps/riskofbias/serializers.py
@@ -138,7 +138,7 @@ class StudyScoreSerializer(RiskOfBiasScoreSerializer):
         ret["url_edit"] = instance.riskofbias.get_edit_url()
         ret["study_name"] = instance.riskofbias.study.short_citation
         ret["study_id"] = instance.riskofbias.study.id
-        ret["study_types"] = instance.riskofbias.study.get_study_type()
+        ret["study_types"] = instance.riskofbias.study.get_study_types()
         return ret
 
 

--- a/hawc/apps/riskofbias/templates/riskofbias/rob_edit.html
+++ b/hawc/apps/riskofbias/templates/riskofbias/rob_edit.html
@@ -3,13 +3,20 @@
 {% load add_class %}
 {% load get_at_index %}
 {% load crispy_forms_tags %}
+{% load bs4 %}
 
 {% block content %}
     <h2>{{object}}&nbsp;{% if object.final %}[final]{% else %}[individual review]{% endif %}</h2>
+    {% if not object.study.get_study_types %}
+        {% alert warning %}
+        This study currently has no type(s) selected. If you'd like to perform study evaluation for this study, you'll need to update the study and select at least one type (e.g., bioassay, epidemiology, etc.).
+        {% endalert %}
+    {% endif %}
     {% if object.final and not object.study_reviews_complete %}
-        <h4 class="alert alert-danger">All other {{assessment.get_rob_name_display|lower}} reviews for
-            {{object.study}} must be complete in order to complete the final review.
-        </h4>
+        {% alert danger %}
+        All other {{assessment.get_rob_name_display|lower}} reviews for this study must be complete
+        in order to complete the final review.
+        {% endalert %}
     {% else %}
         <div id='main'></div>
     {% endif %}

--- a/hawc/apps/study/models.py
+++ b/hawc/apps/study/models.py
@@ -192,7 +192,7 @@ class Study(Reference):
             )
         )
 
-    def get_study_type(self):
+    def get_study_types(self) -> list[str]:
         types = []
         for field in self.STUDY_TYPE_FIELDS:
             if getattr(self, field):

--- a/hawc/apps/study/templates/study/study_detail.html
+++ b/hawc/apps/study/templates/study/study_detail.html
@@ -66,7 +66,7 @@
     </div>
   {% endif %}
 
-  {% if not object.get_study_type and obj_perms.edit and object.editable %}
+  {% if not object.get_study_type and object.editable %}
     <p class="alert alert-warning mb-3" role="alert">There are no metrics associated with this study. If you expected to evaluate this study, you may need to modify its study type (e.g., bioassay, epi, in vitro, etc).</p>
   {% endif %}
 

--- a/hawc/apps/study/templates/study/study_detail.html
+++ b/hawc/apps/study/templates/study/study_detail.html
@@ -66,8 +66,7 @@
     </div>
   {% endif %}
 
-  <!-- TODO find a DRY way to avoid this huge if statement with all data types  -->
-  {% if not object.bioassay and not object.epi and obj_perms.edit and object.editable %}
+  {% if not object.get_study_type and obj_perms.edit and object.editable %}
     <p class="alert alert-warning mb-3" role="alert">There are no metrics associated with this study. If you expected to evaluate this study, you may need to modify its study type (e.g., bioassay, epi, in vitro, etc).</p>
   {% endif %}
 

--- a/hawc/apps/study/templates/study/study_detail.html
+++ b/hawc/apps/study/templates/study/study_detail.html
@@ -66,6 +66,11 @@
     </div>
   {% endif %}
 
+  <!-- TODO find a DRY way to avoid this huge if statement with all data types  -->
+  {% if not object.bioassay and not object.epi and obj_perms.edit and object.editable %}
+    <p class="alert alert-warning mb-3" role="alert">There are no metrics associated with this study. If you expected to evaluate this study, you may need to modify its study type (e.g., bioassay, epi, in vitro, etc).</p>
+  {% endif %}
+
   <div id="study_details"></div>
 
   {% if obj_perms.edit and internal_communications|hastext %}

--- a/hawc/apps/study/templates/study/study_detail.html
+++ b/hawc/apps/study/templates/study/study_detail.html
@@ -1,6 +1,7 @@
 {% extends 'assessment-rooted.html' %}
 
 {% load hastext %}
+{% load bs4 %}
 
 {% block content %}
   <h2 class="d-inline-block">{{object}}</h2>
@@ -66,8 +67,10 @@
     </div>
   {% endif %}
 
-  {% if not object.get_study_type and object.editable %}
-    <p class="alert alert-warning mb-3" role="alert">There are no metrics associated with this study. If you expected to evaluate this study, you may need to modify its study type (e.g., bioassay, epi, <i>in vitro</i>, etc).</p>
+  {% if not object.get_study_types and obj_perms.edit %}
+    {% alert warning %}
+    This study currently has no type(s) selected. If you'd like to perform data extraction or study evaluation for this study, you'll need to update the study and select at least one type (e.g., bioassay, epidemiology, etc.).
+    {% endalert %}
   {% endif %}
 
   <div id="study_details"></div>

--- a/hawc/apps/study/templates/study/study_detail.html
+++ b/hawc/apps/study/templates/study/study_detail.html
@@ -67,7 +67,7 @@
   {% endif %}
 
   {% if not object.get_study_type and object.editable %}
-    <p class="alert alert-warning mb-3" role="alert">There are no metrics associated with this study. If you expected to evaluate this study, you may need to modify its study type (e.g., bioassay, epi, in vitro, etc).</p>
+    <p class="alert alert-warning mb-3" role="alert">There are no metrics associated with this study. If you expected to evaluate this study, you may need to modify its study type (e.g., bioassay, epi, <i>in vitro</i>, etc).</p>
   {% endif %}
 
   <div id="study_details"></div>


### PR DESCRIPTION
- added alert to www.haw.epa.gov/study/x/ page if no data metric is chosen
![empty study type](https://github.com/shapiromatron/hawc/assets/113325602/085ada42-05c4-4bae-a31a-ca25610554db)
