### PR TITLE
bugfixes from 2024.Q1 release

### DIFF
--- a/frontend/summary/dataPivot/DataPivotVisualization.js
+++ b/frontend/summary/dataPivot/DataPivotVisualization.js
@@ -223,7 +223,7 @@ class DataPivotVisualization extends D3Plot {
                 });
             return row;
         };
-        return _.cloneDeep(dataset).map(d => parseRow(d));
+        return _.cloneDeep(dataset).map((d, i) => parseRow(d, i));
     }
 
     set_defaults() {

--- a/hawc/apps/assessment/constants.py
+++ b/hawc/apps/assessment/constants.py
@@ -24,11 +24,9 @@ class PublishedStatus(models.TextChoices):
 
 
 class AssessmentViewPermissions(models.IntegerChoices):
-    PROJECT_MANAGER = 1  # project manager or higher
-    TEAM_MEMBER = 2  # team member or higher
+    PROJECT_MANAGER = 1
+    TEAM_MEMBER = 2
     VIEWER = 3
-    TEAM_MEMBER_EDITABLE = 4  # team member or higher and content must be editable
-    PROJECT_MANAGER_EDITABLE = 5  # team member or higher and content must be editable
 
 
 class AssessmentViewSetPermissions(models.IntegerChoices):

--- a/hawc/apps/assessment/constants.py
+++ b/hawc/apps/assessment/constants.py
@@ -24,9 +24,11 @@ class PublishedStatus(models.TextChoices):
 
 
 class AssessmentViewPermissions(models.IntegerChoices):
-    PROJECT_MANAGER = 1
-    TEAM_MEMBER = 2
+    PROJECT_MANAGER = 1  # project manager or higher
+    TEAM_MEMBER = 2  # team member or higher
     VIEWER = 3
+    TEAM_MEMBER_EDITABLE = 4  # team member or higher and content must be editable
+    PROJECT_MANAGER_EDITABLE = 5  # team member or higher and content must be editable
 
 
 class AssessmentViewSetPermissions(models.IntegerChoices):

--- a/hawc/apps/lit/views.py
+++ b/hawc/apps/lit/views.py
@@ -793,7 +793,7 @@ class RefFilterList(BaseFilterList):
             super()
             .get_queryset()
             .select_related("study")
-            .prefetch_related("searches", "identifiers", "tags")
+            .prefetch_related("searches", "identifiers", "tags", "saved_tag_contents")
         )
 
     def get_context_data(self, **kwargs):

--- a/hawc/apps/study/forms.py
+++ b/hawc/apps/study/forms.py
@@ -46,6 +46,7 @@ class BaseStudyForm(UDFModelFormMixin, forms.ModelForm):
         if type(parent) is Assessment:
             self.instance.assessment = parent
         elif type(parent) is Reference:
+            self.instance.assessment = parent.assessment
             self.instance.reference_ptr = parent
 
         if self.instance:

--- a/hawc/apps/summary/forms.py
+++ b/hawc/apps/summary/forms.py
@@ -720,14 +720,18 @@ class DataPivotUploadForm(DataPivotForm):
         worksheet_name = cleaned_data.get("worksheet_name", "")
 
         if excel_file:
+            cannot_read = "Unable to read Excel file. Please upload an Excel file in XLSX format."
+
+            # ensure it has correct extension
+            if not excel_file.name.endswith(".xlsx"):
+                self.add_error("excel_file", cannot_read)
+                return
+
             # see if it loads
             try:
                 wb = load_workbook(excel_file, read_only=True)
             except (BadZipFile, InvalidFileException):
-                self.add_error(
-                    "excel_file",
-                    "Unable to read Excel file. Please upload an Excel file in XLSX format.",
-                )
+                self.add_error("excel_file", cannot_read)
                 return
 
             # check worksheet name

--- a/tests/hawc/apps/study/test_views.py
+++ b/tests/hawc/apps/study/test_views.py
@@ -166,6 +166,7 @@ def test_get_200():
         reverse("study:list", args=(main,)),
         reverse("study:detail", args=(main,)),
         reverse("study:delete", args=(main,)),
+        reverse("study:new_study", args=(3,)),
     ]
     for url in urls:
         check_200(client, url)

--- a/tests/hawc/apps/summary/test_forms.py
+++ b/tests/hawc/apps/summary/test_forms.py
@@ -270,6 +270,10 @@ class TestDataPivotUploadForm:
                 {"excel_file": SimpleUploadedFile("test.xlsx", b"a,b,c\n1,2,3\n")},
                 "Unable to read Excel file. Please upload an Excel file in XLSX format.",
             ),
+            (
+                {"excel_file": SimpleUploadedFile("test.csv", b"a,b,c\n1,2,3\n")},
+                "Unable to read Excel file. Please upload an Excel file in XLSX format.",
+            ),
         ]
         for files, error_msg in bad_files:
             form = DataPivotUploadForm(


### PR DESCRIPTION
Fix assorted errors encountered by users with our 2024.Q1 release. 

1. Fix regression in data pivot visualizations, where OR filters accidentally filtered all content out except one row (we had a Map, but the key for all items was undefined so there was only one item in the map); regression in #991 
2. Fix an N+1 query error on the reference search page; regression in #913
3. Fix an error when converting a literature reference to a study, introduced by the UDF form integration; regression in #906 
4. Add an additional check for data pivot file uploads to check the extension