### PR TITLE
Risk Of Bias review tasks dashboard

### DIFF
--- a/hawc/apps/mgmt/templates/mgmt/fragments/rob_reviews.html
+++ b/hawc/apps/mgmt/templates/mgmt/fragments/rob_reviews.html
@@ -1,5 +1,5 @@
 <p class="text-muted my-2">This lists shows all {{rob_name|lower}} reviews which are currently assigned to you that require completion.</p>
-<div class="list-group">
+<div class="list-group mb-3">
     {% for review in rob_reviews %}
     <a class="list-group-item list-group-item-action dark-link" href="{{review.get_edit_url}}">{% icon 'fa-edit' %}&nbsp;{% if show_assessment %}{{review.study.assessment}}&nbsp;|&nbsp;{% endif %}{{review.study.short_citation}}&nbsp;({{review.final|yesno:"final,individual"}} review)</a>
     {% empty %}

--- a/hawc/apps/mgmt/templates/mgmt/fragments/rob_reviews.html
+++ b/hawc/apps/mgmt/templates/mgmt/fragments/rob_reviews.html
@@ -1,7 +1,7 @@
 <p class="text-muted my-2">This lists shows all {{rob_name|lower}} reviews which are currently assigned to you that require completion.</p>
 <div class="list-group">
     {% for review in rob_reviews %}
-    <a class="list-group-item list-group-item-action" href="{{review.get_edit_url}}">{% icon 'fa-edit' %}&nbsp;{% if show_assessment %}{{review.study.assessment}}&nbsp;|&nbsp;{% endif %}{{review.study.short_citation}}&nbsp;({{review.final|yesno:"final,individual"}} review)</a>
+    <a class="list-group-item list-group-item-action dark-link" href="{{review.get_edit_url}}">{% icon 'fa-edit' %}&nbsp;{% if show_assessment %}{{review.study.assessment}}&nbsp;|&nbsp;{% endif %}{{review.study.short_citation}}&nbsp;({{review.final|yesno:"final,individual"}} review)</a>
     {% empty %}
     <p class="list-group-item disabled">You have no remaining reviews.</li>
     {% endfor %}

--- a/hawc/apps/mgmt/templates/mgmt/fragments/rob_reviews.html
+++ b/hawc/apps/mgmt/templates/mgmt/fragments/rob_reviews.html
@@ -1,0 +1,8 @@
+<p class="text-muted my-2">This lists shows all {{rob_name|lower}} reviews which are currently assigned to you that require completion.</p>
+<div class="list-group">
+    {% for review in rob_reviews %}
+    <a class="list-group-item list-group-item-action" href="{{review.get_edit_url}}">{% icon 'fa-edit' %}&nbsp;{% if show_assessment %}{{review.study.assessment}}&nbsp;|&nbsp;{% endif %}{{review.study.short_citation}}&nbsp;({{review.final|yesno:"final,individual"}} review)</a>
+    {% empty %}
+    <p class="list-group-item disabled">You have no remaining reviews.</li>
+    {% endfor %}
+</div>

--- a/hawc/apps/mgmt/templates/mgmt/user_assessment_task_list.html
+++ b/hawc/apps/mgmt/templates/mgmt/user_assessment_task_list.html
@@ -24,4 +24,10 @@
 {% else %}
 <p><i>There are no tasks available</i></p>
 {% endif %}
+
+{% with rob_name=assessment.get_rob_name_display %}
+<h3>Assigned {{rob_name|title}} Reviews</h3>
+{% include "mgmt/fragments/rob_reviews.html" with show_assessment=False %}
+{% endwith %}
+
 {% endblock %}

--- a/hawc/apps/mgmt/templates/mgmt/user_assessment_task_list.html
+++ b/hawc/apps/mgmt/templates/mgmt/user_assessment_task_list.html
@@ -26,7 +26,7 @@
 {% endif %}
 
 {% with rob_name=assessment.get_rob_name_display %}
-<h3>Assigned {{rob_name|title}} Reviews</h3>
+<h3 class="mb-0">Assigned {{rob_name|title}} Reviews</h3>
 {% include "mgmt/fragments/rob_reviews.html" with show_assessment=False %}
 {% endwith %}
 

--- a/hawc/apps/mgmt/templates/mgmt/user_task_list.html
+++ b/hawc/apps/mgmt/templates/mgmt/user_task_list.html
@@ -32,7 +32,7 @@
 {% endif %}
 
 {% with rob_name=assessment.get_rob_name_display %}
-<h3>Assigned Study Evaluation/Risk of Bias Reviews</h3>
+<h3 class="mb-3">Assigned Study Evaluation/Risk of Bias Reviews</h3>
 {% include "mgmt/fragments/rob_reviews.html" with show_assessment=True %}
 {% endwith %}
 

--- a/hawc/apps/mgmt/templates/mgmt/user_task_list.html
+++ b/hawc/apps/mgmt/templates/mgmt/user_task_list.html
@@ -30,4 +30,10 @@
 {% else %}
 <p><i>There are no tasks available</i></p>
 {% endif %}
+
+{% with rob_name=assessment.get_rob_name_display %}
+<h3>Assigned Study Evaluation/Risk of Bias Reviews</h3>
+{% include "mgmt/fragments/rob_reviews.html" with show_assessment=True %}
+{% endwith %}
+
 {% endblock %}

--- a/hawc/apps/mgmt/templates/mgmt/user_task_list.html
+++ b/hawc/apps/mgmt/templates/mgmt/user_task_list.html
@@ -32,7 +32,7 @@
 {% endif %}
 
 {% with rob_name=assessment.get_rob_name_display %}
-<h3 class="mb-3">Assigned Study Evaluation/Risk of Bias Reviews</h3>
+<h3 class="mb-0">Assigned Study Evaluation/Risk of Bias Reviews</h3>
 {% include "mgmt/fragments/rob_reviews.html" with show_assessment=True %}
 {% endwith %}
 

--- a/hawc/static/css/epa-bootstrap.css
+++ b/hawc/static/css/epa-bootstrap.css
@@ -55,6 +55,6 @@ a.btn-warning:visited, a.badge-warning:visited {
   padding: 0 0 0 1em;
 }
 .dropdown-item.active,
-.dropdown-item:active {
+.dropdown-item:active, .logout-btn:active {
   color: #fff !important;
 }

--- a/hawc/static/css/hawc.css
+++ b/hawc/static/css/hawc.css
@@ -93,6 +93,9 @@ tfoot > tr > td {
 .box-shadow {
     box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
 }
+.dark-link, .dark-link:visited {
+    color: #495057;
+}
 .showOptsCaret:hover .optsCaret {
     opacity: 1;
     -webkit-transition: all 0.5s ease-in-out;

--- a/hawc/templates/includes/_navigation_links.html
+++ b/hawc/templates/includes/_navigation_links.html
@@ -2,12 +2,14 @@
     <a class="nav-link" href="{% url 'contact' %}">Contact Us</a>
 </li>
 {% if not contact_only %}
+{% if feature_flags.ENABLE_DOCS_LINK and not user.is_authenticated %}
 <li class="nav-item">
     <a class="nav-link" href="{% url 'about' %}">About</a>
 </li>
 <li class="nav-item">
     <a class="nav-link" href="{% url 'resources' %}">Resources</a>
 </li>
+{% endif %}
 {% if feature_flags.ENABLE_DOCS_LINK and user.is_authenticated %}
 <li class="nav-item">
     <a class="nav-link" href="{% url 'wagtail_serve' '' %}">Documentation</a>

--- a/hawc/templates/includes/_navigation_links.html
+++ b/hawc/templates/includes/_navigation_links.html
@@ -37,7 +37,7 @@
         <div class="dropdown-divider"></div>
         <form class="dropdown-item" method="post" action="{% url 'user:logout' %}">
             {% csrf_token %}
-            <button class="unstyled-action-button" type="submit">Logout</button>
+            <button class="unstyled-action-button logout-btn" type="submit">Logout</button>
         </form>
     </div>
 </li>


### PR DESCRIPTION
A prior PR, #808, removed what we thought was an unused list of study evaluations a user is currently assigned but have not yet completed. We heard from users that this feature was used, so we've added it back in this PR.

- Add a list of incomplete study evaluations at the assessment mgmt level, as well as the overall user level
    - `/mgmt/assessment/:id/tasks/`
    - `/mgmt/tasks/`

![image](https://github.com/shapiromatron/hawc/assets/999952/d9a8303b-2f41-4b67-8124-6f72d04b03b5)


--- 

In addition, updated the navbar to only show the "about" and "resources" pages if the user is not logged in and the new documentation tab is not enabled. I found that even with a "wide" laptop monitor of 1440px, with the EPA flavor of the styles, it wouldn't fit on the a single line with the HAWC title as well.
