### PR TITLE
Catch FieldErrors and ValidationErrors in autocomplete

### DIFF
--- a/hawc/apps/common/autocomplete/registry.py
+++ b/hawc/apps/common/autocomplete/registry.py
@@ -1,4 +1,4 @@
-from django.core.exceptions import BadRequest
+from django.core.exceptions import BadRequest, FieldError, ValidationError
 from django.http import Http404
 from django.utils.encoding import force_str
 from django.utils.module_loading import autodiscover_modules
@@ -50,7 +50,7 @@ def get_autocomplete(request, autocomplete_name):
         raise Http404(f"Autocomplete {autocomplete_name} not found")
     try:
         return autocomplete_cls.as_view()(request)
-    except ValueError as err:
+    except (ValueError, ValidationError, FieldError) as err:
         raise BadRequest(str(err))
 
 

--- a/tests/hawc/apps/common/test_autocomplete.py
+++ b/tests/hawc/apps/common/test_autocomplete.py
@@ -9,3 +9,16 @@ def test_null_query():
     client = Client()
     resp = client.get(url + "?q=\0")
     assert resp.status_code == 200
+
+
+@pytest.mark.django_db
+def test_400_errors():
+    # check that bad requests are caught properly
+    url = "/autocomplete/study-studyautocomplete/?assessment_id=1&bioassay=bKRc26YM:%20h4vqyNto"
+    client = Client()
+    resp = client.get(url)
+    assert resp.status_code == 400
+
+    url = "/autocomplete/animal-endpointautocomplete/?animal_group__experiment__study__assessment_id=499&create=false&field=%3C!--&q=e"
+    resp = client.get(url)
+    assert resp.status_code == 400


### PR DESCRIPTION
Prevents autocomplete from causing 500 errors when users send a bad request.