### PR TITLE
data pivot - fix conditional formatting on numeric data

### DIFF
--- a/frontend/summary/dataPivot/DataPivotVisualization.js
+++ b/frontend/summary/dataPivot/DataPivotVisualization.js
@@ -484,15 +484,14 @@ class DataPivotVisualization extends D3Plot {
             settings.barchart.conditional_formatting.forEach(function(cf) {
                 switch (cf.condition_type) {
                     case "discrete-style":
-                        var hash = buildStyleMap(cf, false);
+                        // force strings for discrete styles
+                        var hash = buildStyleMap(cf, true);
                         rows.forEach(function(d) {
-                            if (hash.get(d[cf.field_name]) === NULL_CASE) {
-                                return;
+                            let key = _.toString(d[cf.field_name]),
+                                value = hash.get(key);
+                            if (value && value !== NULL_CASE) {
+                                d._styles.barchartBar = get_associated_style("rectangles", value);
                             }
-                            d._styles.barchartBar = get_associated_style(
-                                "rectangles",
-                                hash.get(d[cf.field_name])
-                            );
                         });
                         break;
 
@@ -506,13 +505,13 @@ class DataPivotVisualization extends D3Plot {
                     const styles = "bars";
                     switch (cf.condition_type) {
                         case "discrete-style":
-                            var hash = buildStyleMap(cf, false);
+                            // force strings for discrete styles
+                            var hash = buildStyleMap(cf, true);
                             rows.forEach(function(d) {
-                                if (hash.get(d[cf.field_name]) !== NULL_CASE) {
-                                    d._styles[styles] = get_associated_style(
-                                        "lines",
-                                        hash.get(d[cf.field_name])
-                                    );
+                                let key = _.toString(d[cf.field_name]),
+                                    value = hash.get(key);
+                                if (value && value !== NULL_CASE) {
+                                    d._styles[styles] = get_associated_style("bars", value);
                                 }
                             });
 
@@ -564,7 +563,8 @@ class DataPivotVisualization extends D3Plot {
                             break;
 
                         case "discrete-style":
-                            var mapping = buildStyleMap(cf, false);
+                            // force strings for discrete styles
+                            var mapping = buildStyleMap(cf, true);
                             rows.forEach(d => {
                                 let key = _.toString(d[cf.field_name]),
                                     value = mapping.get(key);

--- a/frontend/summary/dataPivot/DataPivotVisualization.js
+++ b/frontend/summary/dataPivot/DataPivotVisualization.js
@@ -511,7 +511,7 @@ class DataPivotVisualization extends D3Plot {
                                 let key = _.toString(d[cf.field_name]),
                                     value = hash.get(key);
                                 if (value && value !== NULL_CASE) {
-                                    d._styles[styles] = get_associated_style("bars", value);
+                                    d._styles[styles] = get_associated_style("lines", value);
                                 }
                             });
 


### PR DESCRIPTION
Fixed a possible regression in #993.

On data pivots, for all conditional formatting when using the "discrete-style" type of conditional formatting, always cast to a string for both the conditional formatting rule, and the value for the observation in question.

Previously, we used to cast the observation, but not the rule, which could break in some cases.  This should be much more robust, and a string comparison should always be valid for "discrete-style" conditional formatting. The other styles such as "point-size" and "point-color" need to be numeric for scaling and shading gradients, but these discrete rules can use string matches.

As an example, this will fix the control formatting for `/summary/data-pivot/assessment/100500243/DCS-IHD-case-controlcohort-ratios-water-categ-9182/`.