### PR TITLE
fix assessment list to make distinct by assessment

### DIFF
--- a/hawc/apps/assessment/filterset.py
+++ b/hawc/apps/assessment/filterset.py
@@ -65,10 +65,10 @@ class AssessmentFilterSet(BaseFilterSet):
             | Q(details__project_type__icontains=value)
             | Q(details__report_id__icontains=value)
         )
-        return queryset.filter(query).distinct()
+        return queryset.filter(query)
 
     def filter_role(self, queryset, name, value):
-        return queryset.filter(**{value: self.request.user}).distinct()
+        return queryset.filter(**{value: self.request.user})
 
     def filter_published(self, queryset, name, value):
         return queryset.with_published().filter(published=value)

--- a/hawc/apps/assessment/managers.py
+++ b/hawc/apps/assessment/managers.py
@@ -5,7 +5,7 @@ from typing import Any, NamedTuple
 import pandas as pd
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import Case, Exists, OuterRef, Q, QuerySet, Subquery, Value, When
+from django.db.models import Case, Exists, OuterRef, Q, QuerySet, Value, When
 from reversion.models import Version
 
 from ..common.helper import HAWCDjangoJSONEncoder, map_enum

--- a/hawc/apps/assessment/managers.py
+++ b/hawc/apps/assessment/managers.py
@@ -3,8 +3,9 @@ from datetime import datetime, timedelta
 from typing import Any, NamedTuple
 
 import pandas as pd
+from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import Case, OuterRef, Q, QuerySet, Subquery, Value, When
+from django.db.models import Case, Exists, OuterRef, Q, QuerySet, Subquery, Value, When
 from reversion.models import Version
 
 from ..common.helper import HAWCDjangoJSONEncoder, map_enum
@@ -65,22 +66,20 @@ class AssessmentQuerySet(QuerySet):
         return self.annotate(published=published())
 
     def with_role(self, user) -> QuerySet:
-        qs2 = (
-            self.model.objects.filter(id=OuterRef("id"))
-            .annotate(
-                user_role=Case(
-                    When(
-                        project_manager=user, then=Value(constants.AssessmentRole.PROJECT_MANAGER)
-                    ),
-                    When(team_members=user, then=Value(constants.AssessmentRole.TEAM_MEMBER)),
-                    When(reviewers=user, then=Value(constants.AssessmentRole.REVIEWER)),
-                    default=Value(constants.AssessmentRole.NO_ROLE),
-                )
-            )
-            .order_by("id")
-            .distinct("id")
+        User = get_user_model()
+        return self.annotate(
+            user_is_pm=Exists(User.objects.filter(id=user.id, assessment_pms=OuterRef("pk"))),
+            user_is_team=Exists(User.objects.filter(id=user.id, assessment_teams=OuterRef("pk"))),
+            user_is_reviewer=Exists(
+                User.objects.filter(id=user.id, assessment_reviewers=OuterRef("pk"))
+            ),
+            user_role=Case(
+                When(user_is_pm=True, then=Value(constants.AssessmentRole.PROJECT_MANAGER)),
+                When(user_is_team=True, then=Value(constants.AssessmentRole.TEAM_MEMBER)),
+                When(user_is_reviewer=True, then=Value(constants.AssessmentRole.REVIEWER)),
+                default=Value(constants.AssessmentRole.NO_ROLE),
+            ),
         )
-        return self.annotate(user_role=Subquery(qs2.values("user_role")[:1]))
 
     def global_chemical_report(self) -> pd.DataFrame:
         mapping = {

--- a/hawc/apps/assessment/views.py
+++ b/hawc/apps/assessment/views.py
@@ -338,14 +338,7 @@ class AssessmentFullList(FilterSetMixin, ListView):
         )
 
     def get_queryset(self):
-        return (
-            super()
-            .get_queryset()
-            .with_published()
-            .with_role(self.request.user)
-            .order_by("id")
-            .distinct("id")
-        )
+        return super().get_queryset().with_published().with_role(self.request.user)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/hawc/apps/assessment/views.py
+++ b/hawc/apps/assessment/views.py
@@ -338,7 +338,14 @@ class AssessmentFullList(FilterSetMixin, ListView):
         )
 
     def get_queryset(self):
-        return super().get_queryset().with_published().with_role(self.request.user)
+        return (
+            super()
+            .get_queryset()
+            .with_published()
+            .with_role(self.request.user)
+            .order_by("id")
+            .distinct("id")
+        )
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
Fix bug where `/assessment/all/` duplicated assessments based on the number of people assigned to various roles. The previous implementation made duplicative assessments since it was generating a row for each assessment-user combination; to dedup using the distinct() disabled our ability to have a custom sort ordering. 

The new approach breaks adds an `Exists` annotation to the assessment so we prevent the duplicates; query performance is actually faster despite the extra annotations.