### PR TITLE
Add tag deletion/addition filters for conflict resolution page

### DIFF
--- a/hawc/apps/lit/templates/lit/_reference_with_tags.html
+++ b/hawc/apps/lit/templates/lit/_reference_with_tags.html
@@ -68,24 +68,28 @@
                     <b>{{user_tag.user.get_full_name}}</b> <i class="small">{{user_tag.last_updated}}</i>
                 </div>
             </div>
-            {% if conflict_resolution %}
-                {% with user_tag.consensus_diff as diff %}
-                    {% for tag in ref.tags.all %}
-                        {% if tag in diff.intersection %}
+            {% with user_tag.consensus_diff as diff %}
+                {% for tag in ref.tags.all %}
+                    {% if tag in diff.intersection %}
+                        {% if conflict_resolution %}
                             {% include 'lit/_nested_tag.html' with tag=tag extra_classes='' %}
                         {% else %}
+                            {% include 'lit/_nested_tag.html' with tag=tag extra_classes='refUserTag' %}
+                        {% endif %}
+                    {% else %}
+                        {% if not user_tag.is_resolved %}
                             {% include 'lit/_nested_tag.html' with tag=tag extra_classes='refUserTagRemove' %}
                         {% endif %}
-                    {% endfor %}
-                    {% for tag in diff.difference %}
-                        {% include 'lit/_nested_tag.html' with tag=tag extra_classes='refUserTag' %}
-                    {% endfor %}
-                {% endwith %}
-            {% else %}
-                {% for tag in user_tag.tags.all %}
+                    {% endif %}
+                {% endfor %}
+                {% for tag in diff.difference %}
                     {% include 'lit/_nested_tag.html' with tag=tag extra_classes='refUserTag' %}
                 {% endfor %}
-            {% endif %}
+                {% if diff.intersection|length is 0 and diff.difference|length is 0 and user_tag.is_resolved %} 
+                    <p>No tags selected</p>
+                {% endif %}
+            {% endwith %}
+            
         </div>
         {% endfor %}
     </div>

--- a/hawc/apps/lit/templates/lit/conflict_resolution.html
+++ b/hawc/apps/lit/templates/lit/conflict_resolution.html
@@ -11,8 +11,8 @@
     </li>
     {% empty %}
     <li class="list-group-item">
-        <div class="alert alert-success">
-            <i class='fa fa-fw fa-check mr-1'></i>&nbsp;Conflict resolution complete! No conflicts to resolve.
+        <div class="alert alert-warning">
+            <i class='fa fa-fw fa-exclamation-triangle mr-1'></i>&nbsp;No conflicts found.
         </div>
     </li>
     {% endfor %}

--- a/hawc/apps/lit/views.py
+++ b/hawc/apps/lit/views.py
@@ -424,6 +424,10 @@ class ConflictResolution(BaseFilterList):
                 "my_tags",
                 "include_mytag_descendants",
                 "anything_tagged_me",
+                "addition_tags",
+                "include_additiontag_descendants",
+                "deletion_tags",
+                "include_deletiontag_descendants",
             ],
             grid_layout={
                 "rows": [
@@ -442,7 +446,7 @@ class ConflictResolution(BaseFilterList):
                     {
                         "columns": [
                             {
-                                "width": 6,
+                                "width": 3,
                                 "rows": [
                                     {
                                         "columns": [
@@ -454,13 +458,35 @@ class ConflictResolution(BaseFilterList):
                                 ],
                             },
                             {
-                                "width": 6,
+                                "width": 3,
                                 "rows": [
                                     {
                                         "columns": [
                                             {"width": 12},
                                             {"width": 6},
                                             {"width": 6},
+                                        ]
+                                    }
+                                ],
+                            },
+                            {
+                                "width": 3,
+                                "rows": [
+                                    {
+                                        "columns": [
+                                            {"width": 12},
+                                            {"width": 12},
+                                        ]
+                                    }
+                                ],
+                            },
+                            {
+                                "width": 3,
+                                "rows": [
+                                    {
+                                        "columns": [
+                                            {"width": 12},
+                                            {"width": 12},
                                         ]
                                     }
                                 ],


### PR DESCRIPTION
Adds additional filtering to conflict resolution page.
- Candidate Tag Additions: filters by references with users seeking to add a specific tag (tag is present for an unresolved UserReferenceTag, but not on reference.tags)
- Candidate Tag Deletions: filters by references with users seeking to remove a specific tag (tag is present on reference.tags, but not in an unresolved UserReferenceTag)

![image](https://github.com/shapiromatron/hawc/assets/42587248/817d2eea-17b2-4b9e-a4d4-b10c5ddf184f)

- Show tag deletions on Tag Status page
- Show text for empty UserReferenceTag case
![image](https://github.com/shapiromatron/hawc/assets/42587248/94330cf4-2a4a-4e6a-9086-b36c9dca53fc)

