### PR TITLE
Add pagination to the references list view

### DIFF
--- a/frontend/lit/ReferenceTreeBrowse/Main.js
+++ b/frontend/lit/ReferenceTreeBrowse/Main.js
@@ -4,6 +4,7 @@ import {toJS} from "mobx";
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
 import React, {Component} from "react";
+import HelpText from "shared/components/HelpText";
 import Loading from "shared/components/Loading";
 import TextInput from "shared/components/TextInput";
 
@@ -55,7 +56,13 @@ class ReferenceTreeMain extends Component {
     }
     render() {
         const {store} = this.props,
-            {selectedReferences, selectedReferencesLoading, filteredReferences, paginatedReferences, yearFilter} = store,
+            {
+                selectedReferences,
+                selectedReferencesLoading,
+                filteredReferences,
+                paginatedReferences,
+                yearFilter,
+            } = store,
             yearText = yearFilter ? ` (${yearFilter.min}-${yearFilter.max})` : "";
 
         return (
@@ -100,6 +107,7 @@ class ReferenceTreeMain extends Component {
                             <QuickSearch
                                 updateQuickFilter={text => store.changeQuickFilterText(text)}
                             />
+                            <HelpText text={"References on this page:"} />
                             <div
                                 id="reference-list"
                                 className="list-group"

--- a/frontend/lit/ReferenceTreeBrowse/Main.js
+++ b/frontend/lit/ReferenceTreeBrowse/Main.js
@@ -72,18 +72,18 @@ class ReferenceTreeMain extends Component {
             <div className="row">
                 <div className="col-md-12 pb-3">
                     {store.untaggedReferencesSelected === true ? (
-                        <h4>Untagged references</h4>
+                        <h3>Untagged references</h3>
                     ) : store.selectedTag === null ? (
-                        <h4>Available references</h4>
+                        <h3>Available references</h3>
                     ) : (
                         <div className="d-flex">
-                            <h4 className="mb-0 align-self-center">
+                            <h3 className="mb-0 align-self-center">
                                 <span>
                                     {selectedReferences && selectedReferences.length > 0
                                         ? `${filteredReferences.length} references tagged:`
                                         : "References tagged:"}
                                 </span>
-                            </h4>
+                            </h3>
                             <span className="mb-0 ml-2 refTag">
                                 {store.selectedTag.get_full_name()}
                             </span>

--- a/frontend/lit/ReferenceTreeBrowse/Main.js
+++ b/frontend/lit/ReferenceTreeBrowse/Main.js
@@ -55,7 +55,7 @@ class ReferenceTreeMain extends Component {
     }
     render() {
         const {store} = this.props,
-            {selectedReferences, selectedReferencesLoading, filteredReferences, yearFilter} = store,
+            {selectedReferences, selectedReferencesLoading, filteredReferences, paginatedReferences, yearFilter} = store,
             yearText = yearFilter ? ` (${yearFilter.min}-${yearFilter.max})` : "";
 
         return (
@@ -104,7 +104,7 @@ class ReferenceTreeMain extends Component {
                                 id="reference-list"
                                 className="list-group"
                                 style={{maxHeight: "50vh"}}>
-                                {filteredReferences.map(referenceListItem)}
+                                {paginatedReferences.map(referenceListItem)}
                             </div>
                         </>
                     ) : null}

--- a/frontend/lit/ReferenceTreeBrowse/Main.js
+++ b/frontend/lit/ReferenceTreeBrowse/Main.js
@@ -4,7 +4,6 @@ import {toJS} from "mobx";
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
 import React, {Component} from "react";
-import HelpText from "shared/components/HelpText";
 import Loading from "shared/components/Loading";
 import TextInput from "shared/components/TextInput";
 
@@ -107,7 +106,9 @@ class ReferenceTreeMain extends Component {
                             <QuickSearch
                                 updateQuickFilter={text => store.changeQuickFilterText(text)}
                             />
-                            <HelpText text={"References on this page:"} />
+                            <label>
+                                Showing {paginatedReferences.length} of {selectedReferences.length}:
+                            </label>
                             <div
                                 id="reference-list"
                                 className="list-group"

--- a/frontend/lit/ReferenceTreeBrowse/Main.js
+++ b/frontend/lit/ReferenceTreeBrowse/Main.js
@@ -4,7 +4,9 @@ import {toJS} from "mobx";
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
 import React, {Component} from "react";
+import LabelInput from "shared/components/LabelInput";
 import Loading from "shared/components/Loading";
+import Paginator from "shared/components/Paginator";
 import TextInput from "shared/components/TextInput";
 
 import ReferenceSortSelector from "../components/ReferenceSortSelector";
@@ -61,6 +63,8 @@ class ReferenceTreeMain extends Component {
                 filteredReferences,
                 paginatedReferences,
                 yearFilter,
+                page,
+                fetchPage,
             } = store,
             yearText = yearFilter ? ` (${yearFilter.min}-${yearFilter.max})` : "";
 
@@ -106,14 +110,13 @@ class ReferenceTreeMain extends Component {
                             <QuickSearch
                                 updateQuickFilter={text => store.changeQuickFilterText(text)}
                             />
-                            <label>
-                                Showing {paginatedReferences.length} of {selectedReferences.length}:
-                            </label>
-                            <div
-                                id="reference-list"
-                                className="list-group"
-                                style={{maxHeight: "50vh"}}>
+                            <LabelInput
+                                label={`Showing ${paginatedReferences.length} of ${selectedReferences.length}:`}
+                            />
+                            <div id="reference-list" className="list-group">
                                 {paginatedReferences.map(referenceListItem)}
+                                <span className="mt-3"></span>
+                                {page ? <Paginator page={page} onChangePage={fetchPage} /> : null}
                             </div>
                         </>
                     ) : null}

--- a/frontend/lit/ReferenceTreeBrowse/ReferenceTableMain.js
+++ b/frontend/lit/ReferenceTreeBrowse/ReferenceTableMain.js
@@ -11,7 +11,7 @@ import Wordcloud from "./Wordcloud";
 class ReferenceTableMain extends Component {
     render() {
         const {store} = this.props,
-            {selectedReferences, filteredReferences} = store,
+            {selectedReferences, filteredReferences, paginatedReferences, page, fetchPage} = store,
             {canEdit} = store.config;
         if (!selectedReferences) {
             return null;
@@ -25,7 +25,7 @@ class ReferenceTableMain extends Component {
                     <Tab>Insights</Tab>
                 </TabList>
                 <TabPanel>
-                    <ReferenceTable references={filteredReferences} showActions={canEdit} />
+                    <ReferenceTable references={paginatedReferences} showActions={canEdit} page={page} fetchPage={fetchPage} />
                 </TabPanel>
                 <TabPanel>
                     <h4>Title wordcloud</h4>

--- a/frontend/lit/ReferenceTreeBrowse/ReferenceTableMain.js
+++ b/frontend/lit/ReferenceTreeBrowse/ReferenceTableMain.js
@@ -25,7 +25,12 @@ class ReferenceTableMain extends Component {
                     <Tab>Insights</Tab>
                 </TabList>
                 <TabPanel>
-                    <ReferenceTable references={paginatedReferences} showActions={canEdit} page={page} fetchPage={fetchPage} />
+                    <ReferenceTable
+                        references={paginatedReferences}
+                        showActions={canEdit}
+                        page={page}
+                        fetchPage={fetchPage}
+                    />
                 </TabPanel>
                 <TabPanel>
                     <h4>Title wordcloud</h4>

--- a/frontend/lit/ReferenceTreeBrowse/store.js
+++ b/frontend/lit/ReferenceTreeBrowse/store.js
@@ -15,7 +15,7 @@ class Store {
         autorun(() => (this.current_page = this.filteredReferences ? 1 : null));
     }
 
-    pagination = 25;
+    pagination = 50;
 
     @observable untaggedReferencesSelected = false;
     @observable selectedTag = null;

--- a/frontend/lit/ReferenceTreeBrowse/store.js
+++ b/frontend/lit/ReferenceTreeBrowse/store.js
@@ -1,4 +1,4 @@
-import {action, autorun, computed, observable, toJS} from "mobx";
+import {action, computed, observable} from "mobx";
 import h from "shared/utils/helpers";
 
 import $ from "$";
@@ -12,10 +12,9 @@ class Store {
         this.config = config;
         this.tagtree = new TagTree(config.tags[0], config.assessment_id, config.search_id);
         this.tagtree.add_references(config.references);
-        autorun(() => (this.current_page = this.filteredReferences ? 1 : null));
     }
 
-    pagination = 50;
+    paginate_by = 50;
 
     @observable untaggedReferencesSelected = false;
     @observable selectedTag = null;
@@ -23,16 +22,15 @@ class Store {
     @observable tagtree = null;
     @observable selectedReferences = null;
     @observable selectedReferencesLoading = false;
-    @observable current_page = null;
+    @observable current_page = 1;
 
     @computed get page() {
-        if (!this.current_page) {
+        if (!this.selectedReferences) {
             return null;
         }
 
-        let refs = toJS(this.filteredReferences),
-            {current_page} = this,
-            total_pages = Math.ceil(refs.length / this.pagination);
+        let {current_page, filteredReferences} = this,
+            total_pages = Math.ceil(filteredReferences.length / this.paginate_by);
 
         return {
             current_page,
@@ -47,14 +45,13 @@ class Store {
     }
 
     @computed get paginatedReferences() {
-        let refs = toJS(this.filteredReferences);
-
-        if (!this.current_page) {
-            return refs;
+        if (!this.selectedReferences) {
+            return null;
         }
 
-        let start = (this.current_page - 1) * this.pagination,
-            end = this.current_page * this.pagination;
+        let refs = this.filteredReferences,
+            start = (this.current_page - 1) * this.paginate_by,
+            end = this.current_page * this.paginate_by;
 
         return refs.slice(start, end);
     }

--- a/frontend/lit/ReferenceTreeBrowse/store.js
+++ b/frontend/lit/ReferenceTreeBrowse/store.js
@@ -12,10 +12,10 @@ class Store {
         this.config = config;
         this.tagtree = new TagTree(config.tags[0], config.assessment_id, config.search_id);
         this.tagtree.add_references(config.references);
-        autorun(() => {this.current_page = this.filteredReferences ? 1: null; console.log("please work")});
+        autorun(() => (this.current_page = this.filteredReferences ? 1 : null));
     }
 
-    pagination = 25
+    pagination = 25;
 
     @observable untaggedReferencesSelected = false;
     @observable selectedTag = null;
@@ -23,10 +23,9 @@ class Store {
     @observable tagtree = null;
     @observable selectedReferences = null;
     @observable selectedReferencesLoading = false;
-    @observable current_page = null
+    @observable current_page = null;
 
     @computed get page() {
-        console.log("Computed page!")
         if (!this.current_page) {
             return null;
         }
@@ -36,11 +35,11 @@ class Store {
             total_pages = Math.ceil(refs.length / this.pagination);
 
         return {
-            current_page: current_page,
-            total_pages: total_pages,
+            current_page,
+            total_pages,
             next: current_page < total_pages ? current_page + 1 : null,
             previous: current_page > 1 ? current_page - 1 : null,
-        }
+        };
     }
 
     @action.bound fetchPage(page) {
@@ -48,7 +47,6 @@ class Store {
     }
 
     @computed get paginatedReferences() {
-        console.log("Computed paginated references!")
         let refs = toJS(this.filteredReferences);
 
         if (!this.current_page) {

--- a/frontend/lit/ReferenceTreeBrowse/store.js
+++ b/frontend/lit/ReferenceTreeBrowse/store.js
@@ -1,4 +1,4 @@
-import {action, computed, observable} from "mobx";
+import {action, autorun, computed, observable} from "mobx";
 import h from "shared/utils/helpers";
 
 import $ from "$";
@@ -12,6 +12,9 @@ class Store {
         this.config = config;
         this.tagtree = new TagTree(config.tags[0], config.assessment_id, config.search_id);
         this.tagtree.add_references(config.references);
+        // pagination should be reset when the filters change
+        // to ensure that the current page is not out of bounds
+        autorun(() => (this.currentPage = this.filteredReferences ? 1 : null));
     }
 
     paginateBy = 50;
@@ -22,7 +25,7 @@ class Store {
     @observable tagtree = null;
     @observable selectedReferences = null;
     @observable selectedReferencesLoading = false;
-    @observable currentPage = 1;
+    @observable currentPage = null;
 
     @computed get page() {
         if (!this.selectedReferences) {

--- a/frontend/lit/ReferenceTreeBrowse/store.js
+++ b/frontend/lit/ReferenceTreeBrowse/store.js
@@ -14,7 +14,7 @@ class Store {
         this.tagtree.add_references(config.references);
     }
 
-    paginate_by = 50;
+    paginateBy = 50;
 
     @observable untaggedReferencesSelected = false;
     @observable selectedTag = null;
@@ -22,26 +22,26 @@ class Store {
     @observable tagtree = null;
     @observable selectedReferences = null;
     @observable selectedReferencesLoading = false;
-    @observable current_page = 1;
+    @observable currentPage = 1;
 
     @computed get page() {
         if (!this.selectedReferences) {
             return null;
         }
 
-        let {current_page, filteredReferences} = this,
-            total_pages = Math.ceil(filteredReferences.length / this.paginate_by);
+        let {currentPage, filteredReferences} = this,
+            totalPages = Math.ceil(filteredReferences.length / this.paginateBy);
 
         return {
-            current_page,
-            total_pages,
-            next: current_page < total_pages ? current_page + 1 : null,
-            previous: current_page > 1 ? current_page - 1 : null,
+            currentPage,
+            totalPages,
+            next: currentPage < totalPages ? currentPage + 1 : null,
+            previous: currentPage > 1 ? currentPage - 1 : null,
         };
     }
 
     @action.bound fetchPage(page) {
-        this.current_page = page;
+        this.currentPage = page;
     }
 
     @computed get paginatedReferences() {
@@ -50,8 +50,8 @@ class Store {
         }
 
         let refs = this.filteredReferences,
-            start = (this.current_page - 1) * this.paginate_by,
-            end = this.current_page * this.paginate_by;
+            start = (this.currentPage - 1) * this.paginateBy,
+            end = this.currentPage * this.paginateBy;
 
         return refs.slice(start, end);
     }

--- a/frontend/lit/TagTreeViz.js
+++ b/frontend/lit/TagTreeViz.js
@@ -189,7 +189,8 @@ class TagTreeViz extends D3Plot {
                 toggle(d);
             },
             fetch_references = function(tag) {
-                var title = `<h4>${tag.data.name}</h4>`,
+                const url = `/lit/assessment/${tag.assessment_id}/references/?tag_id=${tag.data.pk}`,
+                    title = `<h3>References tagged: <a class="refTag mb-0" href="${url}">${tag.data.name}</a></h3>`,
                     div = $("<div>");
 
                 self.modal

--- a/frontend/lit/components/ReferenceTable.js
+++ b/frontend/lit/components/ReferenceTable.js
@@ -1,11 +1,12 @@
 import PropTypes from "prop-types";
 import React, {Component} from "react";
+import Paginator from "shared/components/Paginator";
 
 import Reference from "./Reference";
 
 class ReferenceTable extends Component {
     render() {
-        const {references} = this.props,
+        const {references, page, fetchPage} = this.props,
             args = {showActions: this.props.showActions, showHr: true};
 
         if (references.length === 0) {
@@ -13,17 +14,22 @@ class ReferenceTable extends Component {
         }
 
         return (
-            <div>
-                {references.map((reference, i) => (
-                    <Reference key={i} reference={reference} {...args} />
-                ))}
-            </div>
+            <>
+                <div>
+                    {references.map((reference, i) => (
+                        <Reference key={i} reference={reference} {...args} />
+                    ))}
+                </div>
+                {page ? <Paginator page={page} onChangePage={fetchPage} /> : null}
+            </>
         );
     }
 }
 ReferenceTable.propTypes = {
     references: PropTypes.array.isRequired,
     showActions: PropTypes.bool.isRequired,
+    page: PropTypes.object,
+    fetchPage: PropTypes.func,
 };
 
 export default ReferenceTable;

--- a/frontend/shared/components/Paginator.js
+++ b/frontend/shared/components/Paginator.js
@@ -40,8 +40,8 @@ Paginator.propTypes = {
     page: PropTypes.shape({
         current_page: PropTypes.number.isRequired,
         total_pages: PropTypes.number.isRequired,
-        next: PropTypes.any,
-        previous: PropTypes.any,
+        next: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+        previous: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     }),
     onChangePage: PropTypes.func.isRequired,
 };

--- a/frontend/shared/components/Paginator.js
+++ b/frontend/shared/components/Paginator.js
@@ -40,8 +40,8 @@ Paginator.propTypes = {
     page: PropTypes.shape({
         current_page: PropTypes.number.isRequired,
         total_pages: PropTypes.number.isRequired,
-        next: PropTypes.string,
-        previous: PropTypes.string,
+        next: PropTypes.any,
+        previous: PropTypes.any,
     }),
     onChangePage: PropTypes.func.isRequired,
 };

--- a/frontend/shared/components/Paginator.js
+++ b/frontend/shared/components/Paginator.js
@@ -5,7 +5,7 @@ import React from "react";
 const Paginator = props => {
     const {onChangePage, page} = props;
 
-    if (page.total_pages === 1) {
+    if (page.totalPages === 1) {
         return null;
     }
 
@@ -22,7 +22,7 @@ const Paginator = props => {
             ) : null}
             <li className="page-item disabled">
                 <span className="page-link">
-                    {page.current_page} of {page.total_pages}
+                    {page.currentPage} of {page.totalPages}
                 </span>
             </li>
             {page.next ? (
@@ -38,8 +38,8 @@ const Paginator = props => {
 
 Paginator.propTypes = {
     page: PropTypes.shape({
-        current_page: PropTypes.number.isRequired,
-        total_pages: PropTypes.number.isRequired,
+        currentPage: PropTypes.number.isRequired,
+        totalPages: PropTypes.number.isRequired,
         next: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
         previous: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     }),

--- a/hawc/apps/common/api/pagination.py
+++ b/hawc/apps/common/api/pagination.py
@@ -8,6 +8,6 @@ class DisabledPagination(PageNumberPagination):
 class PaginationWithCount(PageNumberPagination):
     def get_paginated_response(self, data):
         response = super().get_paginated_response(data)
-        response.data["current_page"] = self.page.number
-        response.data["total_pages"] = self.page.paginator.num_pages
+        response.data["currentPage"] = self.page.number
+        response.data["totalPages"] = self.page.paginator.num_pages
         return response


### PR DESCRIPTION
The references list view used to render all references for a given tag. However, if there were hundreds or thousands of references for a given tag, it became slow to load and hard to navigate for a user.

This pull request adds pagination to this view. Counts in the tag tree and histogram remain the same, however only 25 references are loaded at a time, and the select box on the left only contains the references on the page.

A more intrusive solution that could speed it up further would be to make an API call that returns a paginated response. However, both the tag tree and year histogram rely on the full list, and the tag tree and histogram are used in other places besides this view so it would be a much bigger change. A future PR could involve making API endpoints that retrieve counts for the tag tree and counts for the year histogram, and then using a paginated API call for the reference list.