### PR TITLE
remove user_can_edit_assessment

### DIFF
--- a/hawc/apps/assessment/models.py
+++ b/hawc/apps/assessment/models.py
@@ -355,11 +355,6 @@ class Assessment(models.Model):
             perms = self.get_permissions()
         return perms.can_edit_object(user)
 
-    def user_can_edit_assessment(self, user, perms: AssessmentPermissions | None = None) -> bool:
-        if perms is None:
-            perms = self.get_permissions()
-        return perms.project_manager_or_higher(user)
-
     def user_is_reviewer_or_higher(self, user) -> bool:
         perms = self.get_permissions()
         return perms.reviewer_or_higher(user)

--- a/hawc/apps/assessment/templates/assessment/assessment_detail.html
+++ b/hawc/apps/assessment/templates/assessment/assessment_detail.html
@@ -137,93 +137,100 @@
   </table>
 
   {% if is_team_member %}
-    <h3>Assessment details for team members*</h3>
-    <table id="assessment_table" class="table table-sm table-striped">
-      {% bs4_colgroup '25,25,25,25' %}
-      <tbody>
-        <tr>
-          <th>Assessment team</th>
-          <td>
-            <p><strong>Project manager{{ object.project_manager.all|pluralize }}</strong></p>
-            <ul class="mb-0">
-              {% for m in object.project_manager.active %}
-                <li title="{{m.email}}">{{ m.get_full_name }}</li>
-              {% endfor %}
-            </ul>
-          </td>
-          <td>
-            <p><strong>Team member{{ object.team_members.all|pluralize }}</strong></p>
-            <ul class="mb-0">
-              {% for m in object.team_members.active %}
-                <li title="{{m.email}}">{{ m.get_full_name }}</li>
-              {% empty %}
-                <li><i>None assigned</i></li>
-              {% endfor %}
-            </ul>
-          </td>
-          <td>
-            <p><strong>Reviewer{{ object.reviewers.all|pluralize }}</strong></p>
-            <ul class="mb-0">
-              {% for m in object.reviewers.active %}
-                <li title="{{m.email}}">{{ m.get_full_name }}</li>
-              {% empty %}
-                <li><i>None assigned</i></li>
-              {% endfor %}
-            </ul>
-          </td>
-        </tr>
-
-        <tr>
-          <th>Editable</th>
-          <td colspan="3">{{object.editable|yesno:"Yes,No"}}</td>
-        </tr>
-
-        <tr>
-          <th>Public</th>
-          <td colspan="3">
-            {% if object.public_on %}
-              Yes; published on {{object.public_on|date:"DATE_FORMAT"}}
-            {% else %}
-              No; this assessment is currently private
-            {% endif %}
-          </td>
-        </tr>
-
-        {% if object.public_on %}
+    <div class="bg-primary-lighter rounded p-3 mb-3">
+      <h3>Assessment details for team members*</h3>
+      <table id="assessment_table" class="table table-sm table-striped my-0">
+        {% bs4_colgroup '25,25,25,25' %}
+        <tbody>
           <tr>
-            <th>Hidden from public assessments page?</th>
-            <td colspan="3">{{object.hide_from_public_page|yesno:"Yes; available if you have the link but hidden from the list page,No; it's available via searching or browsing"|safe}}</td>
+            <th>Assessment team</th>
+            <td>
+              <p><strong>Project manager{{ object.project_manager.all|pluralize }}</strong></p>
+              <ul class="mb-0">
+                {% for m in object.project_manager.active %}
+                  <li title="{{m.email}}">{{ m.get_full_name }}</li>
+                {% endfor %}
+              </ul>
+            </td>
+            <td>
+              <p><strong>Team member{{ object.team_members.all|pluralize }}</strong></p>
+              <ul class="mb-0">
+                {% for m in object.team_members.active %}
+                  <li title="{{m.email}}">{{ m.get_full_name }}</li>
+                {% empty %}
+                  <li><i>None assigned</i></li>
+                {% endfor %}
+              </ul>
+            </td>
+            <td>
+              <p><strong>Reviewer{{ object.reviewers.all|pluralize }}</strong></p>
+              <ul class="mb-0">
+                {% for m in object.reviewers.active %}
+                  <li title="{{m.email}}">{{ m.get_full_name }}</li>
+                {% empty %}
+                  <li><i>None assigned</i></li>
+                {% endfor %}
+              </ul>
+            </td>
           </tr>
-        {% endif %}
 
-        <tr>
-          <th>Date created</th>
-          <td colspan="3">Created by {{object.creator}} on {{object.created|date:"DATE_FORMAT"}}</td>
-        </tr>
-
-        {% if object.details and object.details.qa_id %}
-          {% url_or_span object.details.qa_id object.details.qa_url as qa_identifier %}
           <tr>
-            <th>QA Identifier</th>
-            <td colspan="3">{{ qa_identifier }}</td>
+            <th>Assessment ID</th>
+            <td colspan="3">{{object.id}}</td>
           </tr>
-        {% endif %}
 
-        {% if internal_communications|hastext %}
           <tr>
-            <th>Internal communications</th>
-            <td colspan="3">{{ internal_communications|safe }}</td>
+            <th>Editable</th>
+            <td colspan="3">{{object.editable|yesno:"Yes,No"}}</td>
           </tr>
-        {% endif %}
-      </tbody>
-      <tfoot>
-        <tr>
-          <td colspan="5" class="text-muted">
-            * These fields are only shown to assessment team members, even if the assessment is made public.
-          </td>
-        </tr>
-      </tfoot>
-    </table>
+
+          <tr>
+            <th>Public</th>
+            <td colspan="3">
+              {% if object.public_on %}
+                Yes; published on {{object.public_on|date:"DATE_FORMAT"}}
+              {% else %}
+                No; this assessment is currently private
+              {% endif %}
+            </td>
+          </tr>
+
+          {% if object.public_on %}
+            <tr>
+              <th>Hidden from public assessments page?</th>
+              <td colspan="3">{{object.hide_from_public_page|yesno:"Yes; available if you have the link but hidden from the list page,No; it's available via searching or browsing"|safe}}</td>
+            </tr>
+          {% endif %}
+
+          <tr>
+            <th>Date created</th>
+            <td colspan="3">Created by {{object.creator}} on {{object.created|date:"DATE_FORMAT"}}</td>
+          </tr>
+
+          {% if object.details and object.details.qa_id %}
+            {% url_or_span object.details.qa_id object.details.qa_url as qa_identifier %}
+            <tr>
+              <th>QA Identifier</th>
+              <td colspan="3">{{ qa_identifier }}</td>
+            </tr>
+          {% endif %}
+
+          {% if internal_communications|hastext %}
+            <tr>
+              <th>Internal communications</th>
+              <td colspan="3">{{ internal_communications|safe }}</td>
+            </tr>
+          {% endif %}
+        </tbody>
+        <tfoot>
+          <tr>
+            <td colspan="5" class="text-muted">
+              * These fields are only shown to assessment team members, even if the assessment is made public.
+            </td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
   {% endif %}
 
   {% if crud == "Read" %}

--- a/hawc/apps/assessment/templates/assessment/assessment_detail.html
+++ b/hawc/apps/assessment/templates/assessment/assessment_detail.html
@@ -137,9 +137,9 @@
   </table>
 
   {% if is_team_member %}
-    <div class="bg-primary-lighter rounded p-3 mb-3">
+    <div class="bg-lightblue rounded p-3 mb-3">
       <h3>Assessment details for team members*</h3>
-      <table id="assessment_table" class="table table-sm table-striped my-0">
+      <table id="assessment_table" class="table table-sm table-striped bg-white my-0">
         {% bs4_colgroup '25,25,25,25' %}
         <tbody>
           <tr>
@@ -222,14 +222,10 @@
             </tr>
           {% endif %}
         </tbody>
-        <tfoot>
-          <tr>
-            <td colspan="5" class="text-muted">
-              * These fields are only shown to assessment team members, even if the assessment is made public.
-            </td>
-          </tr>
-        </tfoot>
       </table>
+      <span class="text-muted">
+        * These fields are only shown to assessment team members, even if the assessment is made public.
+      </span>
     </div>
   {% endif %}
 

--- a/hawc/apps/riskofbias/actions/rob_clone.py
+++ b/hawc/apps/riskofbias/actions/rob_clone.py
@@ -201,8 +201,8 @@ class BulkRobCopyAction(BaseApiAction):
         if src_assessment is None or dst_assessment is None:
             return False, "Invalid source and/or destination assessment ID."
         if (
-            src_assessment.user_can_edit_assessment(request.user) is False
-            or dst_assessment.user_can_edit_assessment(request.user) is False
+            src_assessment.user_is_project_manager_or_higher(request.user) is False
+            or dst_assessment.user_is_project_manager_or_higher(request.user) is False
         ):
             return False, "Must be a Project Manager for source and destination assessments."
         return super().has_permission(request)

--- a/hawc/apps/riskofbias/serializers.py
+++ b/hawc/apps/riskofbias/serializers.py
@@ -387,7 +387,7 @@ class RiskOfBiasAssignmentSerializer(serializers.ModelSerializer):
 
     def validate(self, data):
         assessment = self.instance.study.assessment if self.instance else data["study"].assessment
-        if not assessment.user_can_edit_assessment(self.context["request"].user):
+        if not assessment.user_is_project_manager_or_higher(self.context["request"].user):
             raise PermissionDenied()
         if "author" in data and not assessment.user_can_edit_object(data["author"]):
             raise serializers.ValidationError({"author": "Author cannot be assigned"})

--- a/hawc/apps/riskofbias/views.py
+++ b/hawc/apps/riskofbias/views.py
@@ -253,7 +253,7 @@ class RobAssignmentUpdate(BaseFilterList):
     assessment_permission = AssessmentViewPermissions.PROJECT_MANAGER_EDITABLE
 
     def get_queryset(self):
-        if not self.assessment.user_can_edit_assessment(self.request.user):
+        if not self.assessment.user_is_project_manager_or_higher(self.request.user):
             raise PermissionDenied()
         robs = models.RiskOfBias.objects.prefetch_related("author", "scores")
         return (
@@ -295,7 +295,7 @@ class RobNumberReviewsUpdate(BaseUpdate):
             assessment=self.kwargs.get("pk"),
         )
         obj = super().get_object(object=obj)
-        if not self.assessment.user_can_edit_assessment(self.request.user):
+        if not self.assessment.user_is_project_manager_or_higher(self.request.user):
             raise PermissionDenied()
         return obj
 
@@ -468,8 +468,9 @@ class RoBEdit(TimeSpentOnPageMixin, BaseDetail):
     def get_object(self, **kwargs):
         # either project managers OR the author can edit/view.
         obj = super().get_object(**kwargs)
-        if obj.author != self.request.user and not self.assessment.user_can_edit_assessment(
-            self.request.user
+        if (
+            obj.author != self.request.user
+            and not self.assessment.user_is_project_manager_or_higher(self.request.user)
         ):
             raise PermissionDenied
         return obj

--- a/hawc/apps/study/models.py
+++ b/hawc/apps/study/models.py
@@ -292,7 +292,7 @@ class Study(Reference):
         Communication.set_message(self, text)
 
     def user_can_toggle_editable(self, user) -> bool:
-        return self.assessment.user_can_edit_assessment(user)
+        return self.assessment.user_is_project_manager_or_higher(user)
 
     def toggle_editable(self):
         self.editable = not self.editable


### PR DESCRIPTION
Minor updates to permissions.
- Remove user_can_edit_assessment in favor of user_is_project_manager_or_higher
- Put team-member information in a blue box on assessment page so it is more easily identifed
- Add assessment id to detail page