### PR TITLE
add coverage report to github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,10 +43,20 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
     - name: loc
-      if: github.ref == 'refs/heads/coverage'
+      if: github.ref_name == 'coverage'
       run: |
-        sudo apt-get install -y cloc
-        make loc
+        echo $GITHUB_REF_NAME
+        if [ "$GITHUB_REF_NAME" == "coverage" ]; then
+          echo "yes"
+          #coverage run -m pytest --vcr-record=none
+          #coverage html -d coverage_report
+        else
+          echo "no"
+          #py.test --vcr-record=none
+        fi
+        #sudo apt-get install -y cloc
+        #make loc
+        exit 1
     - name: install
       run: |
         mv tests/data/ci-webpack-stats.json hawc/webpack-stats.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,16 +76,14 @@ jobs:
         fi
         coverage run -m pytest --vcr-record=none
         coverage html -d coverage_report
-        echo '# Python coverage report\n\n```text\n' >> $GITHUB_STEP_SUMMARY
-        coverage report >> $GITHUB_STEP_SUMMARY
-        echo '\n```\n\n' >> $GITHUB_STEP_SUMMARY
+        echo "# Python coverage report\\n\\n" >> $GITHUB_STEP_SUMMARY
+        coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
+        echo "\\n\\n" >> $GITHUB_STEP_SUMMARY
     - name: loc
       run: |
         sudo apt-get install -y cloc
-        echo '# Lines of code report'
-        echo '# Lines of code report\n\n```text\n' >> $GITHUB_STEP_SUMMARY
+        echo "# Lines of code report\\n\\n" >> $GITHUB_STEP_SUMMARY
         make loc >> $GITHUB_STEP_SUMMARY
-        echo '\n```\n\n' >> $GITHUB_STEP_SUMMARY
     - name: upload-coverage-report
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,21 +35,6 @@ jobs:
       with:
         python-version: '3.11'
         architecture: 'x64'
-    - name: loc
-      if: ${{github.ref_name == 'coverage'}}
-      run: |
-        echo $GITHUB_REF_NAME
-        if [ "$GITHUB_REF_NAME" == "coverage" ]; then
-          echo "yes"
-          #coverage run -m pytest --vcr-record=none
-          #coverage html -d coverage_report
-        else
-          echo "no"
-          #py.test --vcr-record=none
-        fi
-        #sudo apt-get install -y cloc
-        #make loc
-        exit 1
     - name: try to restore pip cache
       uses: actions/cache@v3
       with:
@@ -57,21 +42,6 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements/*.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-    - name: loc
-      if: github.ref_name == 'coverage'
-      run: |
-        echo $GITHUB_REF_NAME
-        if [ "$GITHUB_REF_NAME" == "coverage" ]; then
-          echo "yes"
-          #coverage run -m pytest --vcr-record=none
-          #coverage html -d coverage_report
-        else
-          echo "no"
-          #py.test --vcr-record=none
-        fi
-        #sudo apt-get install -y cloc
-        #make loc
-        exit 1
     - name: install
       run: |
         mv tests/data/ci-webpack-stats.json hawc/webpack-stats.json
@@ -104,15 +74,14 @@ jobs:
         if [ "$RUNNER_OS" == "Linux" ]; then
           export "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib"
         fi
-        if [ "$GITHUB_REF_NAME" == "coverage" ]; then
-          coverage run -m pytest --vcr-record=none
-          coverage html -d coverage_report
-        else
-          py.test --vcr-record=none
-        fi
+        coverage run -m pytest --vcr-record=none
+        coverage html -d coverage_report
+    - name: loc
+      run: |
+        sudo apt-get install -y cloc
+        make loc
     - name: upload-coverage-report
       uses: actions/upload-artifact@v3
-      if: github.ref == 'refs/heads/coverage'
       with:
         name: my-artifact
         path: coverage_report/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
     - name: loc
+      if: github.ref == 'refs/heads/coverage'
       run: |
         sudo apt-get install -y cloc
         make loc
@@ -78,7 +79,18 @@ jobs:
         if [ "$RUNNER_OS" == "Linux" ]; then
           export "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib"
         fi
-        py.test --vcr-record=none
+        if [ "$GITHUB_REF_NAME" == "coverage" ]; then
+          coverage run -m pytest --vcr-record=none
+          coverage html -d coverage_report
+        else
+          py.test --vcr-record=none
+        fi
+    - name: upload-coverage-report
+      uses: actions/upload-artifact@v3
+      if: github.ref == 'refs/heads/coverage'
+      with:
+        name: my-artifact
+        path: coverage_report/
 
   frontend:
     name: frontend

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,21 @@ jobs:
       with:
         python-version: '3.11'
         architecture: 'x64'
+    - name: loc
+      if: ${{github.ref_name == 'coverage'}}
+      run: |
+        echo $GITHUB_REF_NAME
+        if [ "$GITHUB_REF_NAME" == "coverage" ]; then
+          echo "yes"
+          #coverage run -m pytest --vcr-record=none
+          #coverage html -d coverage_report
+        else
+          echo "no"
+          #py.test --vcr-record=none
+        fi
+        #sudo apt-get install -y cloc
+        #make loc
+        exit 1
     - name: try to restore pip cache
       uses: actions/cache@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,13 +76,12 @@ jobs:
         fi
         coverage run -m pytest --vcr-record=none
         coverage html -d coverage_report
-        echo "# Python coverage report\\n\\n" >> $GITHUB_STEP_SUMMARY
+        echo "# Python coverage report" >> $GITHUB_STEP_SUMMARY
         coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
-        echo "\\n\\n" >> $GITHUB_STEP_SUMMARY
     - name: loc
       run: |
         sudo apt-get install -y cloc
-        echo "# Lines of code report\\n\\n" >> $GITHUB_STEP_SUMMARY
+        echo "# Lines of code report" >> $GITHUB_STEP_SUMMARY
         make loc >> $GITHUB_STEP_SUMMARY
     - name: upload-coverage-report
       uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,15 +76,21 @@ jobs:
         fi
         coverage run -m pytest --vcr-record=none
         coverage html -d coverage_report
+        echo '# Python coverage report\n\n```text\n' >> $GITHUB_STEP_SUMMARY
+        coverage report >> $GITHUB_STEP_SUMMARY
+        echo '\n```\n\n' >> $GITHUB_STEP_SUMMARY
     - name: loc
       run: |
         sudo apt-get install -y cloc
-        make loc
+        echo '# Lines of code report'
+        echo '# Lines of code report\n\n```text\n' >> $GITHUB_STEP_SUMMARY
+        make loc >> $GITHUB_STEP_SUMMARY
+        echo '\n```\n\n' >> $GITHUB_STEP_SUMMARY
     - name: upload-coverage-report
       uses: actions/upload-artifact@v3
       with:
-        name: my-artifact
-        path: coverage_report/
+        name: coverage-report
+        path: coverage_report
 
   frontend:
     name: frontend

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ loc: ## Generate lines of code report
 		--exclude-ext=json,yaml,svg,toml,ini \
 		--vcs=git \
 		--counted loc-files.txt \
+		--md \
 		.
 
 lint: lint-py lint-js  ## Check formatting issues


### PR DESCRIPTION
Run coverage in CI/CD and add a report summary to the job action. 

For example:
https://github.com/shapiromatron/hawc/actions/runs/5612666910?pr=859

The detailed html coverage report is also available as a downloadable artifact


