### PR TITLE
remove source change for literature import update

### DIFF
--- a/hawc/apps/lit/forms.py
+++ b/hawc/apps/lit/forms.py
@@ -145,6 +145,7 @@ class ImportForm(SearchForm):
             self.fields["search_string"].label = "ID List"
         else:
             self.fields.pop("search_string")
+            self.fields.pop("source")
 
     @property
     def helper(self):

--- a/hawc/apps/lit/forms.py
+++ b/hawc/apps/lit/forms.py
@@ -152,7 +152,10 @@ class ImportForm(SearchForm):
         if self.instance.id:
             inputs = {
                 "legend_text": f"Update {self.instance}",
-                "help_text": "Update an existing literature search",
+                "help_text": """
+                    Update an existing literature import. After a literature import
+                    has been created, you can no longer edit the source or IDs to import.
+                """,
                 "cancel_url": self.instance.get_absolute_url(),
             }
         else:


### PR DESCRIPTION
A user shouldn't be able to change the source (HERO, PubMed) after an import has been executed. Also update the help text to explain why the fields are missing.

![image](https://github.com/shapiromatron/hawc/assets/999952/f28a88ed-8815-4876-8ac2-372f883815d2)
