### PR TITLE
Study filter for exports

### DIFF
--- a/hawc/apps/animal/api.py
+++ b/hawc/apps/animal/api.py
@@ -29,10 +29,10 @@ class AnimalAssessmentViewSet(BaseAssessmentViewSet):
 
     def get_endpoint_queryset(self, request):
         published_only = get_published_only(self.assessment, request)
-        study_ids = [int(study_id) for study_id in self.request.query_params.get("study_id", [])]
+        study_ids = [int(study_id) for study_id in self.request.query_params.get("study_ids", [])]
         qs = models.Endpoint.objects.get_qs(self.assessment).published_only(published_only)
         if study_ids:
-            qs.filter(animal_group__experiment__study__in=study_ids)
+            qs = qs.filter(animal_group__experiment__study__in=study_ids)
         return qs
 
     @action(

--- a/hawc/apps/animal/api.py
+++ b/hawc/apps/animal/api.py
@@ -29,7 +29,11 @@ class AnimalAssessmentViewSet(BaseAssessmentViewSet):
 
     def get_endpoint_queryset(self, request):
         published_only = get_published_only(self.assessment, request)
-        return models.Endpoint.objects.get_qs(self.assessment).published_only(published_only)
+        study_ids = [int(study_id) for study_id in self.request.query_params.get("study_id", [])]
+        qs = models.Endpoint.objects.get_qs(self.assessment).published_only(published_only)
+        if study_ids:
+            qs.filter(animal_group__experiment__study__in=study_ids)
+        return qs
 
     @action(
         detail=True,

--- a/hawc/apps/animal/api.py
+++ b/hawc/apps/animal/api.py
@@ -14,7 +14,7 @@ from ..assessment.api import (
 )
 from ..assessment.constants import AssessmentViewSetPermissions
 from ..common.api.utils import get_published_only
-from ..common.helper import FlatExport, cacheable
+from ..common.helper import FlatExport, cacheable, try_parse_list_ints
 from ..common.renderers import PandasRenderers
 from ..common.serializers import ExportQuerySerializer, UnusedSerializer
 from ..common.views import create_object_log
@@ -29,7 +29,7 @@ class AnimalAssessmentViewSet(BaseAssessmentViewSet):
 
     def get_endpoint_queryset(self, request):
         published_only = get_published_only(self.assessment, request)
-        study_ids = [int(study_id) for study_id in self.request.query_params.get("study_ids", [])]
+        study_ids = try_parse_list_ints(request.query_params.get("study_ids"))
         qs = models.Endpoint.objects.get_qs(self.assessment).published_only(published_only)
         if study_ids:
             qs = qs.filter(animal_group__experiment__study__in=study_ids)

--- a/hawc/apps/epiv2/api.py
+++ b/hawc/apps/epiv2/api.py
@@ -12,7 +12,7 @@ from ..assessment.api import (
 from ..assessment.constants import AssessmentViewSetPermissions
 from ..assessment.models import Assessment
 from ..common.api.utils import get_published_only
-from ..common.helper import FlatExport
+from ..common.helper import FlatExport, try_parse_list_ints
 from ..common.renderers import PandasRenderers
 from ..common.serializers import UnusedSerializer
 from ..study.models import Study
@@ -36,7 +36,7 @@ class EpiAssessmentViewSet(BaseAssessmentViewSet):
         """
         assessment: Assessment = self.get_object()
         published_only = get_published_only(assessment, request)
-        study_ids = [int(study_id) for study_id in self.request.query_params.get("study_ids", [])]
+        study_ids = try_parse_list_ints(request.query_params.get("study_ids"))
         qs = (
             models.DataExtraction.objects.get_qs(assessment)
             .published_only(published_only)

--- a/hawc/apps/epiv2/api.py
+++ b/hawc/apps/epiv2/api.py
@@ -43,7 +43,7 @@ class EpiAssessmentViewSet(BaseAssessmentViewSet):
             .complete()
         )
         if study_ids:
-            qs.filter(design__study__in=study_ids)
+            qs = qs.filter(design__study__in=study_ids)
         exporter = exports.EpiV2Exporter.flat_export(qs, filename=f"{assessment}-epi")
         return Response(exporter)
 

--- a/tests/hawc/apps/animal/test_api.py
+++ b/tests/hawc/apps/animal/test_api.py
@@ -49,6 +49,18 @@ class TestAssessmentViewSet:
         )
         self._test_flat_export(rewrite_data_files, fn, url)
 
+    def test_export_study_filter(self, db_keys):
+        url = (
+            reverse("animal:api:assessment-full-export", args=(db_keys.assessment_final,))
+            + "?format=json?"
+        )
+        client = APIClient()
+        assert client.login(username="team@hawcproject.org", password="pw") is True
+        resp = client.get(url, data={"study_ids": 7}, format="application/json")
+        assert len(resp.json()) == 25
+        resp = client.get(url, data={"study_ids": 6}, format="application/json")
+        assert len(resp.json()) == 0
+
     def test_missing_dosing_regime(self, rewrite_data_files: bool, db_keys):
         # create an animal group/endpoint with no dosing regime and make sure the export doesn't cause a 500 error
         fn = "api-animal-assessment-full-export-missing-dr.json"

--- a/tests/hawc/apps/epiv2/test_api.py
+++ b/tests/hawc/apps/epiv2/test_api.py
@@ -28,6 +28,19 @@ class TestEpiAssessmentViewSet:
         key = "api-epiv2-export-1.json"
         check_api_json_data(response.json(), key, rewrite_data_files)
 
+        # use study filter
+        response = client.get(
+            url,
+            data={"unpublished": True, "study_ids": [1]},
+            format="application/json",
+        )
+        assert len(response.json()) == 12
+        response = client.get(
+            url,
+            data={"unpublished": True, "study_ids": [2]},
+        )
+        assert len(response.json()) == 0
+
     def test_study_export(self, rewrite_data_files):
         url = reverse("epiv2:api:assessment-study-export", args=(1,))
 


### PR DESCRIPTION
Add a filter for the animal and epiv2 full exports to limit results to specific study ids using the `study_ids` param.