### PR TITLE
bugfix- restrict EHV tag API to accept only integer for detail ID

### DIFF
--- a/hawc/apps/vocab/api.py
+++ b/hawc/apps/vocab/api.py
@@ -6,7 +6,7 @@ from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from ..common.helper import FlatExport, tryParseInt
+from ..common.helper import FlatExport, re_digits, tryParseInt
 from ..common.renderers import PandasRenderers
 from . import constants, models, serializers
 
@@ -14,6 +14,7 @@ from . import constants, models, serializers
 class EhvTermViewSet(viewsets.GenericViewSet):
     serializer_class = serializers.SimpleTermSerializer
     permission_classes = [IsAuthenticated]
+    lookup_value_regex = re_digits
 
     def get_queryset(self) -> QuerySet:
         return models.Term.objects.filter(


### PR DESCRIPTION
Restrict the EHV API to only accept an integer as an ID for the EHV API views. Previously any slug was allowed; this tightens up the API and improves error messaging.