### PR TITLE
disable deletion of some models in admin

### DIFF
--- a/hawc/apps/myuser/admin.py
+++ b/hawc/apps/myuser/admin.py
@@ -43,7 +43,9 @@ class HAWCUserAdmin(admin.ModelAdmin):
     ordering = ("-date_joined",)
     form = forms.AdminUserForm
     inlines = [UserProfileAdmin]
-    can_delete = False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
 
     @admin.action(description="Send welcome email")
     def send_welcome_emails(modeladmin, request, queryset):

--- a/hawc/apps/udf/admin.py
+++ b/hawc/apps/udf/admin.py
@@ -3,21 +3,43 @@ from django.contrib import admin
 from . import models
 
 
-class UserDefinedFormInline(admin.TabularInline):
-    model = models.UserDefinedForm
-    extra = 0
+@admin.register(models.UserDefinedForm)
+class UserDefinedFormInline(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "name",
+        "creator",
+        "last_updated",
+    )
+    list_filter = (
+        "deprecated",
+        "created",
+    )
+
+    def has_delete_permission(self, request, obj=None):
+        return False
 
 
-class ModelBindingInline(admin.TabularInline):
-    model = models.ModelBinding
-    extra = 0
+@admin.register(models.ModelBinding)
+class ModelBindingInline(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "assessment_id",
+        "content_type",
+        "creator",
+        "last_updated",
+    )
+    list_filter = ("created",)
 
 
-class TagBindingInline(admin.TabularInline):
-    model = models.TagBinding
-    extra = 0
-
-
-admin.site.register(models.UserDefinedForm)
-admin.site.register(models.ModelBinding)
-admin.site.register(models.TagBinding)
+@admin.register(models.TagBinding)
+class TagBindingInline(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "assessment_id",
+        "tag_id",
+        "creator",
+        "last_updated",
+    )
+    list_filter = ("created",)
+    raw_id_fields = ("tag",)

--- a/hawc/apps/vocab/admin.py
+++ b/hawc/apps/vocab/admin.py
@@ -38,6 +38,9 @@ class TermAdmin(admin.ModelAdmin):
     def get_entities(self, obj):
         return ul_items(obj.entities.all(), lambda el: f"<a href={el.get_external_url()}>{el}</a>")
 
+    def has_delete_permission(self, request, obj=None):
+        return False
+
 
 class EntityTermRelationAdmin(admin.TabularInline):
     model = models.EntityTermRelation


### PR DESCRIPTION
Prevent deletion of three models in the admin, which instead have an active flag in the case of users, or deprecation flag in case of UDF Forms and Terms.

Also, updated the admins for UDF forms to inherit form the correct class, along with some basic information on the list view form.