### PR TITLE
Fix NOEL/LOEL form and display

### DIFF
--- a/frontend/animal/EditEndpoint.js
+++ b/frontend/animal/EditEndpoint.js
@@ -32,14 +32,11 @@ class EditEndpoint {
 
         // set NOEL, LOEL, FEL
         const {endpoint} = this;
-        var fields = $("#id_NOEL, #id_LOEL, #id_FEL").html(
-            "<option value=-999>&lt;None&gt;</option>"
+        const options = firstDoses.values.map(
+            (v, i) => `<option value="${i}">${v} ${firstDoses.name}</option>`
         );
-
-        $(".doses").each(function(i, v) {
-            fields.append(`<option value="${i}">${v.textContent}</option>`);
-        });
-
+        options.unshift("<option value=-999>&lt;None&gt;</option>");
+        $("#id_NOEL, #id_LOEL, #id_FEL").html(options);
         $(`#id_NOEL option[value="${endpoint.data.NOEL}"]`).prop("selected", true);
         $(`#id_LOEL option[value="${endpoint.data.LOEL}"]`).prop("selected", true);
         $(`#id_FEL option[value="${endpoint.data.FEL}"]`).prop("selected", true);

--- a/frontend/animal/Endpoint.js
+++ b/frontend/animal/Endpoint.js
@@ -249,7 +249,7 @@ class Endpoint extends Observee {
             critical_dose = function(type) {
                 if (self.data[type] < 0) return;
                 var span = $("<span>");
-                new EndpointCriticalDose(self, span, type, true);
+                new EndpointCriticalDose(self, span, type);
                 return span;
             },
             bmd_response = function(type, showURL) {
@@ -257,7 +257,7 @@ class Endpoint extends Observee {
                     return;
                 }
                 var el = $("<div>");
-                new BMDResult(self, el, type, true, showURL);
+                new BMDResult(self, el, type, showURL);
                 return el;
             },
             getTaglist = function(tags, assessment_id) {

--- a/frontend/animal/EndpointCriticalDose.js
+++ b/frontend/animal/EndpointCriticalDose.js
@@ -1,40 +1,28 @@
-import PropTypes from "prop-types";
-import React from "react";
-import ReactDOM from "react-dom";
+import _ from "lodash";
 import h from "shared/utils/helpers";
 
-const Renderer = function(props) {
-    return (
-        <p>
-            {props.dose} {props.units}
-        </p>
-    );
-};
-
 class EndpointCriticalDose {
-    constructor(endpoint, span, type, show_units) {
+    constructor(endpoint, span, type) {
         // custom field to observe dose changes and respond based on selected dose
         endpoint.addObserver(this);
         this.endpoint = endpoint;
         this.span = span;
         this.type = type;
         this.critical_effect_idx = endpoint.data[type];
-        this.show_units = show_units;
         this.update();
     }
 
     update() {
-        const ep = this.endpoint,
-            dose = h.ff(ep.data.groups[this.critical_effect_idx].dose),
-            units = this.show_units ? ep.doseUnits.activeUnit.name : "";
-
-        ReactDOM.render(<Renderer dose={dose} units={units} />, this.span[0]);
+        const dose_group_id = this.critical_effect_idx,
+            dose_units_id = this.endpoint.doseUnits.activeUnit.id,
+            group = _.find(this.endpoint.data.animal_group.dosing_regime.doses, el => {
+                return el.dose_group_id === dose_group_id && el.dose_units.id === dose_units_id;
+            }),
+            dose = group ? h.ff(group.dose) : "",
+            units = group ? group.dose_units.name : "",
+            text = `${dose} ${units}`;
+        this.span.text(text);
     }
 }
-
-Renderer.propTypes = {
-    dose: PropTypes.string,
-    units: PropTypes.string,
-};
 
 export default EndpointCriticalDose;


### PR DESCRIPTION
Fix a bug where users couldn't set or view NOEL/LOEL for endpoints where data was not extracted.  

This bug would only occur if a user created an endpoint, but didn't extract any dose group data. Then, when they tried to update the endpoint, it didn't have dose units available so the LOEL select input didn't have any options.

It also failed on the read-only view of view.