### PR TITLE
add a simple SQL select query

### DIFF
--- a/tests/hawc/apps/common/test_models.py
+++ b/tests/hawc/apps/common/test_models.py
@@ -2,7 +2,7 @@ import pytest
 
 # use concrete implementations to test
 from hawc.apps.animal.models import DoseGroup, Experiment
-from hawc.apps.common.models import apply_flavored_help_text, sql_format
+from hawc.apps.common.models import apply_flavored_help_text, sql_format, sql_query_to_dicts
 from hawc.apps.lit.models import ReferenceFilterTag
 from hawc.apps.riskofbias import models
 
@@ -68,3 +68,10 @@ def test_apply_flavored_help_text(settings):
     apply_flavored_help_text("riskofbias")
     changed = models.RiskOfBiasAssessment._meta.get_field("help_text").help_text
     assert initial != changed
+
+
+@pytest.mark.django_db
+def test_sql_query_to_dicts():
+    query = "SELECT id, name FROM assessment_assessment ORDER BY id LIMIT %s "
+    results = sql_query_to_dicts(query, (2,))
+    assert list(results) == [{"id": 1, "name": "Chemical Z"}, {"id": 2, "name": "Chemical X"}]


### PR DESCRIPTION
Write a simple utility function that given a SQL query statement, return a iterator of dictionary results. This can be helpful for development when experimenting w/ SQL directly instead of the ORM.