### PR TITLE
migrate to Django 5.0.0

### DIFF
--- a/hawc/apps/animal/managers.py
+++ b/hawc/apps/animal/managers.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from typing import Any
 
 import numpy as np
@@ -20,13 +19,12 @@ class ExperimentManager(BaseManager):
     assessment_relation = "study__assessment"
 
     def get_type_choices(self, assessment_id: int):
-        choices = deepcopy(constants.ExperimentType.choices)
         types = set(
             self.model.objects.filter(study__assessment_id=assessment_id)
             .values_list("type", flat=True)
             .distinct()
         )
-        return [c for c in choices if c[0] in types]
+        return [c for c in constants.ExperimentType.choices if c[0] in types]
 
 
 class AnimalGroupManager(BaseManager):

--- a/hawc/apps/animal/models.py
+++ b/hawc/apps/animal/models.py
@@ -48,7 +48,7 @@ class Experiment(models.Model):
     )
     type = models.CharField(
         max_length=2,
-        choices=constants.ExperimentType.choices,
+        choices=constants.ExperimentType,
         help_text="Type of study being performed; be as specific as possible",
     )
     has_multiple_generations = models.BooleanField(default=False)
@@ -84,7 +84,7 @@ class Experiment(models.Model):
     purity_available = models.BooleanField(default=True, verbose_name="Chemical purity available?")
     purity_qualifier = models.CharField(
         max_length=1,
-        choices=constants.PurityQualifier.choices,
+        choices=constants.PurityQualifier,
         blank=True,
         default=constants.PurityQualifier.NA,
     )
@@ -220,7 +220,7 @@ class AnimalGroup(models.Model):
         help_text="When adding a new strain, put the stock in parenthesis, e.g., "
         + '"Sprague-Dawley (Harlan)."',
     )
-    sex = models.CharField(max_length=1, choices=constants.Sex.choices)
+    sex = models.CharField(max_length=1, choices=constants.Sex)
     animal_source = models.CharField(
         max_length=128, help_text="Source from where animals were acquired", blank=True
     )
@@ -250,7 +250,7 @@ class AnimalGroup(models.Model):
     )
     siblings = models.ForeignKey("self", blank=True, null=True, on_delete=models.SET_NULL)
     generation = models.CharField(
-        blank=True, default="", max_length=2, choices=constants.Generation.choices
+        blank=True, default="", max_length=2, choices=constants.Generation
     )
     parents = models.ManyToManyField("self", related_name="children", symmetrical=False, blank=True)
     dosing_regime = models.ForeignKey(
@@ -381,7 +381,7 @@ class DosingRegime(models.Model):
     )
     route_of_exposure = models.CharField(
         max_length=2,
-        choices=constants.RouteExposure.choices,
+        choices=constants.RouteExposure,
         help_text="Primary route of exposure. If multiple primary-exposures, describe in notes-field below",
     )
     duration_exposure = models.FloatField(
@@ -429,7 +429,7 @@ class DosingRegime(models.Model):
     negative_control = models.CharField(
         max_length=2,
         default=constants.NegativeControl.VT,
-        choices=constants.NegativeControl.choices,
+        choices=constants.NegativeControl,
         help_text="Description of negative-controls used",
     )
     description = models.TextField(
@@ -626,7 +626,7 @@ class Endpoint(BaseEndpoint):
     )
     litter_effects = models.CharField(
         max_length=2,
-        choices=constants.LitterEffect.choices,
+        choices=constants.LitterEffect,
         default=constants.LitterEffect.NA,
         help_text='Type of controls used for litter-effects. The "No" response '
         + "will be infrequently used. More typically the information will be "
@@ -645,7 +645,7 @@ class Endpoint(BaseEndpoint):
         "optional, should be recorded if the same effect was measured multiple times.",
     )
     observation_time_units = models.PositiveSmallIntegerField(
-        default=constants.ObservationTimeUnits.NR, choices=constants.ObservationTimeUnits.choices
+        default=constants.ObservationTimeUnits.NR, choices=constants.ObservationTimeUnits
     )
     observation_time_text = models.CharField(
         max_length=64,
@@ -660,7 +660,7 @@ class Endpoint(BaseEndpoint):
         '1 and Text, p.24")',
     )
     expected_adversity_direction = models.PositiveSmallIntegerField(
-        choices=constants.AdverseDirection.choices,
+        choices=constants.AdverseDirection,
         default=constants.AdverseDirection.NR,
         verbose_name="Expected response adversity direction",
         help_text="Response direction which would be considered adverse",
@@ -673,12 +673,12 @@ class Endpoint(BaseEndpoint):
     )
     data_type = models.CharField(
         max_length=2,
-        choices=constants.DataType.choices,
+        choices=constants.DataType,
         default=constants.DataType.CONTINUOUS,
         verbose_name="Dataset type",
     )
     variance_type = models.PositiveSmallIntegerField(
-        default=constants.VarianceType.SD, choices=constants.VarianceType.choices
+        default=constants.VarianceType.SD, choices=constants.VarianceType
     )
     confidence_interval = models.FloatField(
         blank=True,
@@ -706,7 +706,7 @@ class Endpoint(BaseEndpoint):
         help_text="Response values were estimated using a digital ruler or other methods",
     )
     monotonicity = models.PositiveSmallIntegerField(
-        default=constants.Monotonicity.NR, choices=constants.Monotonicity.choices
+        default=constants.Monotonicity.NR, choices=constants.Monotonicity
     )
     statistical_test = models.CharField(
         max_length=256,
@@ -718,7 +718,7 @@ class Endpoint(BaseEndpoint):
         null=True, blank=True, help_text="Numerical result for trend-test, if available"
     )
     trend_result = models.PositiveSmallIntegerField(
-        default=constants.TrendResult.NR, choices=constants.TrendResult.choices
+        default=constants.TrendResult.NR, choices=constants.TrendResult
     )
     diagnostic = models.TextField(
         verbose_name="Diagnostic (as reported)",
@@ -1359,7 +1359,7 @@ class EndpointGroup(ConfidenceIntervalsMixin, models.Model):
         null=True,
         blank=True,
         default=None,
-        choices=constants.TreatmentEffect.choices,
+        choices=constants.TreatmentEffect,
         help_text="Expert judgement based report of treatment related effects (add direction if known). Use when statistical analysis not available. In results comments, indicate whether it was author judgment or assessment team judgement",
     )
 

--- a/hawc/apps/assessment/models.py
+++ b/hawc/apps/assessment/models.py
@@ -259,13 +259,13 @@ class Assessment(models.Model):
     )
     noel_name = models.PositiveSmallIntegerField(
         default=get_noel_name_default,
-        choices=constants.NoelName.choices,
+        choices=constants.NoelName,
         verbose_name="NEL/NOEL/NOAEL name",
         help_text="What term should be used to refer to NEL/NOEL/NOAEL and LEL/LOEL/LOAEL?",
     )
     rob_name = models.PositiveSmallIntegerField(
         default=get_rob_name_default,
-        choices=constants.RobName.choices,
+        choices=constants.RobName,
         verbose_name="Risk of bias/Study evaluation name",
         help_text="What term should be used to refer to risk of bias/study evaluation questions?",
     )
@@ -288,7 +288,7 @@ class Assessment(models.Model):
         needed.""",
     )
     epi_version = models.PositiveSmallIntegerField(
-        choices=constants.EpiVersion.choices,
+        choices=constants.EpiVersion,
         default=constants.EpiVersion.V2,
         verbose_name="Epidemiology schema version",
         help_text="Data extraction schema version used for epidemiology studies",
@@ -515,7 +515,7 @@ class AssessmentDetail(models.Model):
         help_text="If part of a product line, the name of the project type",
     )
     project_status = models.PositiveSmallIntegerField(
-        choices=constants.Status.choices,
+        choices=constants.Status,
         default=constants.Status.SCOPING,
         help_text="High-level project management milestones for this assessment",
     )
@@ -527,7 +527,7 @@ class AssessmentDetail(models.Model):
     )
     peer_review_status = models.PositiveSmallIntegerField(
         verbose_name="Peer Review Status",
-        choices=constants.PeerReviewType.choices,
+        choices=constants.PeerReviewType,
         help_text="Define the current status of peer review of this assessment, if any",
         default=constants.PeerReviewType.NONE,
     )
@@ -582,7 +582,7 @@ class AssessmentValue(models.Model):
 
     assessment = models.ForeignKey(Assessment, models.CASCADE, related_name="values")
     evaluation_type = models.PositiveSmallIntegerField(
-        choices=constants.EvaluationType.choices,
+        choices=constants.EvaluationType,
         default=constants.EvaluationType.CANCER,
         help_text="Substance evaluation conducted",
     )
@@ -592,7 +592,7 @@ class AssessmentValue(models.Model):
         help_text="Identify the health system of concern (e.g., Hepatic, Nervous, Reproductive)",
     )
     value_type = models.PositiveSmallIntegerField(
-        choices=constants.ValueType.choices,
+        choices=constants.ValueType,
         help_text="Type of derived value",
     )
     value = models.FloatField(
@@ -640,7 +640,7 @@ class AssessmentValue(models.Model):
     uncertainty = models.IntegerField(
         blank=True,
         null=True,
-        choices=constants.UncertaintyChoices.choices,
+        choices=constants.UncertaintyChoices,
         verbose_name="Uncertainty factor",
         help_text="Composite uncertainty factor applied to POD to derive the final value",
     )
@@ -1121,10 +1121,10 @@ class Job(models.Model):
         Assessment, blank=True, null=True, on_delete=models.CASCADE, related_name="jobs"
     )
     status = models.PositiveSmallIntegerField(
-        choices=constants.JobStatus.choices, default=constants.JobStatus.PENDING, editable=False
+        choices=constants.JobStatus, default=constants.JobStatus.PENDING, editable=False
     )
     job = models.PositiveSmallIntegerField(
-        choices=constants.JobType.choices, default=constants.JobType.TEST
+        choices=constants.JobType, default=constants.JobType.TEST
     )
 
     kwargs = models.JSONField(default=dict, blank=True, null=True)
@@ -1268,7 +1268,7 @@ class ContentTypeChoices(models.IntegerChoices):
 
 
 class Content(models.Model):
-    content_type = models.PositiveIntegerField(choices=ContentTypeChoices.choices, unique=True)
+    content_type = models.PositiveIntegerField(choices=ContentTypeChoices, unique=True)
     template = models.TextField()
     created = models.DateTimeField(auto_now_add=True)
     last_updated = models.DateTimeField(auto_now=True)

--- a/hawc/apps/bmd/models.py
+++ b/hawc/apps/bmd/models.py
@@ -17,7 +17,7 @@ class AssessmentSettings(models.Model):
     )
     version = models.CharField(
         max_length=10,
-        choices=constants.BmdsVersion.choices,
+        choices=constants.BmdsVersion,
         default=constants.BmdsVersion.BMDS330,
         help_text="Select the BMDS version to be used for dose-response modeling. Version 2 is no longer supported for execution; but results will be available for any version after execution is complete.",
     )
@@ -56,7 +56,7 @@ class Session(models.Model):
     dose_units = models.ForeignKey(
         "assessment.DoseUnits", on_delete=models.CASCADE, related_name="bmd_sessions"
     )
-    version = models.CharField(max_length=10, choices=constants.BmdsVersion.choices)
+    version = models.CharField(max_length=10, choices=constants.BmdsVersion)
     inputs = models.JSONField(default=dict)
     outputs = models.JSONField(default=dict)
     errors = models.JSONField(default=dict)

--- a/hawc/apps/eco/models.py
+++ b/hawc/apps/eco/models.py
@@ -24,7 +24,7 @@ class State(models.Model):
 
 class NestedTerm(MP_Node):
     name = models.CharField(max_length=128)
-    type = models.CharField(choices=TypeChoices.choices, max_length=2, default="CE")
+    type = models.CharField(choices=TypeChoices, max_length=2, default="CE")
     created = models.DateTimeField(auto_now_add=True)
     last_updated = models.DateTimeField(auto_now=True)
     notes = models.TextField(blank=True)
@@ -66,7 +66,7 @@ class NestedTerm(MP_Node):
 
 
 class Vocab(models.Model):
-    category = models.IntegerField(choices=VocabCategories.choices)
+    category = models.IntegerField(choices=VocabCategories)
     value = models.CharField(max_length=128)
     parent = models.ForeignKey(
         "self",
@@ -408,7 +408,7 @@ class Result(models.Model):
         default=0,
     )
     relationship_direction = models.IntegerField(
-        choices=ChangeTrajectory.choices,
+        choices=ChangeTrajectory,
         verbose_name="Direction of relationship",
         help_text="Direction of cause and effect relationship",
     )

--- a/hawc/apps/epi/models.py
+++ b/hawc/apps/epi/models.py
@@ -98,7 +98,7 @@ class StudyPopulationCriteria(models.Model):
     study_population = models.ForeignKey(
         "StudyPopulation", on_delete=models.CASCADE, related_name="spcriteria"
     )
-    criteria_type = models.CharField(max_length=1, choices=constants.CriteriaType.choices)
+    criteria_type = models.CharField(max_length=1, choices=constants.CriteriaType)
 
 
 class StudyPopulation(models.Model):
@@ -137,7 +137,7 @@ class StudyPopulation(models.Model):
     )
     design = models.CharField(
         max_length=2,
-        choices=constants.Design.choices,
+        choices=constants.Design,
         help_text="Choose the most specific description of study design." + HAWC_VIS_NOTE,
     )
     age_profile = models.CharField(
@@ -319,7 +319,7 @@ class Outcome(BaseEndpoint):
         help_text="Effect subtype, using common-vocabulary. Use title style (capitalize all words). Ex. Absolute"
         + formatHelpTextNotes("This field is not mandatory; often no effect subtype is necessary"),
     )
-    diagnostic = models.PositiveSmallIntegerField(choices=constants.Diagnostic.choices)
+    diagnostic = models.PositiveSmallIntegerField(choices=constants.Diagnostic)
     diagnostic_description = models.TextField(
         help_text='Copy and paste diagnostic methods directly from study. Ex. "Birth weight (grams) was measured by trained midwives at delivery." '
         + formatHelpTextNotes("Use quotation marks around direct quotes from a study")
@@ -547,7 +547,7 @@ class Group(models.Model):
         + "typically the group with the lowest or no exposure",
         blank=True,
     )
-    sex = models.CharField(max_length=1, default=constants.Sex.U, choices=constants.Sex.choices)
+    sex = models.CharField(max_length=1, default=constants.Sex.U, choices=constants.Sex)
     ethnicities = models.ManyToManyField(Ethnicity, blank=True, help_text="Optional")
     eligible_n = models.PositiveIntegerField(
         blank=True, null=True, verbose_name="Eligible N", help_text="Optional"
@@ -850,13 +850,13 @@ class CentralTendency(models.Model):
         + HAWC_VIS_NOTE,
     )
     estimate_type = models.PositiveSmallIntegerField(
-        choices=constants.EstimateType.choices,
+        choices=constants.EstimateType,
         verbose_name="Central estimate type",
         default=constants.EstimateType.NONE,
     )
     variance = models.FloatField(blank=True, null=True, verbose_name="Variance")
     variance_type = models.PositiveSmallIntegerField(
-        choices=constants.VarianceType.choices, default=constants.VarianceType.NONE
+        choices=constants.VarianceType, default=constants.VarianceType.NONE
     )
     lower_ci = models.FloatField(
         blank=True, null=True, verbose_name="Lower CI", help_text="Numerical value"
@@ -939,7 +939,7 @@ class GroupNumericalDescriptions(models.Model):
     )
     mean = models.FloatField(blank=True, null=True, verbose_name="Central estimate")
     mean_type = models.PositiveSmallIntegerField(
-        choices=constants.GroupMeanType.choices,
+        choices=constants.GroupMeanType,
         verbose_name="Central estimate type",
         default=constants.GroupMeanType.NONE,
     )
@@ -948,15 +948,15 @@ class GroupNumericalDescriptions(models.Model):
     )
     variance = models.FloatField(blank=True, null=True)
     variance_type = models.PositiveSmallIntegerField(
-        choices=constants.GroupVarianceType.choices, default=constants.GroupVarianceType.NONE
+        choices=constants.GroupVarianceType, default=constants.GroupVarianceType.NONE
     )
     lower = models.FloatField(blank=True, null=True)
     lower_type = models.PositiveSmallIntegerField(
-        choices=constants.LowerLimit.choices, default=constants.LowerLimit.NONE
+        choices=constants.LowerLimit, default=constants.LowerLimit.NONE
     )
     upper = models.FloatField(blank=True, null=True)
     upper_type = models.PositiveSmallIntegerField(
-        choices=constants.UpperLimit.choices, default=constants.UpperLimit.NONE
+        choices=constants.UpperLimit, default=constants.UpperLimit.NONE
     )
 
     class Meta:
@@ -1055,7 +1055,7 @@ class Result(models.Model):
         verbose_name="Dose Response Trend",
         help_text=OPTIONAL_NOTE,
         default=constants.DoseResponse.NA,
-        choices=constants.DoseResponse.choices,
+        choices=constants.DoseResponse,
     )
     dose_response_details = models.TextField(blank=True, help_text=OPTIONAL_NOTE)
     prevalence_incidence = models.CharField(
@@ -1067,7 +1067,7 @@ class Result(models.Model):
     statistical_power = models.PositiveSmallIntegerField(
         help_text="Is the study sufficiently powered?" + OPTIONAL_NOTE,
         default=constants.StatisticalPower.NR,
-        choices=constants.StatisticalPower.choices,
+        choices=constants.StatisticalPower,
     )
     statistical_power_details = models.TextField(blank=True, help_text=OPTIONAL_NOTE)
     statistical_test_results = models.TextField(blank=True, help_text=OPTIONAL_NOTE)
@@ -1085,12 +1085,12 @@ class Result(models.Model):
         blank=True,
     )
     estimate_type = models.PositiveSmallIntegerField(
-        choices=constants.EstimateType.choices,
+        choices=constants.EstimateType,
         verbose_name="Central estimate type",
         default=constants.EstimateType.NONE,
     )
     variance_type = models.PositiveSmallIntegerField(
-        choices=constants.VarianceType.choices, default=constants.VarianceType.NONE
+        choices=constants.VarianceType, default=constants.VarianceType.NONE
     )
     ci_units = models.FloatField(
         blank=True,
@@ -1368,7 +1368,7 @@ class GroupResult(models.Model):
     )
     p_value_qualifier = models.CharField(
         max_length=1,
-        choices=constants.PValueQualifier.choices,
+        choices=constants.PValueQualifier,
         default="-",
         verbose_name="p-value qualifier",
         help_text="Select n.s. if results are not statistically significant; otherwise, choose the appropriate qualifier. "
@@ -1395,7 +1395,7 @@ class GroupResult(models.Model):
         + HAWC_VIS_NOTE_UNSTYLED,
     )
     main_finding_support = models.PositiveSmallIntegerField(
-        choices=constants.MainFinding.choices,
+        choices=constants.MainFinding,
         help_text="Select appropriate level of support for the main finding."
         + 'See "Results" section of https://ehp.niehs.nih.gov/1205502/ for examples and further details. '
         + 'Choose between "inconclusive" vs. "not-supportive" based on chemical- and study-specific context. '

--- a/hawc/apps/epimeta/models.py
+++ b/hawc/apps/epimeta/models.py
@@ -18,11 +18,11 @@ class MetaProtocol(models.Model):
     )
     name = models.CharField(verbose_name="Protocol name", max_length=128)
     protocol_type = models.PositiveSmallIntegerField(
-        choices=constants.MetaProtocol.choices, default=constants.MetaProtocol.META
+        choices=constants.MetaProtocol, default=constants.MetaProtocol.META
     )
     lit_search_strategy = models.PositiveSmallIntegerField(
         verbose_name="Literature search strategy",
-        choices=constants.MetaLitSearch.choices,
+        choices=constants.MetaLitSearch,
         default=constants.MetaLitSearch.SYSTEMATIC,
     )
     lit_search_notes = models.TextField(verbose_name="Literature search notes", blank=True)

--- a/hawc/apps/epiv2/models.py
+++ b/hawc/apps/epiv2/models.py
@@ -28,12 +28,12 @@ class Design(models.Model):
     )
     study_design = models.CharField(
         max_length=2,
-        choices=constants.StudyDesign.choices,
+        choices=constants.StudyDesign,
         help_text='Select the most appropriate design from the list. If more than one study design applies (e.g., a cohort with cross-sectional analyses of baseline measures), can either a) select one design ("cohort") and clarify different timing in remaining extraction or b) select "other" and provide details in comments.',
     )
-    source = models.CharField(max_length=2, choices=constants.Source.choices)
+    source = models.CharField(max_length=2, choices=constants.Source)
     age_profile = ArrayField(
-        models.CharField(max_length=2, choices=constants.AgeProfile.choices),
+        models.CharField(max_length=2, choices=constants.AgeProfile),
         help_text='Select all that apply. Note: do not select "Pregnant women" if pregnant women are only included as part of a general population sample',
         verbose_name="Population age category",
     )
@@ -42,7 +42,7 @@ class Design(models.Model):
         blank=True,
         verbose_name="Population age details",
     )
-    sex = models.CharField(default=constants.Sex.BOTH, max_length=1, choices=constants.Sex.choices)
+    sex = models.CharField(default=constants.Sex.BOTH, max_length=1, choices=constants.Sex)
     race = models.CharField(max_length=128, blank=True, verbose_name="Population race/ethnicity")
     participant_n = models.PositiveIntegerField(
         verbose_name="Overall study population N",
@@ -165,10 +165,10 @@ class Exposure(models.Model):
         verbose_name="Exposure measurement types",
     )
     biomonitoring_matrix = models.CharField(
-        max_length=3, choices=constants.BiomonitoringMatrix.choices, blank=True
+        max_length=3, choices=constants.BiomonitoringMatrix, blank=True
     )
     biomonitoring_source = models.CharField(
-        max_length=2, choices=constants.BiomonitoringSource.choices, blank=True
+        max_length=2, choices=constants.BiomonitoringSource, blank=True
     )
     measurement_timing = models.CharField(
         max_length=256,
@@ -178,7 +178,7 @@ class Exposure(models.Model):
     )
     exposure_route = models.CharField(
         max_length=2,
-        choices=constants.ExposureRoute.choices,
+        choices=constants.ExposureRoute,
         default=constants.ExposureRoute.UNKNOWN,
         help_text='Select the most appropriate route. In most cases, biomarkers will be "Unknown/Total" unless a clear exposure source is known.',
     )
@@ -241,7 +241,7 @@ class ExposureLevel(models.Model):
     mean = models.FloatField(blank=True, null=True)
     variance = models.FloatField(blank=True, null=True)
     variance_type = models.PositiveSmallIntegerField(
-        choices=constants.VarianceType.choices,
+        choices=constants.VarianceType,
         default=constants.VarianceType.NA,
         verbose_name="Type of variance estimate",
         help_text="Specify which measure of variation was reported from list",
@@ -273,7 +273,7 @@ class ExposureLevel(models.Model):
     )
     ci_type = models.CharField(
         max_length=3,
-        choices=constants.ConfidenceIntervalType.choices,
+        choices=constants.ConfidenceIntervalType,
         default=constants.ConfidenceIntervalType.NA,
         verbose_name="Lower/upper interval type",
     )
@@ -331,7 +331,7 @@ class Outcome(models.Model):
     design = models.ForeignKey(Design, on_delete=models.CASCADE, related_name="outcomes")
     system = models.CharField(
         max_length=2,
-        choices=constants.HealthOutcomeSystem.choices,
+        choices=constants.HealthOutcomeSystem,
         help_text="Select the most relevant system from the drop down menu. If more than one system is applicable refer to assessment team instructions.",
     )
     effect = models.CharField(
@@ -452,13 +452,13 @@ class DataExtraction(models.Model):
     ci_ucl = models.FloatField(verbose_name="Upper bound", blank=True, null=True)
     ci_type = models.CharField(
         max_length=3,
-        choices=constants.ConfidenceIntervalType.choices,
+        choices=constants.ConfidenceIntervalType,
         default=constants.ConfidenceIntervalType.P95,
         verbose_name="Lower/upper bound type",
     )
     units = models.CharField(max_length=128, blank=True)
     variance_type = models.PositiveSmallIntegerField(
-        choices=constants.VarianceType.choices,
+        choices=constants.VarianceType,
         default=constants.VarianceType.NA,
         verbose_name="Type of variance estimate",
         help_text="Specify which measure of variation was reported from list",
@@ -468,7 +468,7 @@ class DataExtraction(models.Model):
     p_value = models.CharField(verbose_name="p-value", max_length=8, blank=True)
     significant = models.PositiveSmallIntegerField(
         verbose_name="Statistically Significant",
-        choices=constants.Significant.choices,
+        choices=constants.Significant,
         default=constants.Significant.NR,
     )
     group = models.CharField(
@@ -509,7 +509,7 @@ class DataExtraction(models.Model):
     )
     adverse_direction = models.CharField(
         max_length=12,
-        choices=constants.AdverseDirection.choices,
+        choices=constants.AdverseDirection,
         default=constants.AdverseDirection.UNSPECIFIED,
         verbose_name="Adverse direction",
         help_text=" Select the direction of effect that would be adverse if observed. This does not mean that the actual results were adverse or were in that direction; this is a guide for interpretation of the results. For example, for a given neuropsychological score, is an increase interpreted as a better or worse score? For some outcomes (e.g., thyroid hormones), an association in either direction could conceivably be adverse.",

--- a/hawc/apps/hawc_admin/methods/daily_changes.py
+++ b/hawc/apps/hawc_admin/methods/daily_changes.py
@@ -1,16 +1,17 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import pandas as pd
 import plotly.express as px
 from django.db.models import Count
 from django.db.models.functions import Trunc
+from django.utils.timezone import now
 from reversion.models import Revision
 
 
 def _get_df(Model, freq: str, field: str) -> pd.DataFrame:
     qs = (
         Model.objects.all()
-        .filter(**{f"{field}__gt": datetime.today() - timedelta(days=365)})
+        .filter(**{f"{field}__date__gt": now() - timedelta(days=365)})
         .annotate(date=Trunc(field, freq))
         .order_by("date")
         .values("date")

--- a/hawc/apps/invitro/models.py
+++ b/hawc/apps/invitro/models.py
@@ -89,9 +89,9 @@ class IVCellType(models.Model):
     study = models.ForeignKey("study.Study", on_delete=models.CASCADE, related_name="ivcelltypes")
     species = models.CharField(max_length=64)
     strain = models.CharField(max_length=64, default="not applicable")
-    sex = models.CharField(max_length=2, choices=constants.Sex.choices)
+    sex = models.CharField(max_length=2, choices=constants.Sex)
     cell_type = models.CharField(max_length=64)
-    culture_type = models.CharField(max_length=2, choices=constants.CultureType.choices)
+    culture_type = models.CharField(max_length=2, choices=constants.CultureType)
     tissue = models.CharField(max_length=64)
     source = models.CharField(max_length=128, verbose_name="Source of cell cultures")
 
@@ -144,7 +144,7 @@ class IVExperiment(models.Model):
     )
     metabolic_activation = models.CharField(
         max_length=2,
-        choices=constants.MetabolicActivation.choices,
+        choices=constants.MetabolicActivation,
         default=constants.MetabolicActivation.NR,
         help_text="Was metabolic-activation used in system (ex: S9)?",
     )
@@ -254,12 +254,12 @@ class IVEndpoint(BaseEndpoint):
     )
     data_type = models.CharField(
         max_length=2,
-        choices=constants.DataType.choices,
+        choices=constants.DataType,
         default=constants.DataType.CONTINUOUS,
         verbose_name="Dataset type",
     )
     variance_type = models.PositiveSmallIntegerField(
-        default=constants.VarianceType.NA, choices=constants.VarianceType.choices
+        default=constants.VarianceType.NA, choices=constants.VarianceType
     )
     response_units = models.CharField(max_length=64, blank=True, verbose_name="Response units")
     values_estimated = models.BooleanField(
@@ -268,7 +268,7 @@ class IVEndpoint(BaseEndpoint):
     )
     observation_time = models.CharField(blank=True, max_length=32)
     observation_time_units = models.PositiveSmallIntegerField(
-        default=constants.ObservationTimeUnits.NR, choices=constants.ObservationTimeUnits.choices
+        default=constants.ObservationTimeUnits.NR, choices=constants.ObservationTimeUnits
     )
     NOEL = models.SmallIntegerField(
         verbose_name="NOEL", default=-999, help_text="No observed effect level"
@@ -277,10 +277,10 @@ class IVEndpoint(BaseEndpoint):
         verbose_name="LOEL", default=-999, help_text="Lowest observed effect level"
     )
     monotonicity = models.PositiveSmallIntegerField(
-        default=constants.Monotonicity.NR, choices=constants.Monotonicity.choices
+        default=constants.Monotonicity.NR, choices=constants.Monotonicity
     )
     overall_pattern = models.PositiveSmallIntegerField(
-        default=constants.OverallPattern.NA, choices=constants.OverallPattern.choices
+        default=constants.OverallPattern.NA, choices=constants.OverallPattern
     )
     statistical_test_notes = models.CharField(
         max_length=256,
@@ -288,7 +288,7 @@ class IVEndpoint(BaseEndpoint):
         help_text="Notes describing details on the statistical tests performed",
     )
     trend_test = models.PositiveSmallIntegerField(
-        default=constants.TrendTestResult.NR, choices=constants.TrendTestResult.choices
+        default=constants.TrendTestResult.NR, choices=constants.TrendTestResult
     )
     trend_test_notes = models.CharField(
         max_length=256,
@@ -367,11 +367,11 @@ class IVEndpointGroup(ConfidenceIntervalsMixin, models.Model):
     variance = models.FloatField(blank=True, null=True, validators=[MinValueValidator(0)])
     difference_control = models.CharField(
         max_length=2,
-        choices=constants.DifferenceControl.choices,
+        choices=constants.DifferenceControl,
         default=constants.DifferenceControl.NC,
     )
     significant_control = models.CharField(
-        max_length=2, default=constants.Significance.NR, choices=constants.Significance.choices
+        max_length=2, default=constants.Significance.NR, choices=constants.Significance
     )
     cytotoxicity_observed = models.BooleanField(
         default=None,

--- a/hawc/apps/lit/models.py
+++ b/hawc/apps/lit/models.py
@@ -194,9 +194,9 @@ class Search(models.Model):
     assessment = models.ForeignKey(
         "assessment.Assessment", on_delete=models.CASCADE, related_name="literature_searches"
     )
-    search_type = models.CharField(max_length=1, choices=constants.SearchType.choices)
+    search_type = models.CharField(max_length=1, choices=constants.SearchType)
     source = models.PositiveSmallIntegerField(
-        choices=constants.ReferenceDatabase.choices,
+        choices=constants.ReferenceDatabase,
         help_text="Database used to identify literature.",
     )
     title = models.CharField(
@@ -609,7 +609,7 @@ class Identifiers(models.Model):
     unique_id = models.CharField(
         max_length=256, db_index=True
     )  # DOI has no limit; we make this relatively large
-    database = models.IntegerField(choices=constants.ReferenceDatabase.choices)
+    database = models.IntegerField(choices=constants.ReferenceDatabase)
     content = models.TextField()
     url = models.URLField(blank=True)
 

--- a/hawc/apps/mgmt/models.py
+++ b/hawc/apps/mgmt/models.py
@@ -27,9 +27,9 @@ class Task(models.Model):
         related_name="tasks",
     )
     study = models.ForeignKey(Study, on_delete=models.CASCADE, related_name="tasks")
-    type = models.PositiveSmallIntegerField(choices=constants.TaskType.choices)
+    type = models.PositiveSmallIntegerField(choices=constants.TaskType)
     status = models.PositiveSmallIntegerField(
-        default=constants.TaskStatus.NOT_STARTED, choices=constants.TaskStatus.choices
+        default=constants.TaskStatus.NOT_STARTED, choices=constants.TaskStatus
     )
     open = models.BooleanField(default=False)
     due_date = models.DateTimeField(blank=True, null=True)

--- a/hawc/apps/riskofbias/models.py
+++ b/hawc/apps/riskofbias/models.py
@@ -75,7 +75,7 @@ class RiskOfBiasMetric(models.Model):
     description = models.TextField(
         blank=True, help_text="Detailed instructions for how to apply this metric."
     )
-    responses = models.PositiveSmallIntegerField(choices=constants.RiskOfBiasResponses.choices)
+    responses = models.PositiveSmallIntegerField(choices=constants.RiskOfBiasResponses)
     required_animal = models.BooleanField(
         default=True,
         verbose_name="Required for bioassay?",
@@ -363,7 +363,7 @@ class RiskOfBiasScore(models.Model):
     label = models.CharField(max_length=128, blank=True)
     score = models.PositiveSmallIntegerField(choices=constants.SCORE_CHOICES)
     bias_direction = models.PositiveSmallIntegerField(
-        choices=constants.BiasDirections.choices,
+        choices=constants.BiasDirections,
         default=constants.BiasDirections.BIAS_DIRECTION_UNKNOWN,
         help_text="Judgment of direction of bias (⬆ = away from null, ⬇ = towards null); only add entry if important to show in visuals",
     )

--- a/hawc/apps/study/models.py
+++ b/hawc/apps/study/models.py
@@ -63,7 +63,7 @@ class Study(Reference):
     )
     full_citation = models.TextField(help_text="Complete study citation, in desired format.")
     coi_reported = models.PositiveSmallIntegerField(
-        choices=constants.CoiReported.choices,
+        choices=constants.CoiReported,
         default=constants.CoiReported.UNKNOWN,
         verbose_name="COI reported",
         help_text="Was a conflict of interest reported by the study authors?",

--- a/hawc/apps/summary/models.py
+++ b/hawc/apps/summary/models.py
@@ -140,7 +140,7 @@ class SummaryTable(models.Model):
     )
     content = models.JSONField(default=dict)
     table_type = models.PositiveSmallIntegerField(
-        choices=constants.TableType.choices, default=constants.TableType.GENERIC
+        choices=constants.TableType, default=constants.TableType.GENERIC
     )
     published = models.BooleanField(
         default=False,
@@ -281,8 +281,8 @@ class Visual(models.Model):
         "(no spaces or special-characters).",
     )
     assessment = models.ForeignKey(Assessment, on_delete=models.CASCADE, related_name="visuals")
-    visual_type = models.PositiveSmallIntegerField(choices=constants.VisualType.choices)
-    evidence_type = models.PositiveSmallIntegerField(choices=constants.StudyType.choices)
+    visual_type = models.PositiveSmallIntegerField(choices=constants.VisualType)
+    evidence_type = models.PositiveSmallIntegerField(choices=constants.StudyType)
     dose_units = models.ForeignKey(DoseUnits, on_delete=models.SET_NULL, blank=True, null=True)
     endpoints = models.ManyToManyField(
         BaseEndpoint,
@@ -299,7 +299,7 @@ class Visual(models.Model):
     )
     sort_order = models.CharField(
         max_length=40,
-        choices=constants.SortOrder.choices,
+        choices=constants.SortOrder,
         default=constants.SortOrder.SC,
     )
     prefilters = models.JSONField(default=dict)
@@ -714,10 +714,10 @@ class DataPivotQuery(DataPivot):
     MAXIMUM_QUERYSET_COUNT = 1000
 
     evidence_type = models.PositiveSmallIntegerField(
-        choices=constants.StudyType.choices, default=constants.StudyType.BIOASSAY
+        choices=constants.StudyType, default=constants.StudyType.BIOASSAY
     )
     export_style = models.PositiveSmallIntegerField(
-        choices=constants.ExportStyle.choices,
+        choices=constants.ExportStyle,
         default=constants.ExportStyle.EXPORT_GROUP,
         help_text="The export style changes the level at which the "
         "data are aggregated, and therefore which columns and types "

--- a/hawc/apps/vocab/models.py
+++ b/hawc/apps/vocab/models.py
@@ -12,10 +12,10 @@ class Term(models.Model):
 
     uid = models.PositiveIntegerField(unique=True)
     namespace = models.PositiveSmallIntegerField(
-        choices=constants.VocabularyNamespace.choices, default=constants.VocabularyNamespace.EHV
+        choices=constants.VocabularyNamespace, default=constants.VocabularyNamespace.EHV
     )
     parent = models.ForeignKey("Term", on_delete=models.CASCADE, blank=True, null=True)
-    type = models.PositiveIntegerField(choices=constants.VocabularyTermType.choices)
+    type = models.PositiveIntegerField(choices=constants.VocabularyTermType)
     name = models.CharField(max_length=256)
     notes = models.TextField(blank=True)
     deprecated_on = models.DateTimeField(blank=True, null=True)
@@ -113,7 +113,7 @@ class Term(models.Model):
 
 class Entity(models.Model):
     # mapping of controlled vocabulary to ontology
-    ontology = models.PositiveSmallIntegerField(choices=constants.Ontology.choices)
+    ontology = models.PositiveSmallIntegerField(choices=constants.Ontology)
     uid = models.CharField(max_length=128, verbose_name="UID")
     terms = models.ManyToManyField(
         Term,

--- a/hawc/main/settings/base.py
+++ b/hawc/main/settings/base.py
@@ -372,3 +372,5 @@ IS_TESTING = False
 TEST_DB_FIXTURE = PROJECT_ROOT / "tests/data/fixtures/db.yaml"
 
 DISCLAIMER_TEXT = ""
+
+FORMS_URLFIELD_ASSUME_HTTPS = True

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # web application
-Django~=4.2.7
+Django~=5.0.0
 django-crispy-forms==2.1
 crispy-bootstrap4==2023.1
 django-filter==23.4
@@ -13,7 +13,7 @@ djangorestframework==3.14.0
   uritemplate==4.1.1  # schema dependencies
   pyyaml==6.0.1       # schema dependencies
 gunicorn==21.2.0
-wagtail==5.2.1
+wagtail==5.2.2
 wagtail-draftail-anchors==0.6.0
 
 # tasks


### PR DESCRIPTION
Migrates HAWC to Django version 5.0.0

The only thing I could find that broke was wagtail, which required a small update to the next version

I wasn't able to find anything in our codebase that is on the list of [backwards incompatible changes](https://docs.djangoproject.com/en/5.0/releases/5.0/#backwards-incompatible-5-0).