### PR TITLE
allow anonymous contact us w/ turnstile enabled

### DIFF
--- a/hawc/apps/assessment/forms.py
+++ b/hawc/apps/assessment/forms.py
@@ -515,7 +515,6 @@ class ContactForm(forms.Form):
         self.user = kwargs.pop("user")
         super().__init__(*args, **kwargs)
         if self.user.is_anonymous:
-            self.turnstile = Turnstile()
             self.fields["name"].disabled = False
             self.fields["email"].disabled = False
         else:

--- a/hawc/apps/assessment/forms.py
+++ b/hawc/apps/assessment/forms.py
@@ -16,6 +16,7 @@ from hawc.apps.assessment import constants
 from hawc.apps.study.models import Study
 from hawc.services.epa.dsstox import DssSubstance
 
+from ..common.auth.turnstile import Turnstile
 from ..common.autocomplete import AutocompleteSelectMultipleWidget, AutocompleteTextWidget
 from ..common.forms import (
     BaseFormHelper,
@@ -513,8 +514,16 @@ class ContactForm(forms.Form):
         self.back_href = kwargs.pop("back_href")
         self.user = kwargs.pop("user")
         super().__init__(*args, **kwargs)
-        self.fields["name"].initial = self.user.get_full_name()
-        self.fields["email"].initial = self.user.email
+        if self.user.is_anonymous:
+            self.turnstile = Turnstile()
+            self.fields["name"].disabled = False
+            self.fields["email"].disabled = False
+        else:
+            self.fields["name"].initial = self.user.get_full_name()
+            self.fields["email"].initial = self.user.email
+        self.enable_turnstile: bool = self.user.is_anonymous
+        if self.enable_turnstile:
+            self.turnstile = Turnstile()
         self.fields["previous_page"].initial = self.back_href
 
     def send_email(self):
@@ -532,12 +541,20 @@ class ContactForm(forms.Form):
 
     @property
     def helper(self):
-        return BaseFormHelper(
+        helper = BaseFormHelper(
             self,
             legend_text="Contact us",
             help_text="Have a question, comment, or need some help? Use this form to to let us know what's going on.",
             cancel_url=self.back_href,
         )
+        if self.enable_turnstile:
+            helper.layout.insert(len(helper.layout) - 1, self.turnstile.render())
+        return helper
+
+    def clean(self):
+        if self.enable_turnstile:
+            self.turnstile.validate(self.data)
+        return self.cleaned_data
 
 
 class DatasetForm(forms.ModelForm):

--- a/hawc/apps/assessment/views.py
+++ b/hawc/apps/assessment/views.py
@@ -115,7 +115,7 @@ class Resources(TemplateView):
         return context
 
 
-class Contact(LoginRequiredMixin, MessageMixin, FormView):
+class Contact(MessageMixin, FormView):
     template_name = "hawc/contact.html"
     form_class = forms.ContactForm
     success_url = reverse_lazy("home")
@@ -124,6 +124,8 @@ class Contact(LoginRequiredMixin, MessageMixin, FormView):
     def dispatch(self, request, *args, **kwargs):
         if settings.EXTERNAL_CONTACT_US:
             return HttpResponseRedirect(settings.EXTERNAL_CONTACT_US)
+        elif self.request.user.is_anonymous and not settings.TURNSTILE_SITE:
+            return HttpResponseRedirect(settings.LOGIN_URL)
         return super().dispatch(request, *args, **kwargs)
 
     def get_form_kwargs(self):

--- a/tests/hawc/apps/assessment/test_views.py
+++ b/tests/hawc/apps/assessment/test_views.py
@@ -7,11 +7,12 @@ from django.test.client import Client
 from django.urls import reverse
 from pytest_django.asserts import assertTemplateUsed
 
+from hawc.apps.assessment.forms import ContactForm
 from hawc.apps.assessment.models import Assessment
 from hawc.apps.myuser.models import HAWCUser
 from hawc.apps.study.models import Study
 
-from ..test_utils import check_200, get_client
+from ..test_utils import check_200, check_302, get_client
 
 
 def has_redis():
@@ -200,7 +201,7 @@ class TestContactUsPage:
         # login required
         resp = client.get(contact_url)
         assert resp.status_code == 302
-        assert urlparse(resp.url).path == reverse("user:login")
+        assert urlparse(resp.url).path == settings.LOGIN_URL
 
         # valid
         client.login(username="pm@hawcproject.org", password="pw")
@@ -241,6 +242,45 @@ class TestContactUsPage:
         # invalid referrer; use default
         resp = client.get(contact_url, HTTP_REFERER=about_url + '"onmouseover="alert(26)"')
         assert resp.context["form"].fields["previous_page"].initial == portal_url
+
+    def test_turnstile(self, settings):
+        anon = get_client()
+        team = get_client("team")
+        url = reverse("contact")
+
+        # turnstile disabled
+        settings.TURNSTILE_SITE = ""
+        settings.TURNSTILE_KEY = ""
+
+        # anon - redirect to login
+        resp = anon.get(url, follow=True)
+        check_302(anon, url, str(settings.LOGIN_URL))
+
+        # auth - form displayed; no challenge
+        resp = team.get(url, follow=True)
+        form = resp.context["form"]
+        assert isinstance(form, ContactForm)
+        assert b"challenges.cloudflare.com/turnstile" not in resp.content
+
+        # turnstile enabled
+        settings.TURNSTILE_SITE = "https://test-me.org"
+        settings.TURNSTILE_KEY = "secret"
+
+        # anon - form displayed; has challenge
+        resp = anon.get(url)
+        form = resp.context["form"]
+        assert isinstance(form, ContactForm)
+        assert b"challenges.cloudflare.com/turnstile" in resp.content
+
+        # auth - form displayed; no challenge
+        resp = team.get(url, follow=True)
+        form = resp.context["form"]
+        assert isinstance(form, ContactForm)
+        assert b"challenges.cloudflare.com/turnstile" not in resp.content
+
+        # turnstile disabled
+        settings.TURNSTILE_SITE = ""
+        settings.TURNSTILE_KEY = ""
 
 
 @pytest.mark.django_db

--- a/tests/hawc/apps/assessment/test_views.py
+++ b/tests/hawc/apps/assessment/test_views.py
@@ -260,7 +260,7 @@ class TestContactUsPage:
         resp = team.get(url, follow=True)
         form = resp.context["form"]
         assert isinstance(form, ContactForm)
-        assert b"challenges.cloudflare.com/turnstile" not in resp.content
+        assert form.enable_turnstile is False
 
         # turnstile enabled
         settings.TURNSTILE_SITE = "https://test-me.org"
@@ -270,13 +270,13 @@ class TestContactUsPage:
         resp = anon.get(url)
         form = resp.context["form"]
         assert isinstance(form, ContactForm)
-        assert b"challenges.cloudflare.com/turnstile" in resp.content
+        assert form.enable_turnstile is True
 
         # auth - form displayed; no challenge
         resp = team.get(url, follow=True)
         form = resp.context["form"]
         assert isinstance(form, ContactForm)
-        assert b"challenges.cloudflare.com/turnstile" not in resp.content
+        assert form.enable_turnstile is False
 
         # turnstile disabled
         settings.TURNSTILE_SITE = ""


### PR DESCRIPTION
We were getting some spam on our contact us page, so we disabled anonymous contact us (#145) in 2019.  Instead of disabling, we revised the contact page to use use [turnstile](https://developers.cloudflare.com), so anonymous human users can still contact. This uses the same patterns in #775 and #1004.

If turnstile is not enabled, contact-us is disabled for anonymous users.