### PR TITLE
Add epiv2 and eco to openapi specification

### DIFF
--- a/hawc/apps/assessment/templates/assessment/fragments/assessment_list_public.html
+++ b/hawc/apps/assessment/templates/assessment/fragments/assessment_list_public.html
@@ -10,7 +10,7 @@
       <td>
         <p class='mb-0'><a href="{{object.get_absolute_url}}">{{object.name}}</a></p>
         {% if object.assessment_objective %}
-        <div class='text-muted'>{{object.assessment_objective|truncatewords:30|striptags|safe}}</div>
+        <div class='text-muted'>{{object.assessment_objective|striptags|truncatewords:30|safe}}</div>
         {% endif %}
       </td>
       <td>{{object.year}}</td>

--- a/hawc/apps/assessment/templates/assessment/fragments/assessment_list_team.html
+++ b/hawc/apps/assessment/templates/assessment/fragments/assessment_list_team.html
@@ -10,7 +10,7 @@
       <td>
         <p class='mb-0'><a href="{{object.get_absolute_url}}">{{object.name}}</a></p>
         {% if object.assessment_objective %}
-        <div class='text-muted'>{{object.assessment_objective|truncatewords:30|striptags|safe}}</div>
+        <div class='text-muted'>{{object.assessment_objective|striptags|truncatewords:30|safe}}</div>
         {% endif %}
       </td>
       <td>{{object.year}}</td>

--- a/hawc/apps/epiv2/api.py
+++ b/hawc/apps/epiv2/api.py
@@ -13,6 +13,7 @@ from ..assessment.models import Assessment
 from ..common.api.utils import get_published_only
 from ..common.helper import FlatExport
 from ..common.renderers import PandasRenderers
+from ..common.serializers import UnusedSerializer
 from ..study.models import Study
 from . import exports, models, serializers
 from .actions.model_metadata import EpiV2Metadata
@@ -20,6 +21,7 @@ from .actions.model_metadata import EpiV2Metadata
 
 class EpiAssessmentViewSet(BaseAssessmentViewSet):
     model = Assessment
+    serializer_class = UnusedSerializer
 
     @action(
         detail=True,

--- a/hawc/apps/summary/templates/summary/visual_list.html
+++ b/hawc/apps/summary/templates/summary/visual_list.html
@@ -31,7 +31,7 @@
           <i class="fa fa-eye-slash" title="Unpublished (not be visible to the public)" aria-hidden="true"></i>
           {% endif %}
           {% if visual.caption %}
-          <div class='text-muted'>{{visual.caption|truncatewords_html:20|striptags|safe}}</div>
+          <div class='text-muted'>{{visual.captionstriptags|striptags|truncatewords:20|safe}}</div>
           {% endif %}
         </td>
         <td>{{visual.get_visual_type_display}}</td>

--- a/hawc/main/urls.py
+++ b/hawc/main/urls.py
@@ -6,8 +6,10 @@ import hawc.apps.animal.urls
 import hawc.apps.assessment.urls
 import hawc.apps.bmd.urls
 import hawc.apps.common.urls
+import hawc.apps.eco.urls
 import hawc.apps.epi.urls
 import hawc.apps.epimeta.urls
+import hawc.apps.epiv2.urls
 import hawc.apps.hawc_admin.urls
 import hawc.apps.invitro.urls
 import hawc.apps.lit.urls
@@ -64,8 +66,10 @@ open_api_patterns = [
     path("assessment/api/", include(hawc.apps.assessment.urls.router.urls)),
     path("bmd/api/", include(hawc.apps.bmd.urls.router.urls)),
     path("common/api/", include(hawc.apps.common.urls.router.urls)),
+    path("eco/api/", include(hawc.apps.eco.urls.router.urls)),
     path("epi/api/", include(hawc.apps.epi.urls.router.urls)),
     path("epi-meta/api/", include(hawc.apps.epimeta.urls.router.urls)),
+    path("epidemiology/api/", include(hawc.apps.epiv2.urls.router.urls)),
     path("in-vitro/api/", include(hawc.apps.invitro.urls.router.urls)),
     path("lit/api/", include(hawc.apps.lit.urls.router.urls)),
     path("rob/api/", include(hawc.apps.riskofbias.urls.router.urls)),


### PR DESCRIPTION
- Add the `eco` and `epiv2` apps to the openapi specification available on the admin

In addition, a minor change to templates:

- strip tags before truncating text
