### PR TITLE
add minimum python coverage number

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
         coverage run -m pytest --record-mode=none
         echo "# Python coverage report" >> $GITHUB_STEP_SUMMARY
         coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
-        coverage html -d coverage -i --fail-under=92
+        coverage html -d coverage -i
     - name: loc
       run: |
         sudo apt-get install -y cloc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
         coverage run -m pytest --record-mode=none
         echo "# Python coverage report" >> $GITHUB_STEP_SUMMARY
         coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
-        coverage html -d coverage -i
+        coverage html -d coverage -i --fail-under=92
     - name: loc
       run: |
         sudo apt-get install -y cloc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,10 @@ omit = [
   "./venv/*",
 ]
 
+[tool.coverage.report]
+fail_under=91.5
+precision=1
+
 [tool.flit.sdist]
 include = [
   "hawc/static/bundles/**/*",


### PR DESCRIPTION
Add a minimum coverage of 91.5%. This will fail in CI/CD if we go below this number. It's expected we'll revisit this number and hopefully increase it quarterly.

> If you provide a --fail-under value, the total percentage covered will be compared to that value. If it is less, the command will exit with a status code of 2, indicating that the total coverage was less than your target. This can be used as part of a pass/fail condition, for example in a continuous integration server. This option isn’t available for annotate.

https://coverage.readthedocs.io/en/latest/cmd.html#html-reporting-coverage-html