### PR TITLE
new permission classes

### DIFF
--- a/docs/docs/development.md
+++ b/docs/docs/development.md
@@ -251,6 +251,16 @@ This makes the test database useful when writing new features. There are multipl
  **Team member**     | team@hawcproject.org     | pw
  **Reviewer**        | reviewer@hawcproject.org | pw
 
+
+There are currently four assessments in the database:
+
+ID | Name | Editable | Public
+---|---|---|---
+1 | Chemical Z | Yes | No
+2 | Chemical X | No | Yes
+3 | Chemical Y | Yes | Yes
+4 | Chemical A | Yes | No
+
 As new features are added, adding and changing content in the test database will be required to test these features. Instructions for loading and dumping are described below.
 
 #### Generating the test database

--- a/hawc/apps/assessment/constants.py
+++ b/hawc/apps/assessment/constants.py
@@ -25,10 +25,10 @@ class PublishedStatus(models.TextChoices):
 
 class AssessmentViewPermissions(models.IntegerChoices):
     PROJECT_MANAGER = 1  # project manager or higher
-    TEAM_MEMBER = 2  # team member or higher
-    VIEWER = 3
-    TEAM_MEMBER_EDITABLE = 4  # team member or higher and content must be editable
-    PROJECT_MANAGER_EDITABLE = 5  # team member or higher and content must be editable
+    PROJECT_MANAGER_EDITABLE = 2  # project manager or higher + content must be editable
+    TEAM_MEMBER = 3  # team member or higher
+    TEAM_MEMBER_EDITABLE = 4  # team member or higher + content must be editable
+    VIEWER = 5
 
 
 class AssessmentViewSetPermissions(models.IntegerChoices):

--- a/hawc/apps/assessment/constants.py
+++ b/hawc/apps/assessment/constants.py
@@ -24,9 +24,11 @@ class PublishedStatus(models.TextChoices):
 
 
 class AssessmentViewPermissions(models.IntegerChoices):
-    PROJECT_MANAGER = 1
-    TEAM_MEMBER = 2
+    PROJECT_MANAGER = 1  # project manager or higher
+    TEAM_MEMBER = 2  # team member or higher
     VIEWER = 3
+    TEAM_MEMBER_EDITABLE = 4  # team member or higher and content must be editable
+    PROJECT_MANAGER_EDITABLE = 5  # team member or higher and content must be editable
 
 
 class AssessmentViewSetPermissions(models.IntegerChoices):

--- a/hawc/apps/assessment/models.py
+++ b/hawc/apps/assessment/models.py
@@ -341,11 +341,13 @@ class Assessment(models.Model):
         return perms.to_dict(user)
 
     def user_can_view_object(self, user, perms: AssessmentPermissions | None = None) -> bool:
+        # reviewer or higher OR assessment is public
         if perms is None:
             perms = self.get_permissions()
         return perms.can_view_object(user)
 
     def user_can_edit_object(self, user, perms: AssessmentPermissions | None = None) -> bool:
+        # team member or higher AND assessment is editable
         if perms is None:
             perms = self.get_permissions()
         return perms.can_edit_object(user)

--- a/hawc/apps/assessment/permissions.py
+++ b/hawc/apps/assessment/permissions.py
@@ -1,11 +1,13 @@
-from typing import TYPE_CHECKING, Self
+from __future__ import annotations
+
+import typing
 
 from django.core.cache import cache
 from pydantic import BaseModel
 
 from ..common.helper import cacheable
 
-if TYPE_CHECKING:
+if typing.TYPE_CHECKING:
     from ..myuser.models import HAWCUser
     from ..study.models import Study
 
@@ -27,10 +29,10 @@ class AssessmentPermissions(BaseModel):
         cache.delete(key)
 
     @classmethod
-    def get(cls, assessment) -> Self:
+    def get(cls, assessment) -> typing.Self:
         key = cls.get_cache_key(assessment.id)
 
-        def get_perms() -> Self:
+        def get_perms() -> typing.Self:
             return cls(
                 public=(assessment.public_on is not None),
                 editable=assessment.editable,

--- a/hawc/apps/assessment/templates/assessment/assessment_detail.html
+++ b/hawc/apps/assessment/templates/assessment/assessment_detail.html
@@ -136,7 +136,7 @@
     </tbody>
   </table>
 
-  {% if obj_perms.edit %}
+  {% if is_team_member %}
     <h3>Assessment details for team members*</h3>
     <table id="assessment_table" class="table table-sm table-striped">
       {% bs4_colgroup '25,25,25,25' %}

--- a/hawc/apps/assessment/views.py
+++ b/hawc/apps/assessment/views.py
@@ -327,7 +327,7 @@ class AssessmentDelete(BaseDelete):
     model = models.Assessment
     success_url = reverse_lazy("portal")
     success_message = "Assessment deleted."
-    assessment_permission = constants.AssessmentViewPermissions.PROJECT_MANAGER_EDITABLE
+    assessment_permission = constants.AssessmentViewPermissions.PROJECT_MANAGER
 
 
 class AssessmentClearCache(MessageMixin, View):

--- a/hawc/apps/assessment/views.py
+++ b/hawc/apps/assessment/views.py
@@ -312,21 +312,21 @@ class AssessmentUpdate(BaseUpdate):
     success_message = "Assessment updated."
     model = models.Assessment
     form_class = forms.AssessmentForm
-    assessment_permission = constants.AssessmentViewPermissions.PROJECT_MANAGER
+    assessment_permission = constants.AssessmentViewPermissions.PROJECT_MANAGER_EDITABLE
 
 
 class AssessmentModulesUpdate(AssessmentUpdate):
     success_message = "Assessment modules updated."
     form_class = forms.AssessmentModulesForm
     template_name = "assessment/assessment_module_form.html"
-    assessment_permission = constants.AssessmentViewPermissions.PROJECT_MANAGER
+    assessment_permission = constants.AssessmentViewPermissions.PROJECT_MANAGER_EDITABLE
 
 
 class AssessmentDelete(BaseDelete):
     model = models.Assessment
     success_url = reverse_lazy("portal")
     success_message = "Assessment deleted."
-    assessment_permission = constants.AssessmentViewPermissions.PROJECT_MANAGER
+    assessment_permission = constants.AssessmentViewPermissions.PROJECT_MANAGER_EDITABLE
 
 
 class AssessmentClearCache(MessageMixin, View):
@@ -604,7 +604,7 @@ class CleanExtractedData(BaseEndpointList):
 
     breadcrumb_active_name = "Clean extracted data"
     template_name = "assessment/clean_extracted_data.html"
-    assessment_permission = constants.AssessmentViewPermissions.TEAM_MEMBER
+    assessment_permission = constants.AssessmentViewPermissions.TEAM_MEMBER_EDITABLE
 
     def get_app_config(self, context) -> WebappConfig:
         return WebappConfig(
@@ -652,7 +652,7 @@ class CleanStudyRoB(BaseDetail):
     template_name = "assessment/clean_study_rob_scores.html"
     model = models.Assessment
     breadcrumb_active_name = "Clean reviews"
-    assessment_permission = constants.AssessmentViewPermissions.PROJECT_MANAGER
+    assessment_permission = constants.AssessmentViewPermissions.PROJECT_MANAGER_EDITABLE
 
     def get_app_config(self, context) -> WebappConfig:
         return WebappConfig(

--- a/hawc/apps/assessment/views.py
+++ b/hawc/apps/assessment/views.py
@@ -313,7 +313,7 @@ class AssessmentUpdate(BaseUpdate):
     success_message = "Assessment updated."
     model = models.Assessment
     form_class = forms.AssessmentForm
-    assessment_permission = constants.AssessmentViewPermissions.PROJECT_MANAGER_EDITABLE
+    assessment_permission = constants.AssessmentViewPermissions.PROJECT_MANAGER
 
 
 class AssessmentModulesUpdate(AssessmentUpdate):

--- a/hawc/apps/assessment/views.py
+++ b/hawc/apps/assessment/views.py
@@ -305,6 +305,7 @@ class AssessmentDetail(BaseDetail):
         )
         context["values"] = self.object.values.order_by("value_type")
         context["adaf_footnote"] = constants.ADAF_FOOTNOTE
+        context["is_team_member"] = self.object.user_is_team_member_or_higher(self.request.user)
         return context
 
 

--- a/hawc/apps/bmd/views.py
+++ b/hawc/apps/bmd/views.py
@@ -26,7 +26,7 @@ class AssessSettingsUpdate(BaseUpdate):
     success_message = "BMD Settings updated."
     model = models.AssessmentSettings
     form_class = forms.AssessmentSettingsForm
-    assessment_permission = AssessmentViewPermissions.PROJECT_MANAGER
+    assessment_permission = AssessmentViewPermissions.PROJECT_MANAGER_EDITABLE
 
     def get_object(self, **kwargs):
         # get the bmd settings of the specified assessment
@@ -90,7 +90,7 @@ class SessionUpdate(BaseDetail):
     success_message = "BMD session updated."
     model = models.Session
     get_app_config = partialmethod(_get_session_config, is_editing=True)
-    assessment_permission = AssessmentViewPermissions.TEAM_MEMBER
+    assessment_permission = AssessmentViewPermissions.TEAM_MEMBER_EDITABLE
 
     def dispatch(self, request, *args, **kwargs):
         response = super().dispatch(request, *args, **kwargs)

--- a/hawc/apps/common/views.py
+++ b/hawc/apps/common/views.py
@@ -245,10 +245,10 @@ class AssessmentPermissionsMixin:
         user = self.request.user
         match self.assessment_permission:
             case AssessmentViewPermissions.PROJECT_MANAGER:
-                permission_checked = self.assessment.user_can_edit_assessment(user)
+                permission_checked = self.assessment.user_is_project_manager_or_higher(user)
             case AssessmentViewPermissions.PROJECT_MANAGER_EDITABLE:
                 self.deny_for_locked_assessment(self.assessment)
-                permission_checked = self.assessment.user_can_edit_assessment(user)
+                permission_checked = self.assessment.user_is_project_manager_or_higher(user)
             case AssessmentViewPermissions.TEAM_MEMBER:
                 permission_checked = self.assessment.user_can_edit_object(user)
             case AssessmentViewPermissions.TEAM_MEMBER_EDITABLE:
@@ -277,10 +277,10 @@ class AssessmentPermissionsMixin:
         user = self.request.user
         match self.assessment_permission:
             case AssessmentViewPermissions.PROJECT_MANAGER:
-                permission_checked = self.assessment.user_can_edit_assessment(user)
+                permission_checked = self.assessment.user_is_project_manager_or_higher(user)
             case AssessmentViewPermissions.PROJECT_MANAGER_EDITABLE:
                 self.deny_for_locked_assessment(self.assessment)
-                permission_checked = self.assessment.user_can_edit_assessment(user)
+                permission_checked = self.assessment.user_is_project_manager_or_higher(user)
             case AssessmentViewPermissions.TEAM_MEMBER:
                 permission_checked = self.assessment.user_can_edit_object(user)
             case AssessmentViewPermissions.TEAM_MEMBER_EDITABLE:

--- a/hawc/apps/common/views.py
+++ b/hawc/apps/common/views.py
@@ -281,7 +281,7 @@ class AssessmentPermissionsMixin:
             AssessmentViewPermissions.TEAM_MEMBER,
             AssessmentViewPermissions.TEAM_MEMBER_EDITABLE,
         ]:
-            if self.assessment_permission is AssessmentViewPermissions.PROJECT_MANAGER_EDITABLE:
+            if self.assessment_permission is AssessmentViewPermissions.TEAM_MEMBER_EDITABLE:
                 self.check_queryset_study_editability(queryset)
             permission_checked = self.assessment.user_can_edit_object(self.request.user)
         elif self.assessment_permission is AssessmentViewPermissions.VIEWER:

--- a/hawc/apps/common/views.py
+++ b/hawc/apps/common/views.py
@@ -250,7 +250,7 @@ class AssessmentPermissionsMixin:
                 self.deny_for_locked_assessment(self.assessment)
                 permission_checked = self.assessment.user_is_project_manager_or_higher(user)
             case AssessmentViewPermissions.TEAM_MEMBER:
-                permission_checked = self.assessment.user_can_edit_object(user)
+                permission_checked = self.assessment.user_is_team_member_or_higher(user)
             case AssessmentViewPermissions.TEAM_MEMBER_EDITABLE:
                 self.deny_for_locked_study(user, self.assessment, obj)
                 permission_checked = self.assessment.user_can_edit_object(user)
@@ -282,7 +282,7 @@ class AssessmentPermissionsMixin:
                 self.deny_for_locked_assessment(self.assessment)
                 permission_checked = self.assessment.user_is_project_manager_or_higher(user)
             case AssessmentViewPermissions.TEAM_MEMBER:
-                permission_checked = self.assessment.user_can_edit_object(user)
+                permission_checked = self.assessment.user_is_team_member_or_higher(user)
             case AssessmentViewPermissions.TEAM_MEMBER_EDITABLE:
                 self.check_queryset_study_editability(queryset)
                 permission_checked = self.assessment.user_can_edit_object(user)

--- a/hawc/apps/invitro/views.py
+++ b/hawc/apps/invitro/views.py
@@ -104,7 +104,7 @@ class CellTypeDelete(BaseDelete):
 class EndpointCategoryUpdate(BaseDetail):
     model = Assessment
     template_name = "invitro/ivendpointecategory_form.html"
-    assessment_permission = AssessmentViewPermissions.PROJECT_MANAGER
+    assessment_permission = AssessmentViewPermissions.PROJECT_MANAGER_EDITABLE
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/hawc/apps/lit/views.py
+++ b/hawc/apps/lit/views.py
@@ -251,7 +251,7 @@ class TagReferences(BaseFilterList):
     parent_model = Assessment
     model = models.Reference
     filterset_class = filterset.ReferenceFilterSet
-    assessment_permission = AssessmentViewPermissions.TEAM_MEMBER
+    assessment_permission = AssessmentViewPermissions.TEAM_MEMBER_EDITABLE
     paginate_by = 100
 
     def get_queryset(self):
@@ -514,7 +514,7 @@ class ConflictResolution(BaseFilterList):
     parent_model = Assessment
     model = models.Reference
     filterset_class = filterset.ReferenceFilterSet
-    assessment_permission = AssessmentViewPermissions.TEAM_MEMBER
+    assessment_permission = AssessmentViewPermissions.TEAM_MEMBER_EDITABLE
 
     def get_filterset_form_kwargs(self):
         return dict(
@@ -820,7 +820,7 @@ class RefUploadExcel(BaseUpdate):
     model = Assessment
     template_name = "lit/reference_upload_excel.html"
     form_class = forms.ReferenceExcelUploadForm
-    assessment_permission = AssessmentViewPermissions.PROJECT_MANAGER
+    assessment_permission = AssessmentViewPermissions.PROJECT_MANAGER_EDITABLE
     success_message = "Reference full text URLs updated."
 
     def get_form_kwargs(self):
@@ -850,7 +850,7 @@ class RefListExtract(BaseUpdate):
     model = Assessment
     form_class = forms.BulkReferenceStudyExtractForm
     success_message = "Selected references were successfully converted to studies."
-    assessment_permission = AssessmentViewPermissions.TEAM_MEMBER
+    assessment_permission = AssessmentViewPermissions.TEAM_MEMBER_EDITABLE
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
@@ -1005,7 +1005,7 @@ class TagsUpdate(BaseDetail):
 
     model = Assessment
     template_name = "lit/tags_update.html"
-    assessment_permission = AssessmentViewPermissions.PROJECT_MANAGER
+    assessment_permission = AssessmentViewPermissions.PROJECT_MANAGER_EDITABLE
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -1041,7 +1041,7 @@ class LiteratureAssessmentUpdate(BaseUpdate):
     success_message = "Literature assessment settings updated."
     model = models.LiteratureAssessment
     form_class = forms.LiteratureAssessmentForm
-    assessment_permission = AssessmentViewPermissions.PROJECT_MANAGER
+    assessment_permission = AssessmentViewPermissions.PROJECT_MANAGER_EDITABLE
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -1061,7 +1061,7 @@ class TagsCopy(BaseUpdate):
     template_name = "lit/tags_copy.html"
     form_class = forms.TagsCopyForm
     success_message = "Literature tags for this assessment have been updated"
-    assessment_permission = AssessmentViewPermissions.PROJECT_MANAGER
+    assessment_permission = AssessmentViewPermissions.PROJECT_MANAGER_EDITABLE
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -1087,7 +1087,7 @@ class TagsCopy(BaseUpdate):
 class BulkTagReferences(BaseDetail):
     model = Assessment
     template_name = "lit/bulk_tag_references.html"
-    assessment_permission = AssessmentViewPermissions.TEAM_MEMBER
+    assessment_permission = AssessmentViewPermissions.TEAM_MEMBER_EDITABLE
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/hawc/apps/riskofbias/views.py
+++ b/hawc/apps/riskofbias/views.py
@@ -89,7 +89,7 @@ class ARoBEdit(BaseDetail):
     crud = "Update"
     model = models.Assessment
     template_name = "riskofbias/arob_edit.html"
-    assessment_permission = AssessmentViewPermissions.PROJECT_MANAGER
+    assessment_permission = AssessmentViewPermissions.PROJECT_MANAGER_EDITABLE
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -118,7 +118,7 @@ class ARoBTextEdit(BaseUpdate):
     template_name = "riskofbias/arob_text_form.html"
     form_class = forms.RobTextForm
     success_message = "Help text has been updated."
-    assessment_permission = AssessmentViewPermissions.PROJECT_MANAGER
+    assessment_permission = AssessmentViewPermissions.PROJECT_MANAGER_EDITABLE
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -249,7 +249,7 @@ class RobAssignmentUpdate(BaseFilterList):
     template_name = "riskofbias/rob_assignment_update.html"
     filterset_class = StudyFilterSet
     paginate_by = 50
-    assessment_permission = AssessmentViewPermissions.PROJECT_MANAGER
+    assessment_permission = AssessmentViewPermissions.PROJECT_MANAGER_EDITABLE
 
     def get_queryset(self):
         if not self.assessment.user_can_edit_assessment(self.request.user):

--- a/hawc/apps/riskofbias/views.py
+++ b/hawc/apps/riskofbias/views.py
@@ -214,6 +214,7 @@ class RobAssignmentList(BaseFilterList):
     template_name = "riskofbias/rob_assignment_list.html"
     paginate_by = 50
     filterset_class = StudyFilterSet
+    assessment_permission = AssessmentViewPermissions.TEAM_MEMBER
 
     def get_queryset(self):
         if not self.assessment.user_can_edit_object(self.request.user):
@@ -284,6 +285,7 @@ class RobAssignmentUpdate(BaseFilterList):
 class RobNumberReviewsUpdate(BaseUpdate):
     model = models.RiskOfBiasAssessment
     form_class = forms.NumberOfReviewersForm
+    assessment_permission = AssessmentViewPermissions.PROJECT_MANAGER_EDITABLE
     success_message = "Number of reviewers updated."
     template_name = "riskofbias/reviewers_form.html"
 

--- a/hawc/apps/summary/views.py
+++ b/hawc/apps/summary/views.py
@@ -508,7 +508,7 @@ class VisualizationCopySelector(BaseDetail):
     model = Assessment
     template_name = "summary/visual_selector.html"
     breadcrumb_active_name = "Visualization selector"
-    assessment_permission = AssessmentViewPermissions.TEAM_MEMBER
+    assessment_permission = AssessmentViewPermissions.TEAM_MEMBER_EDITABLE
 
     def get_context_data(self, **kwargs):
         kwargs.update(

--- a/tests/integration/test_invitro.py
+++ b/tests/integration/test_invitro.py
@@ -11,7 +11,7 @@ class TestInvitro(PlaywrightTestCase):
         # /in-vitro/assessment/:id/endpoint-categories/update/
         self.login_and_goto_url(
             page,
-            f"{self.live_server_url}/in-vitro/assessment/2/endpoint-categories/update/",
+            f"{self.live_server_url}/in-vitro/assessment/1/endpoint-categories/update/",
             "pm@hawcproject.org",
         )
         expect(page.locator("text=Modify in-vitro endpoint categories")).to_be_visible()


### PR DESCRIPTION
Add new permission class options for views.  Previously, the project manager and team member classes always checked not only that the user is a project manager or team-member, respectively, but also that the content they're trying to view is editable. This is ideal for views that edit content, but is not ideal for read-only views where even if the content is not editable, the team should be able to view.

This work adds two new options, `TEAM_MEMBER_EDITABLE`, and `PROJECT_MANAGER_EDITABLE`.  These options work just as `TEAM_MEMBER` and `PROJECT_MANAGER` did before. The existing classes were updated to only check for role, and not for edibility status for object.

```py
class AssessmentViewPermissions(models.IntegerChoices):
    PROJECT_MANAGER = 1
    TEAM_MEMBER = 2
    VIEWER = 3
    PROJECT_MANAGER_EDITABLE = 4  # NEW
    TEAM_MEMBER_EDITABLE = 5  # NEW
```

Views were also updated to use the new permissions.