### PR TITLE
add backup PMID finder to ris importer

### DIFF
--- a/hawc/services/utils/ris.py
+++ b/hawc/services/utils/ris.py
@@ -15,7 +15,13 @@ class RisImporter:
     def get_mapping(cls):
         mapping = copy(rispy.TAG_KEY_MAPPING)
         mapping.update(
-            {"AT": "accession_type", "PM": "pubmed_id",  "C7": "pubmed_id_backup", "N2": "abstract2", "SV": "serial_volume"}
+            {
+                "AT": "accession_type",
+                "PM": "pubmed_id",
+                "C7": "pubmed_id_backup",
+                "N2": "abstract2",
+                "SV": "serial_volume",
+            }
         )
         return mapping
 

--- a/hawc/services/utils/ris.py
+++ b/hawc/services/utils/ris.py
@@ -15,7 +15,7 @@ class RisImporter:
     def get_mapping(cls):
         mapping = copy(rispy.TAG_KEY_MAPPING)
         mapping.update(
-            {"AT": "accession_type", "PM": "pubmed_id", "N2": "abstract2", "SV": "serial_volume"}
+            {"AT": "accession_type", "PM": "pubmed_id",  "C7": "pubmed_id_backup", "N2": "abstract2", "SV": "serial_volume"}
         )
         return mapping
 
@@ -162,8 +162,7 @@ class ReferenceParser:
 
     def _get_pmid(self) -> int | None:
         # get PMID if specified in that field
-        if "pubmed_id" in self.content:
-            pubmed_id = self.content["pubmed_id"]
+        if pubmed_id := self.content.get("pubmed_id", self.content.get("pubmed_id_backup", None)):
             if isinstance(pubmed_id, int):
                 return pubmed_id
             else:

--- a/hawc/templates/hawc/_delete_block.html
+++ b/hawc/templates/hawc/_delete_block.html
@@ -20,6 +20,7 @@
 {% if confirm %}
 <script>
   window.addEventListener('load', function () {
+    $("#confirmationText").focus();
     $('#confirmationText').on('keyup', function(){
       if (this.value === "delete") {
         $('#deleteConfirmationActionsDiv').removeClass('hidden');


### PR DESCRIPTION
The RIS file importer misses PMIDs if they are not stored under the PM tag. Here I've added C7 as a backup PMID tag (see [wikipedia](https://en.wikipedia.org/wiki/RIS_(file_format))) if nothing is found under PM. I've also added a focus() call to the delete prompt js since it often appears at the bottom of the page.