### PR TITLE
fix display choices for swagger display /admin/api/swagger/

### DIFF
--- a/hawc/apps/assessment/forms.py
+++ b/hawc/apps/assessment/forms.py
@@ -29,6 +29,7 @@ from ..common.helper import new_window_a
 from ..common.widgets import DateCheckboxInput
 from ..myuser.autocomplete import UserAutocomplete
 from ..study.autocomplete import StudyAutocomplete
+from ..vocab.constants import VocabularyNamespace
 from . import autocomplete, constants, models
 
 
@@ -326,6 +327,7 @@ class AssessmentModulesForm(forms.ModelForm):
         self.fields[
             "enable_risk_of_bias"
         ].label = f"Enable {self.instance.get_rob_name_display().lower()}"
+        self.fields["vocabulary"].choices = VocabularyNamespace.display_choices()
 
     @property
     def helper(self):

--- a/hawc/apps/assessment/models.py
+++ b/hawc/apps/assessment/models.py
@@ -278,7 +278,7 @@ class Assessment(models.Model):
         help_text="What term should be used to refer to risk of bias/study evaluation questions?",
     )
     vocabulary = models.PositiveSmallIntegerField(
-        choices=VocabularyNamespace.display_choices(),
+        choices=VocabularyNamespace.choices,
         default=VocabularyNamespace.EHV,
         blank=True,
         null=True,


### PR DESCRIPTION
Swagger display failed b/c the choices were a callable which converted to executable yaml, which fails in our swagger display. Fix so it's no longer a callable, which fixes the openapi rendering on `/admin/api/swagger/`