### PR TITLE
github publish hawc client

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,17 +184,3 @@ jobs:
         else
           exit 1
         fi
-    - name: build wheels
-      if: startsWith(github.event.ref, 'refs/tags/') || endsWith(github.event.ref, 'refs/heads/main')
-      run: |
-        python manage.py set_git_commit
-        flit build --format wheel
-        cd client && flit build --format wheel && cd ..
-        cp client/dist/*.whl dist
-    - name: Upload wheels
-      uses: actions/upload-artifact@v4
-      with:
-        name: wheel
-        path: dist/*.whl
-        if-no-files-found: ignore
-        retention-days: 7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  publish hawc-client:
+  publish hawc_client:
     runs-on: ubuntu-22.04
 
     permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,8 @@ jobs:
       id-token: write
 
     environment:
-      environment: publish
-      environment_url: https://test.pypi.org/project/hawc-client/
+      name: publish
+      url: https://test.pypi.org/project/hawc-client/
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  publish hawc_client:
+  publish hawc client:
     runs-on: ubuntu-22.04
 
     permissions:
@@ -36,7 +36,9 @@ jobs:
         run: cd client && flit build
 
       - name: Publish package to TestPyPI
-        if: secrets.PUBLISH_PYPI != ""
+        env:
+          PUBLISH_PYPI: ${{ secrets.PUBLISH_PYPI }}
+        if: env.PUBLISH_PYPI != null
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,9 @@
 name: publish
 
 on:
-  pull_request:
   push:
-    branches:
-      - main
     tags:
       - "hawc-client-[0-9]+.[0-9]+"
-  workflow_dispatch:
 
 jobs:
   publish-hawc-client:
@@ -18,7 +14,7 @@ jobs:
 
     environment:
       name: publish
-      url: https://test.pypi.org/project/hawc-client/
+      url: https://pypi.org/project/hawc-client/
 
     steps:
       - uses: actions/checkout@v4
@@ -35,13 +31,13 @@ jobs:
       - name: Build client
         run: cd client && flit build
 
-      - name: Publish package to TestPyPI
+      - name: Publish package to PyPI
         env:
           PUBLISH_PYPI: ${{ secrets.PUBLISH_PYPI }}
         if: env.PUBLISH_PYPI != null
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: https://test.pypi.org/legacy/
+          repository-url: https://pypi.org/legacy/
           verbose: true
           attestations: true
           print-hash: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,10 @@
 name: publish
 
 on:
+  pull_request:
   push:
-    branches: main
+    branches:
+      - main
     tags:
       - "hawc-client-[0-9]+.[0-9]+"
   workflow_dispatch:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  publish hawc client:
+  publish-hawc-client:
     runs-on: ubuntu-22.04
 
     permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,44 @@
+name: publish
+
+on:
+  push:
+    branches: main
+    tags:
+      - "hawc-client-[0-9]+.[0-9]+"
+  workflow_dispatch:
+
+jobs:
+  publish hawc-client:
+    runs-on: ubuntu-22.04
+
+    permissions:
+      id-token: write
+
+    environment:
+      environment: publish
+      environment_url: https://test.pypi.org/project/hawc-client/
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          architecture: 'x64'
+          cache: 'pip'
+
+      - name: install
+        run: python -m pip install -U pip wheel flit
+
+      - name: Build client
+        run: cd client && flit build
+
+      - name: Publish package to TestPyPI
+        if: secrets.PUBLISH_PYPI != ""
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          verbose: true
+          attestations: true
+          print-hash: true
+          packages-dir: client/dist/

--- a/make.bat
+++ b/make.bat
@@ -1,5 +1,9 @@
 @ECHO off
 
+:: Windows still uses legacy code pages instead of UTF-8
+:: required for djhtml to work properly
+set PYTHONUTF8=1
+
 if "%~1" == "" goto :help
 if /I %1 == help goto :help
 if /I %1 == sync-dev goto :sync-dev


### PR DESCRIPTION
Automatically publish [hawc-client](https://pypi.org/project/hawc-client/) to pypi when a branch is tagged with a `hawc-client` tag.

In addition to changes in this PR:

* Create a new github environment named `publish`, and restrict to the `main` branch
* Add a secret to the `PUBLISH_PYPI` environment variable

As an example, see [this action](https://github.com/shapiromatron/hawc/actions/runs/11485959210/job/31971386217) which resulted in a complete push to test pypi; the final PR made some [changes](https://github.com/shapiromatron/hawc/pull/1124/commits/b57a8d66e9e638015bc1ed120a36b27760685f69) to limit when this can be executed, and only push from the main branch. 


---

Reference:

* https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
* https://github.com/pypa/gh-action-pypi-publish
* https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment


