### PR TITLE
hotfix - fix generational animal group form

### DIFF
--- a/hawc/apps/animal/forms.py
+++ b/hawc/apps/animal/forms.py
@@ -253,7 +253,7 @@ class GenerationalAnimalGroupForm(AnimalGroupForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["generation"].choices = self.fields["generation"].choices[1:]
+        self.fields["generation"].choices = constants.Generation.choices[1:]
         self.fields["parents"].queryset = models.AnimalGroup.objects.filter(
             experiment=self.instance.experiment
         )


### PR DESCRIPTION
Fix change in how Django 5 handles choice fields so that the choices are sliced directly instead of the form model field choices, which no longer seems to work. I did a quick keyword search in the codebase and didn't see any other cases where this may have been an issue.

Also wrote a test to test the behavior on the views, and raised code coverage for the forms and views:

![image](https://github.com/shapiromatron/hawc/assets/999952/ecfccb4f-4a9d-4755-ae11-b98d1fe6cb9b)
