### PR TITLE
Fix missing popover on assessment details page

### DIFF
--- a/hawc/apps/assessment/templates/assessment/assessmentvalue_detail.html
+++ b/hawc/apps/assessment/templates/assessment/assessmentvalue_detail.html
@@ -73,5 +73,5 @@
 {% endblock %}
 
 {% block extrajs %}
-  {% if object.adaf %}{% include "common/helptext_popup_js.html" %}{% endif %}
+  {% include "common/helptext_popup_js.html" %}
 {% endblock %}


### PR DESCRIPTION
Fixes an issue where Confidence popover would not appear if ADAF was not checked for an assesment value.