### PR TITLE
fix 500 error with invalid dose units

### DIFF
--- a/hawc/apps/animal/views.py
+++ b/hawc/apps/animal/views.py
@@ -412,7 +412,9 @@ class EndpointFilterList(BaseFilterList):
     def get_queryset(self):
         qs = super().get_queryset()
         form = self.filterset.form
-        dose_units = form.cleaned_data["dose_units"] or form.fields["dose_units"].queryset.first()
+        dose_units = (
+            form.cleaned_data.get("dose_units") or form.fields["dose_units"].queryset.first()
+        )
         return qs.select_related("animal_group__experiment__study").annotate_dose_values(dose_units)
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
Fix 500 error when an invalid `dose_units` is passed, for example: `/ani/assessment/:id/endpoints/?dose_units=foo`