### PR TITLE
Fix data pivot file upload form javascript

### DIFF
--- a/hawc/apps/summary/templates/summary/datapivot_form.html
+++ b/hawc/apps/summary/templates/summary/datapivot_form.html
@@ -13,7 +13,7 @@
   {{ smart_tag_form.media }}
   <script type="text/javascript">
     $(document).ready(function () {
-      let js_units_choices = {{form.js_units_choices|safe}},
+      let js_units_choices = {% autoescape off %}{% firstof form.js_units_choices "[]" %}{% endautoescape %},
         epi_version = {{assessment.epi_version}},
         printf = window.app.HAWCUtils.printf;
 


### PR DESCRIPTION
There was a bug in the Django template for the data pivot file upload form that was breaking the javascript that added auto-slugification and quillified the caption field. This PR fixes it by adding a default value when declaring the javascript variables instead of having the template leave the declared value blank.