### PR TITLE
Update Ruff Rules

### DIFF
--- a/client/hawc_client/interactive.py
+++ b/client/hawc_client/interactive.py
@@ -49,8 +49,8 @@ async def get_svg_image(page, timeout_ms) -> BytesIO:
 
     try:
         await expect(download_button.or_(error_alert)).to_be_visible(timeout=timeout_ms)
-    except AssertionError:
-        raise TimeoutError(f"Timeout - exceeded {timeout_ms}ms") from None
+    except AssertionError as err:
+        raise TimeoutError(f"Timeout - exceeded {timeout_ms}ms") from err
 
     if await error_alert.is_visible():
         error_text = await error_alert.inner_text()

--- a/client/hawc_client/interactive.py
+++ b/client/hawc_client/interactive.py
@@ -50,7 +50,7 @@ async def get_svg_image(page, timeout_ms) -> BytesIO:
     try:
         await expect(download_button.or_(error_alert)).to_be_visible(timeout=timeout_ms)
     except AssertionError:
-        raise TimeoutError(f"Timeout - exceeded {timeout_ms}ms")
+        raise TimeoutError(f"Timeout - exceeded {timeout_ms}ms") from None
 
     if await error_alert.is_visible():
         error_text = await error_alert.inner_text()

--- a/hawc/apps/animal/serializers.py
+++ b/hawc/apps/animal/serializers.py
@@ -42,8 +42,10 @@ class ExperimentSerializer(serializers.ModelSerializer):
         if dtxsid:
             try:
                 data["dtxsid"] = DSSTox.objects.get(pk=dtxsid)
-            except models.ObjectDoesNotExist:
-                raise serializers.ValidationError(dict(dtxsid=f"DSSTox {dtxsid} does not exist"))
+            except models.ObjectDoesNotExist as exc:
+                raise serializers.ValidationError(
+                    dict(dtxsid=f"DSSTox {dtxsid} does not exist")
+                ) from exc
 
         return data
 

--- a/hawc/apps/assessment/api/helper.py
+++ b/hawc/apps/assessment/api/helper.py
@@ -33,5 +33,5 @@ def get_assessment_from_query(request: Request) -> models.Assessment:
     assessment_id = get_assessment_id_param(request)
     try:
         return models.Assessment.objects.get(pk=assessment_id)
-    except models.Assessment.DoesNotExist:
-        raise InvalidAssessmentID()
+    except models.Assessment.DoesNotExist as exc:
+        raise InvalidAssessmentID() from exc

--- a/hawc/apps/assessment/management/commands/assessment_db_dump.py
+++ b/hawc/apps/assessment/management/commands/assessment_db_dump.py
@@ -135,7 +135,7 @@ class Command(UnicodeCommand):
         self.stdout.write("--- HAWC PRE-DATABASE SCHEMA\n")
         self.stdout.write("----------------------------\n")
         proc = subprocess.Popen(
-            ["pg_dump", "-d", dbname, "--section=pre-data", "--no-owner"],
+            ["pg_dump", "-d", dbname, "--section=pre-data", "--no-owner"],  # noqa: S607
             stdout=subprocess.PIPE,
             shell=False,
         )
@@ -147,7 +147,7 @@ class Command(UnicodeCommand):
         self.stdout.write("--- HAWC POST-DATABASE SCHEMA\n")
         self.stdout.write("-----------------------------\n")
         proc = subprocess.Popen(
-            ["pg_dump", "-d", dbname, "--section=post-data", "--no-owner"],
+            ["pg_dump", "-d", dbname, "--section=post-data", "--no-owner"],  # noqa: S607
             stdout=subprocess.PIPE,
             shell=False,
         )

--- a/hawc/apps/assessment/models.py
+++ b/hawc/apps/assessment/models.py
@@ -442,7 +442,9 @@ class Assessment(models.Model):
                 cache.clear()
             else:
                 # in prod, throw exception
-                raise NotImplementedError("Cannot wipe assessment cache using this cache backend")
+                raise NotImplementedError(
+                    "Cannot wipe assessment cache using this cache backend"
+                ) from None
 
         # refresh materialized views
         refresh_all_mvs(force=True)
@@ -1124,8 +1126,8 @@ class DatasetRevision(models.Model):
 
         try:
             df = func(data.file, **kwargs)
-        except Exception:
-            raise ValueError("Unable load dataframe")
+        except Exception as exc:
+            raise ValueError("Unable load dataframe") from exc
 
         if df.shape[0] == 0:
             raise ValueError("Dataframe contains no rows")

--- a/hawc/apps/assessment/serializers.py
+++ b/hawc/apps/assessment/serializers.py
@@ -24,8 +24,10 @@ class DSSToxSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         try:
             substance = DssSubstance.create_from_dtxsid(validated_data["dtxsid"])
-        except ValueError:
-            raise serializers.ValidationError(f"Invalid DTXSID: {validated_data["dtxsid"]}")
+        except ValueError as exc:
+            raise serializers.ValidationError(
+                f"Invalid DTXSID: {validated_data["dtxsid"]}"
+            ) from exc
         return models.DSSTox.objects.create(dtxsid=substance.dtxsid, content=substance.content)
 
 
@@ -116,8 +118,8 @@ class RelatedEffectTagSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(f"'{data}' must be a string.")
         try:
             return models.EffectTag.objects.get(name=data)
-        except ObjectDoesNotExist:
-            raise serializers.ValidationError(f"'{data}' not found.")
+        except ObjectDoesNotExist as exc:
+            raise serializers.ValidationError(f"'{data}' not found.") from exc
 
 
 class DoseUnitsSerializer(serializers.ModelSerializer):

--- a/hawc/apps/assessment/views.py
+++ b/hawc/apps/assessment/views.py
@@ -709,8 +709,8 @@ class LogObjectList(ListView):
     def dispatch(self, request, *args, **kwargs):
         try:
             content_type = ContentType.objects.get_for_id(kwargs["content_type"])
-        except ObjectDoesNotExist:
-            raise Http404()
+        except ObjectDoesNotExist as exc:
+            raise Http404() from exc
         first_log = self.model.objects.filter(**self.kwargs).first()
         if not first_log:
             first_log = self.model(content_type=content_type, object_id=kwargs["object_id"])

--- a/hawc/apps/bmd/bmd_interface.py
+++ b/hawc/apps/bmd/bmd_interface.py
@@ -37,7 +37,7 @@ def build_dataset(endpoint: Endpoint, dose_units_id: int, n_drop_doses: int = 0)
         raise ValueError(f"Cannot create BMDS dataset for this data type: {endpoint.data_type}")
 
     # drop doses from the top
-    for i in range(n_drop_doses):
+    for _i in range(n_drop_doses):
         [lst.pop() for lst in kwargs.values()]
 
     return Cls(**kwargs)

--- a/hawc/apps/bmd/views.py
+++ b/hawc/apps/bmd/views.py
@@ -42,8 +42,10 @@ class SessionCreate(RedirectView):
             raise PermissionDenied()
         try:
             obj = models.Session.create_new(self.object)
-        except ValueError:
-            raise BadRequest("Assessment BMDS version is unsupported, can't create a new session.")
+        except ValueError as exc:
+            raise BadRequest(
+                "Assessment BMDS version is unsupported, can't create a new session."
+            ) from exc
         return obj.get_update_url()
 
 

--- a/hawc/apps/common/admin.py
+++ b/hawc/apps/common/admin.py
@@ -80,7 +80,7 @@ def autocomplete(Model, field: str, multi: bool = False):
 @admin.display(description="Detailed edit link")
 def admin_edit_link(instance):
     """
-    Generate a read-only edit link in the admin for deatiled editing.
+    Generate a read-only edit link in the admin for detailed editing.
     """
     if instance.pk:
         url = reverse(

--- a/hawc/apps/common/api/mixins.py
+++ b/hawc/apps/common/api/mixins.py
@@ -69,7 +69,7 @@ class ListUpdateModelMixin:
                     try:
                         value = validator(value)
                     except ValidationError as err:
-                        raise DrfValidationError(err) from err
+                        raise DrfValidationError(err) from None
                 update_bulk_dict[field.source or field_name] = value
         return update_bulk_dict
 

--- a/hawc/apps/common/api/mixins.py
+++ b/hawc/apps/common/api/mixins.py
@@ -69,7 +69,7 @@ class ListUpdateModelMixin:
                     try:
                         value = validator(value)
                     except ValidationError as err:
-                        raise DrfValidationError(err)
+                        raise DrfValidationError(err) from err
                 update_bulk_dict[field.source or field_name] = value
         return update_bulk_dict
 

--- a/hawc/apps/common/auth/turnstile.py
+++ b/hawc/apps/common/auth/turnstile.py
@@ -27,7 +27,7 @@ def validate(turnstile_response: str, user_ip: str | None = None) -> SiteVerifyR
     model = SiteVerifyRequest(
         secret=settings.TURNSTILE_KEY, response=turnstile_response, remoteip=user_ip
     )
-    resp = requests.post(url, data=model.model_dump())
+    resp = requests.post(url, data=model.model_dump(), timeout=15)
     if resp.status_code != 200:
         model = SiteVerifyResponse(success=False, hostname=None)
         model.error_codes.extend(

--- a/hawc/apps/common/autocomplete/registry.py
+++ b/hawc/apps/common/autocomplete/registry.py
@@ -31,8 +31,8 @@ class AutocompleteRegistry:
     def get(self, key) -> type[BaseAutocomplete]:
         try:
             return self._registry[key]
-        except KeyError:
-            raise ValueError(f"Key not found: {key}")
+        except KeyError as err:
+            raise ValueError(f"Key not found: {key}") from err
 
 
 registry = AutocompleteRegistry()
@@ -46,12 +46,12 @@ def register(Cls):
 def get_autocomplete(request, autocomplete_name):
     try:
         autocomplete_cls = registry.get(autocomplete_name)
-    except ValueError:
-        raise Http404(f"Autocomplete {autocomplete_name} not found")
+    except ValueError as err:
+        raise Http404(f"Autocomplete {autocomplete_name} not found") from err
     try:
         return autocomplete_cls.as_view()(request)
     except ValueError as err:
-        raise BadRequest(str(err))
+        raise BadRequest(str(err)) from err
 
 
 def autodiscover():

--- a/hawc/apps/common/autocomplete/views.py
+++ b/hawc/apps/common/autocomplete/views.py
@@ -64,8 +64,8 @@ class BaseAutocomplete(autocomplete.Select2QuerySetView):
         # get base queryset
         try:
             qs = self.get_base_queryset(self.qry)
-        except ValueError:
-            raise BadRequest("Invalid filter parameters")
+        except ValueError as err:
+            raise BadRequest("Invalid filter parameters") from err
 
         # check forwarded values for search_fields
         self.search_fields = self.forwarded.get("search_fields") or self.search_fields
@@ -77,8 +77,8 @@ class BaseAutocomplete(autocomplete.Select2QuerySetView):
             # order by field and get distinct
             try:
                 qs = qs.order_by(self.field).distinct(self.field)
-            except FieldError:
-                raise BadRequest("Invalid field parameters")
+            except FieldError as err:
+                raise BadRequest("Invalid field parameters") from err
         else:
             # check forwarded values for ordering
             self.order_by = self.forwarded.get("order_by") or self.order_by

--- a/hawc/apps/common/htmx.py
+++ b/hawc/apps/common/htmx.py
@@ -153,8 +153,8 @@ class HtmxViewSet(View):
             object = get_object_or_404(self.model, pk=self.kwargs.get(self.pk_url_kwarg))
         try:
             assessment: Assessment = parent.get_assessment() if parent else object.get_assessment()
-        except AssessmentNotFound:
-            raise PermissionDenied()
+        except AssessmentNotFound as err:
+            raise PermissionDenied() from err
         return Item(object=object, parent=parent, assessment=assessment)
 
     def get_context_data(self, **kwargs):

--- a/hawc/apps/common/models.py
+++ b/hawc/apps/common/models.py
@@ -177,7 +177,7 @@ class AssessmentRootMixin:
                 if node.depth > last_depth:
                     pass
                 else:
-                    for i in range(last_depth - node.depth + 1):
+                    for _i in range(last_depth - node.depth + 1):
                         names.pop()
 
                 names.append(node.name)

--- a/hawc/apps/common/models.py
+++ b/hawc/apps/common/models.py
@@ -383,8 +383,8 @@ class AssessmentRootMixin:
             assessment_id = self.get_assessment_id()
             Assessment = apps.get_model("assessment", "Assessment")
             return Assessment.objects.get(id=assessment_id)
-        except Exception:
-            raise self.__class__.DoesNotExist()
+        except Exception as exc:
+            raise self.__class__.DoesNotExist() from exc
 
     def moveWithinSiblingsToIndex(self, newIndex):
         siblings = list(self.get_siblings())

--- a/hawc/apps/common/serializers.py
+++ b/hawc/apps/common/serializers.py
@@ -99,12 +99,12 @@ def get_matching_instance(Model: models.Model, data: dict, field_name: str) -> m
 
     try:
         return Model.objects.get(id=id_)
-    except ValueError:
+    except ValueError as error:
         err[field_name] = f"`{field_name} must be a number; got {id_}."
-        raise serializers.ValidationError(err) from err
-    except models.ObjectDoesNotExist:
+        raise serializers.ValidationError(err) from error
+    except models.ObjectDoesNotExist as error:
         err[field_name] = f"{Model.__name__} {id_} does not exist."
-        raise serializers.ValidationError(err) from err
+        raise serializers.ValidationError(err) from error
 
 
 def get_matching_instances(Model: models.Model, data: dict, field_name: str) -> list[models.Model]:
@@ -130,12 +130,12 @@ def get_matching_instances(Model: models.Model, data: dict, field_name: str) -> 
     for id_ in ids:
         try:
             instances.append(Model.objects.get(id=id_))
-        except ValueError:
+        except ValueError as error:
             err[field_name] = f"`{field_name} must be a number; got {id_}."
-            raise serializers.ValidationError(err) from err
-        except models.ObjectDoesNotExist:
+            raise serializers.ValidationError(err) from error
+        except models.ObjectDoesNotExist as error:
             err[field_name] = f"{Model.__name__} {id_} does not exist."
-            raise serializers.ValidationError(err) from err
+            raise serializers.ValidationError(err) from error
 
     return instances
 

--- a/hawc/apps/common/validators.py
+++ b/hawc/apps/common/validators.py
@@ -189,7 +189,7 @@ def _validate_json_pydantic(value: str, Model: type[BaseModel]):
     try:
         Model.model_validate_json(value)
     except PydanticValidationError as err:
-        raise ValidationError(err.json())
+        raise ValidationError(err.json()) from err
 
 
 def validate_json_pydantic(Model: type[BaseModel]) -> Callable:

--- a/hawc/apps/epi/api.py
+++ b/hawc/apps/epi/api.py
@@ -274,8 +274,8 @@ class Exposure(ReadWriteSerializerMixin, EditPermissionsCheckMixin, AssessmentEd
         if dtxsid := request.data.get("dtxsid"):
             try:
                 DSSTox.objects.get(dtxsid=dtxsid)
-            except DSSTox.DoesNotExist:
-                raise ValidationError(f"{dtxsid} does not exist in HAWC")
+            except DSSTox.DoesNotExist as err:
+                raise ValidationError(f"{dtxsid} does not exist in HAWC") from err
 
     @transaction.atomic
     def update(self, request, *args, **kwargs):

--- a/hawc/apps/epi/models.py
+++ b/hawc/apps/epi/models.py
@@ -1193,7 +1193,7 @@ class GroupResult(models.Model):
             """
             control = None
 
-            for i, rg in enumerate(rgs):
+            for _i, rg in enumerate(rgs):
                 if rg["group"]["isControl"]:
                     control = rg
                     break
@@ -1208,7 +1208,7 @@ class GroupResult(models.Model):
 
         n_1, mu_1, sd_1 = get_control_group(rgs)
 
-        for i, rg in enumerate(rgs):
+        for _i, rg in enumerate(rgs):
             mean = low = high = None
 
             if estimate_type in ["median", "mean"] and variance_type in [

--- a/hawc/apps/epi/serializers.py
+++ b/hawc/apps/epi/serializers.py
@@ -59,8 +59,8 @@ class StudyPopulationCountrySerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(f"'{data}' must be a string.")
         try:
             return models.Country.objects.get(code=data)
-        except ObjectDoesNotExist:
-            raise serializers.ValidationError(f"'{data}' is not a country.")
+        except ObjectDoesNotExist as err:
+            raise serializers.ValidationError(f"'{data}' is not a country.") from err
 
 
 class OutcomeLinkSerializer(serializers.ModelSerializer):

--- a/hawc/apps/invitro/forms.py
+++ b/hawc/apps/invitro/forms.py
@@ -305,8 +305,8 @@ class IVEndpointForm(forms.ModelForm):
         data = self.cleaned_data["additional_fields"]
         try:
             json.loads(data)
-        except ValueError:
-            raise forms.ValidationError("Must be valid JSON.")
+        except ValueError as err:
+            raise forms.ValidationError("Must be valid JSON.") from err
         return data
 
     @property

--- a/hawc/apps/lit/api.py
+++ b/hawc/apps/lit/api.py
@@ -326,8 +326,8 @@ class LiteratureAssessmentViewSet(BaseAssessmentViewSet):
         try:
             # engine required since this is a BytesIO stream
             df = pd.read_excel(file_, engine="openpyxl")
-        except (BadZipFile, ValueError):
-            raise ParseError({"file": "Unable to parse excel file"})
+        except (BadZipFile, ValueError) as err:
+            raise ParseError({"file": "Unable to parse excel file"}) from err
 
         return FlatExport.api_response(df=df, filename=file_.name)
 

--- a/hawc/apps/lit/migrations/0012_reference_authors_list.py
+++ b/hawc/apps/lit/migrations/0012_reference_authors_list.py
@@ -112,7 +112,7 @@ def update_pubmed_queries(apps, schema_editor):
     qs = PubMedQuery.objects.all()
     n_total = qs.count()
     updates = []
-    for idx, query in enumerate(qs):
+    for _idx, query in enumerate(qs):
         if query.results:
             results = json.loads(query.results)
             results = dict(

--- a/hawc/apps/lit/models.py
+++ b/hawc/apps/lit/models.py
@@ -644,10 +644,10 @@ class Identifiers(models.Model):
         # create, but don't save reference object
         try:
             content = self.get_content()
-        except ValueError:
+        except ValueError as err:
             if self.database == constants.ReferenceDatabase.PUBMED:
                 self.update_pubmed_content([self])
-            raise AttributeError(f"Content invalid JSON: {self.unique_id}")
+            raise AttributeError(f"Content invalid JSON: {self.unique_id}") from err
 
         if self.database == constants.ReferenceDatabase.PUBMED:
             ref = Reference(
@@ -939,8 +939,8 @@ class Reference(models.Model):
 
                 try:
                     binding = TagBinding.objects.get(assessment=self.assessment_id, tag=udf_tag_id)
-                except TagBinding.DoesNotExist:
-                    raise ValidationError("UDF binding not found")
+                except TagBinding.DoesNotExist as err:
+                    raise ValidationError("UDF binding not found") from err
 
                 # handle edge-case where a select multiple only has one selected
                 # TODO - can this code + JS be removed to fix this issue?

--- a/hawc/apps/lit/serializers.py
+++ b/hawc/apps/lit/serializers.py
@@ -72,7 +72,7 @@ class SearchSerializer(serializers.ModelSerializer):
             else:
                 raise serializers.ValidationError("API currently only supports PubMed/HERO imports")
         except ValidationError as err:
-            raise serializers.ValidationError(err.message)
+            raise serializers.ValidationError(err.message) from err
 
     @transaction.atomic
     def create(self, validated_data):
@@ -180,10 +180,10 @@ class BulkReferenceTagSerializer(serializers.Serializer):
     def validate_csv(self, value):
         try:
             df = pd.read_csv(StringIO(value)).drop_duplicates()
-        except pd.errors.ParserError:
-            raise serializers.ValidationError("CSV could not be parsed")
-        except pd.errors.EmptyDataError:
-            raise serializers.ValidationError("CSV must not be empty")
+        except pd.errors.ParserError as err:
+            raise serializers.ValidationError("CSV could not be parsed") from err
+        except pd.errors.EmptyDataError as err:
+            raise serializers.ValidationError("CSV must not be empty") from err
 
         # ensure columns are expected
         expected_columns = ["reference_id", "tag_id"]
@@ -379,7 +379,7 @@ class ReferenceReplaceHeroIdSerializer(serializers.Serializer):
         try:
             self.fetched_content = models.Identifiers.objects.validate_hero_ids(self.hero_ids)
         except ValidationError as err:
-            raise serializers.ValidationError(err.args[0])
+            raise serializers.ValidationError(err.args[0]) from err
 
         return replace
 
@@ -417,15 +417,15 @@ class FilterReferences(PydanticDrfSerializer):
     def validate_search_id(cls, v):
         try:
             return models.Search.objects.get(pk=v)
-        except models.Search.DoesNotExist:
-            raise ValueError("Invalid search id")
+        except models.Search.DoesNotExist as err:
+            raise ValueError("Invalid search id") from err
 
     @field_validator("tag")
     def validate_tag_id(cls, v):
         try:
             return models.ReferenceFilterTag.objects.get(pk=v)
-        except models.ReferenceFilterTag.DoesNotExist:
-            raise ValueError("Invalid tag id")
+        except models.ReferenceFilterTag.DoesNotExist as err:
+            raise ValueError("Invalid tag id") from err
 
     @field_validator("required_tags", "pruned_tags", mode="before")
     def str_to_list(cls, v):

--- a/hawc/apps/myuser/forms.py
+++ b/hawc/apps/myuser/forms.py
@@ -362,8 +362,8 @@ class HAWCPasswordResetForm(PasswordResetForm):
         email = self.cleaned_data.get("email")
         try:
             models.HAWCUser.objects.get(email=email)
-        except models.HAWCUser.DoesNotExist:
-            raise forms.ValidationError("Email address not found")
+        except models.HAWCUser.DoesNotExist as err:
+            raise forms.ValidationError("Email address not found") from err
 
         return email
 

--- a/hawc/apps/myuser/views.py
+++ b/hawc/apps/myuser/views.py
@@ -325,8 +325,8 @@ class VerifyEmail(MessageMixin, FormView):
             OverflowError,
             models.HAWCUser.DoesNotExist,
             ValidationError,
-        ):
-            raise Http404()
+        ) as err:
+            raise Http404() from err
 
     def check_token_or_404(self, user: models.HAWCUser, token: str):
         if default_token_generator.check_token(user, token) is False:

--- a/hawc/apps/riskofbias/api.py
+++ b/hawc/apps/riskofbias/api.py
@@ -208,8 +208,8 @@ class RiskOfBias(AssessmentEditViewSet):
 
         try:
             study = Study.objects.get(id=study_id)
-        except ObjectDoesNotExist:
-            raise ValidationError("Invalid study_id")
+        except ObjectDoesNotExist as err:
+            raise ValidationError("Invalid study_id") from err
 
         # permission check using the user submitting the request
         if not study.user_can_edit_study(study.assessment, request.user):

--- a/hawc/apps/riskofbias/serializers.py
+++ b/hawc/apps/riskofbias/serializers.py
@@ -185,8 +185,8 @@ class RiskOfBiasSerializer(serializers.ModelSerializer):
             author = None
             try:
                 author = HAWCUser.objects.get(id=author_id)
-            except ObjectDoesNotExist:
-                raise serializers.ValidationError("Invalid author_id")
+            except ObjectDoesNotExist as err:
+                raise serializers.ValidationError("Invalid author_id") from err
 
             data["author"] = author
 
@@ -329,7 +329,7 @@ class RiskOfBiasSerializer(serializers.ModelSerializer):
             try:
                 score = models.RiskOfBiasScore.objects.create(**score_data, riskofbias=instance)
             except ValidationError as err:
-                raise serializers.ValidationError(err.message)
+                raise serializers.ValidationError(err.message) from err
             for overridden_object in overridden_objects:
                 overridden_object.score = score
                 overridden_object.save()
@@ -358,7 +358,7 @@ class RiskOfBiasSerializer(serializers.ModelSerializer):
             try:
                 score.save()
             except ValidationError as err:
-                raise serializers.ValidationError(err.message)
+                raise serializers.ValidationError(err.message) from err
 
         # update overrides
         new_overrides = []

--- a/hawc/apps/study/models.py
+++ b/hawc/apps/study/models.py
@@ -161,8 +161,8 @@ class Study(Reference):
     def get_final_rob_url(self):
         try:
             return self.get_final_rob().get_final_url()
-        except ObjectDoesNotExist:
-            raise Http404("Final RoB does not exist")
+        except ObjectDoesNotExist as err:
+            raise Http404("Final RoB does not exist") from err
 
     def get_assessment(self):
         return self.assessment
@@ -231,8 +231,8 @@ class Study(Reference):
             return self.riskofbiases.get(final=True, active=True)
         except ObjectDoesNotExist as err:
             raise err
-        except MultipleObjectsReturned:
-            raise ObjectDoesNotExist(f'Multiple active final RoB "{self}", expecting one')
+        except MultipleObjectsReturned as err:
+            raise ObjectDoesNotExist(f'Multiple active final RoB "{self}", expecting one') from err
 
     def get_final_qs(self):
         return self.riskofbiases.filter(active=True, final=True).prefetch_related(

--- a/hawc/apps/study/serializers.py
+++ b/hawc/apps/study/serializers.py
@@ -35,10 +35,10 @@ class SimpleStudySerializer(StudySerializer):
 
             try:
                 Reference.objects.get(id=ref_id)
-            except ValueError:
-                raise serializers.ValidationError("Reference ID must be a number.")
-            except ObjectDoesNotExist:
-                raise serializers.ValidationError("Reference ID does not exist.")
+            except ValueError as err:
+                raise serializers.ValidationError("Reference ID must be a number.") from err
+            except ObjectDoesNotExist as err:
+                raise serializers.ValidationError("Reference ID does not exist.") from err
 
         return super().validate(data)
 
@@ -130,7 +130,7 @@ class StudyFromIdentifierSerializer(serializers.ModelSerializer):
                 data["db_type"], data["db_id"]
             )
         except ValidationError as err:
-            raise serializers.ValidationError(err.message)
+            raise serializers.ValidationError(err.message) from err
 
         return data
 

--- a/hawc/apps/summary/forms.py
+++ b/hawc/apps/summary/forms.py
@@ -648,8 +648,8 @@ def get_visual_form(visual_type):
             constants.VisualType.IMAGE: ImageVisualForm,
             constants.VisualType.PRISMA: PrismaVisualForm,
         }[visual_type]
-    except Exception:
-        raise ValueError()
+    except Exception as exc:
+        raise ValueError() from exc
 
 
 class DataPivotForm(forms.ModelForm):

--- a/hawc/apps/summary/models.py
+++ b/hawc/apps/summary/models.py
@@ -226,7 +226,7 @@ class SummaryTable(models.Model):
             try:
                 self.get_table()
             except ValueError as e:
-                raise ValidationError({"content": str(e)})
+                raise ValidationError({"content": str(e)}) from e
 
         # clean up control characters before string validation
         content_str = json.dumps(self.content).replace('\\"', '"')
@@ -538,7 +538,7 @@ class Visual(models.Model):
         try:
             return from_json(json.dumps(self.settings))
         except ValueError as err:
-            raise ValueError(err)
+            raise ValueError(err) from err
 
     def _rob_data_qs(self, use_settings: bool = True) -> models.QuerySet:
         studies = self.get_studies()

--- a/hawc/apps/summary/views.py
+++ b/hawc/apps/summary/views.py
@@ -173,8 +173,8 @@ class SummaryTableCreate(BaseCreate):
         kwargs = super().get_form_kwargs()
         try:
             table_type = constants.TableType(self.kwargs["table_type"])
-        except ValueError:
-            raise Http404()
+        except ValueError as err:
+            raise Http404() from err
         kwargs["table_type"] = table_type
         return kwargs
 
@@ -428,8 +428,8 @@ class VisualizationCreate(BaseCreate):
         kwargs["visual_type"] = self.kwargs.get("visual_type")
         try:
             constants.VisualType(kwargs["visual_type"])
-        except ValueError:
-            raise Http404
+        except ValueError as err:
+            raise Http404 from err
 
         if kwargs["initial"]:
             kwargs["instance"] = self.model.objects.filter(pk=self.request.GET["initial"]).first()
@@ -444,8 +444,8 @@ class VisualizationCreate(BaseCreate):
                     kwargs["evidence_type"] = constants.get_default_evidence_type(
                         kwargs["visual_type"]
                     )
-                except ValueError:
-                    raise Http404
+                except ValueError as err:
+                    raise Http404 from err
             if (
                 kwargs["evidence_type"]
                 not in constants.VISUAL_EVIDENCE_CHOICES[kwargs["visual_type"]]
@@ -553,8 +553,8 @@ class VisualizationUpdate(GetVisualizationObjectMixin, BaseUpdate):
     def get_form_class(self):
         try:
             return forms.get_visual_form(self.object.visual_type)
-        except ValueError:
-            raise Http404
+        except ValueError as err:
+            raise Http404 from err
 
     def get_template_names(self):
         visual_type = self.object.visual_type
@@ -655,8 +655,8 @@ class DataPivotQueryNew(DataPivotNew):
         try:
             evidence_type = constants.StudyType(self.kwargs["study_type"])
             _ = prefilters.get_prefilter_cls(None, evidence_type, self.assessment)
-        except (KeyError, ValueError):
-            raise Http404
+        except (KeyError, ValueError) as err:
+            raise Http404 from err
         return evidence_type
 
     def get_form_kwargs(self):

--- a/hawc/apps/udf/schemas.py
+++ b/hawc/apps/udf/schemas.py
@@ -25,16 +25,16 @@ class ModifyTagUDFContent(BaseModel):
             self.tag_binding_obj = models.TagBinding.objects.assessment_qs(self.assessment).get(
                 id=self.tag_binding
             )
-        except ObjectDoesNotExist:
-            raise ValueError("Tag binding not found")
+        except ObjectDoesNotExist as err:
+            raise ValueError("Tag binding not found") from err
 
         # get a reference for this assessment
         try:
             self.reference_obj = Reference.objects.assessment_qs(self.assessment).get(
                 id=self.reference
             )
-        except ObjectDoesNotExist:
-            raise ValueError("Reference not found")
+        except ObjectDoesNotExist as err:
+            raise ValueError("Reference not found") from err
 
         # check that UDF content conforms to schema
         self.tag_binding_obj.form.validate_data(self.content)
@@ -65,8 +65,8 @@ class ModifyModelUDFContent(BaseModel):
         ct = self.content_type.split(".")
         try:
             self.content_type_obj = ContentType.objects.get(app_label=ct[0], model=ct[1])
-        except ObjectDoesNotExist:
-            raise ValueError("Content type not found")
+        except ObjectDoesNotExist as err:
+            raise ValueError("Content type not found") from err
 
         # get an object for this assessment and content type
         try:
@@ -75,16 +75,18 @@ class ModifyModelUDFContent(BaseModel):
                 .objects.assessment_qs(self.assessment)
                 .get(id=self.object_id)
             )
-        except ObjectDoesNotExist:
-            raise ValueError("Object not found")
+        except ObjectDoesNotExist as err:
+            raise ValueError("Object not found") from err
 
         # get a model binding for this assessment for this content type
         try:
             self.binding_obj = models.ModelBinding.objects.assessment_qs(self.assessment).get(
                 content_type=self.content_type_obj
             )
-        except ObjectDoesNotExist:
-            raise ValueError("Model binding not found for this content type and assessment")
+        except ObjectDoesNotExist as err:
+            raise ValueError(
+                "Model binding not found for this content type and assessment"
+            ) from err
 
         # check that UDF content conforms to schema
         self.binding_obj.form.validate_data(self.content)

--- a/hawc/apps/vocab/api.py
+++ b/hawc/apps/vocab/api.py
@@ -77,8 +77,8 @@ class EhvTermViewSet(viewsets.GenericViewSet):
                 namespace=constants.VocabularyNamespace.EHV,
                 deprecated_on__isnull=True,
             )
-        except models.Term.DoesNotExist:
-            raise exceptions.NotFound()
+        except models.Term.DoesNotExist as err:
+            raise exceptions.NotFound() from err
         return Response(term.ehv_endpoint_name())
 
     @action(detail=True, methods=("post",), url_path="related-entity")

--- a/hawc/services/epa/dsstox.py
+++ b/hawc/services/epa/dsstox.py
@@ -55,6 +55,7 @@ class DssSubstance(NamedTuple):
         response = requests.get(
             f"https://api-ccte.epa.gov/chemical/detail/search/by-dtxsid/{dtxsid}",
             headers={"x-api-key": settings.CCTE_API_KEY, "Content-Type": "application/json"},
+            timeout=15,
         )
         response_dict = response.json()
         if response_dict.get("dtxsid") != dtxsid:

--- a/hawc/services/nih/pubmed.py
+++ b/hawc/services/nih/pubmed.py
@@ -60,7 +60,7 @@ class PubMedSearch(PubMedUtility):
             return self.id_count
 
         data = dict(db=self.settings["db"], term=self.settings["term"], rettype="count")
-        r = requests.post(PubMedSearch.base_url, data=data)
+        r = requests.post(PubMedSearch.base_url, data=data, timeout=15)
         if r.status_code == 200:
             txt = ET.fromstring(r.text)
             self.id_count = int(txt.find("Count").text)
@@ -86,7 +86,7 @@ class PubMedSearch(PubMedUtility):
         self.request_count = len(rng)
         for retstart in rng:
             data["retstart"] = retstart
-            resp = requests.post(PubMedSearch.base_url, data=data)
+            resp = requests.post(PubMedSearch.base_url, data=data, timeout=15)
             if resp.status_code == 200:
                 ids.extend(self._parse_ids(resp.text))
             else:
@@ -150,7 +150,7 @@ class PubMedFetch(PubMedUtility):
                 break
 
             data["id"] = self.ids[retstart : retstart + self.settings["retmax"]]
-            resp = requests.post(PubMedFetch.base_url, data=data)
+            resp = requests.post(PubMedFetch.base_url, data=data, timeout=15)
             if resp.status_code == 200:
                 tree = ET.fromstring(resp.text.encode("utf-8"))
                 if tree.tag != "PubmedArticleSet":

--- a/hawc/services/utils/ris.py
+++ b/hawc/services/utils/ris.py
@@ -139,8 +139,8 @@ class ReferenceParser:
             return None
         try:
             return int(value)
-        except ValueError:
-            raise ValueError(f"Invalid year: {value}")
+        except ValueError as err:
+            raise ValueError(f"Invalid year: {value}") from err
 
     def get_doi(self, val) -> str | None:
         doi = self.content.get("doi", None)
@@ -151,8 +151,8 @@ class ReferenceParser:
     def get_id(self, val) -> int:
         try:
             return int(val)
-        except (TypeError, ValueError):
-            raise ValueError(self.ID_MISSING)
+        except (TypeError, ValueError) as err:
+            raise ValueError(self.ID_MISSING) from err
 
     def _get_field(self, fields, default):
         for fld in fields:

--- a/hawc/tools/tables/base.py
+++ b/hawc/tools/tables/base.py
@@ -96,8 +96,8 @@ class BaseTable(BaseCellGroup):
                         if table_cells[cell.row + i][cell.column + j]:
                             raise ValueError(f"Cell overlap at {cell}")
                         table_cells[cell.row + i][cell.column + j] = True
-            except IndexError:
-                raise ValueError(f"{cell} outside of table bounds")
+            except IndexError as err:
+                raise ValueError(f"{cell} outside of table bounds") from err
 
     def sort_cells(self):
         self.cells.sort(key=lambda cell: cell.row_order_index(self.columns))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ exclude = [
 line-length = 100
 target-version = "py311"
 lint.select = ["F", "E", "W", "I", "UP", "S", "B", "T20", "RUF"]
-lint.ignore = ["E501", "B904", "B007", "S308", "S113", "S314", "S603", "S607", "RUF012", "RUF015"]
+lint.ignore = ["E501", "B007", "S308", "S113", "S314", "S603", "S607", "RUF012", "RUF015"]
 lint.unfixable = ["F401", "F841"]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ exclude = [
 line-length = 100
 target-version = "py311"
 lint.select = ["F", "E", "W", "I", "UP", "S", "B", "T20", "RUF"]
-lint.ignore = ["E501", "S308", "S314", "S603", "S607", "RUF012", "RUF015"]
+lint.ignore = ["E501", "S308", "S314", "S603", "RUF012", "RUF015"]
 lint.unfixable = ["F401", "F841"]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ exclude = [
 line-length = 100
 target-version = "py311"
 lint.select = ["F", "E", "W", "I", "UP", "S", "B", "T20", "RUF"]
-lint.ignore = ["E501", "B007", "S308", "S113", "S314", "S603", "S607", "RUF012", "RUF015"]
+lint.ignore = ["E501", "S308", "S113", "S314", "S603", "S607", "RUF012", "RUF015"]
 lint.unfixable = ["F401", "F841"]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ exclude = [
 line-length = 100
 target-version = "py311"
 lint.select = ["F", "E", "W", "I", "UP", "S", "B", "T20", "RUF"]
-lint.ignore = ["E501", "S308", "S113", "S314", "S603", "S607", "RUF012", "RUF015"]
+lint.ignore = ["E501", "S308", "S314", "S603", "S607", "RUF012", "RUF015"]
 lint.unfixable = ["F401", "F841"]
 
 [tool.ruff.lint.isort]

--- a/tests/hawc/apps/animal/test_models.py
+++ b/tests/hawc/apps/animal/test_models.py
@@ -65,7 +65,7 @@ class TestEndpoint:
 def _check_percent_control(inputs, outputs, data_type):
     data = [{"n": el[1], "response": el[2], "stdev": el[3]} for el in inputs]
     models.EndpointGroup.percentControl(data_type, data)
-    for i, d in enumerate(outputs):
+    for i, _d in enumerate(outputs):
         if outputs[i][0] is None:
             assert outputs[i][0] == data[i]["percentControlMean"]
         else:

--- a/tests/hawc/apps/common/test_diagnostics.py
+++ b/tests/hawc/apps/common/test_diagnostics.py
@@ -20,7 +20,7 @@ def test_worker_healthcheck():
 
     # has recent data; should be healthy
     worker_healthcheck.MAX_SIZE = 5
-    for i in range(worker_healthcheck.MAX_SIZE + 2):
+    for _i in range(worker_healthcheck.MAX_SIZE + 2):
         worker_healthcheck.push()
     assert worker_healthcheck.healthy() is True
     assert worker_healthcheck.series().size == worker_healthcheck.MAX_SIZE

--- a/tests/hawc/apps/hawc_admin/test_api.py
+++ b/tests/hawc/apps/hawc_admin/test_api.py
@@ -60,7 +60,7 @@ class TestAdminDiagnosticViewSet:
         # success - admin
         assert client.login(username="admin@hawcproject.org", password="pw") is True
         url = reverse("api:diagnostic-throttle")
-        for i in range(5):
+        for _i in range(5):
             resp = client.get(url)
             assert "identity" in resp.data
 

--- a/tests/hawc/apps/myuser/test_api.py
+++ b/tests/hawc/apps/myuser/test_api.py
@@ -34,7 +34,7 @@ def test_throttle(db_keys):
     factory = APIClient()
 
     throttled = False
-    for i in range(10):
+    for _i in range(10):
         response = factory.post(
             url, {"username": db_keys.pm_user.email, "password": "wrong-password"}
         )


### PR DESCRIPTION
Update code base to accept previously ignored ruff rules.
- Return errors when caught and raised
- Unused iterable variable names prefixed with underscores
- Add a 15 second timeout to any GET and POST requests 

Notes on other ignored rules:
S308: using mark_safe
	- we use this a lot in template tags
	- HERO uses a custom HTML sanitizer that calls mark_safe, which is then flagged as safe inline
	- We could use this approach, or flag all our mark_safes inline

S314: raised when parsing XML input; I believe it'd require a new package to solve (defusedxml)
	- 4 cases; could flag inline & remove from ignore list
	- 3 cases are from parsing pubmed imports, one other is in a lit migration (0012) that parses HERO/RIS

S603: executing subprocess calls on "untrusted" inputs
	- 4 cases; could be flagged as safe inline
	- two of these cases are in the assessment_db_dump.py command for getting the db name from settings
	- two of these are in the git.py commit model that returns last commit info; runs "git log" and grabs output

RUF012: 825 errors. too many to fix. related to mutable class attribute annotations

RUF015: iteration check; 3 failing cases, could be flagged safe inline

