### PR TITLE
Add summary.Visual image options

### DIFF
--- a/hawc/apps/common/dynamic_forms/__init__.py
+++ b/hawc/apps/common/dynamic_forms/__init__.py
@@ -1,5 +1,4 @@
-from ..forms import DynamicFormField
 from .forms import DynamicForm
 from .schemas import Schema
 
-__all__ = ["DynamicForm", "DynamicFormField", "Schema"]
+__all__ = ["DynamicForm", "Schema"]

--- a/hawc/apps/summary/forms.py
+++ b/hawc/apps/summary/forms.py
@@ -17,6 +17,7 @@ from ..assessment.models import DoseUnits
 from ..common import validators
 from ..common.autocomplete import AutocompleteChoiceField
 from ..common.clean import sanitize_html
+from ..common.dynamic_forms import Schema
 from ..common.forms import (
     BaseFormHelper,
     CopyForm,
@@ -593,9 +594,34 @@ class PlotlyVisualForm(VisualForm):
 
 
 class ImageVisualForm(VisualForm):
+    settings_schema = {
+        "fields": [
+            {
+                "name": "alt_text",
+                "type": "char",
+                "label": "Image alt-text",
+                "help_text": "Alternative text if an image fails to display and for accessibility support.",
+                "widget": "textarea",
+                "css_class": "col-4",
+            },
+            {
+                "name": "max_width",
+                "type": "integer",
+                "label": "Image maximum width",
+                "help_text": "Max width of the image (in pixels). The image will always shrink to be visible in your browser, but if unset, image will grow to be the full size of your browser, which can be huge for high resolution uploads.",
+                "initial": 1000,
+                "css_class": "col-4",
+                "required": False,
+            },
+        ]
+    }
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["image"].required = True
+        self.fields["settings"] = DynamicFormField(
+            "settings", Schema.model_validate(self.settings_schema).to_form, label=""
+        )
         self.helper = self.setHelper()
 
     def clean_image(self):
@@ -611,7 +637,7 @@ class ImageVisualForm(VisualForm):
 
     class Meta:
         model = models.Visual
-        fields = ("title", "slug", "image", "caption", "published")
+        fields = ("title", "slug", "image", "settings", "caption", "published")
         widgets = {"image": forms.FileInput}
 
 

--- a/hawc/apps/summary/templates/summary/visual_detail_image.html
+++ b/hawc/apps/summary/templates/summary/visual_detail_image.html
@@ -19,7 +19,11 @@
       {% endif %}
     </div>
     <div id="visual-image">
-      <img src="{{object.image.url}}" style="max-width: 100%" />
+      <img src="{{object.image.url}}"
+        alt="{{object.settings.alt_text}}"
+        class="img-fluid"
+        {% if object.settings.max_width %}style="width: {{object.settings.max_width}}px"{% endif %}
+      />
     </div>
     <p>{{object.caption|safe}}</p>
   </div>

--- a/hawc/apps/summary/templates/summary/visual_detail_image.html
+++ b/hawc/apps/summary/templates/summary/visual_detail_image.html
@@ -20,9 +20,9 @@
     </div>
     <div id="visual-image">
       <img src="{{object.image.url}}"
-        alt="{{object.settings.alt_text}}"
-        class="img-fluid"
-        {% if object.settings.max_width %}style="width: {{object.settings.max_width}}px"{% endif %}
+           alt="{{object.settings.alt_text}}"
+           class="img-fluid"
+           {% if object.settings.max_width %}style="width: {{object.settings.max_width}}px"{% endif %}
       />
     </div>
     <p>{{object.caption|safe}}</p>

--- a/tests/data/fixtures/db.yaml
+++ b/tests/data/fixtures/db.yaml
@@ -10301,8 +10301,10 @@
     evidence_type: 3
     dose_units: null
     prefilters: {}
-    settings: {}
-    caption: ''
+    settings:
+      alt_text: Hello alt text
+      max_width: 600
+    caption: Hello caption.
     image: "summary/visual/images/iris.png"
     published: true
     sort_order: short_citation

--- a/tests/hawc/apps/summary/test_forms.py
+++ b/tests/hawc/apps/summary/test_forms.py
@@ -224,6 +224,7 @@ class TestImageVisualForm:
         visual_type = VisualType.IMAGE
         file = SimpleUploadedFile("file.png", create_image((2000, 2000)), content_type="image/png")
         data = dict(title="title", slug="slug", caption="hi")
+        data.update({"settings-alt_text": "hi"})
         form = ImageVisualForm(
             data=data, files={"image": file}, parent=assessment, visual_type=visual_type
         )


### PR DESCRIPTION
Add image options to summary visuals, after noticing some high resolution pixels scale and look way too big for a screen.

Added two new options when configuring a summary image:

* alt-text (required): text required to display on image for accessibility purposes
* max_width (optional; default 1000px) - if specified, the maximum width of an image. If unspecified, it will grow to 100% of the image width in pixels. The image now auto-shrinks on mobile views too.


Example; max width of 600px:
![image](https://github.com/shapiromatron/hawc/assets/999952/c6483742-f4a7-49d8-9c4f-a27e0460ca40)

And a mobile view of 400px wide:
![image](https://github.com/shapiromatron/hawc/assets/999952/f31849e7-a059-4e4c-90e2-4008cde3cf95)
