### PR TITLE
Add team_member API endpoint

### DIFF
--- a/client/hawc_client/assessment.py
+++ b/client/hawc_client/assessment.py
@@ -20,6 +20,16 @@ class AssessmentClient(BaseClient):
         url = f"{self.session.root_url}/assessment/api/assessment/public/"
         return self.session.get(url).json()
 
+    def team_member(self) -> list[dict]:
+        """
+        Retrieves assessments where use is a team member or project manager
+
+        Returns:
+            list[dict]: Public assessment data
+        """
+        url = f"{self.session.root_url}/assessment/api/assessment/team-member/"
+        return self.session.get(url).json()
+
     def create_value(self, data: dict) -> dict:
         """
         Create an assessment value.

--- a/hawc/apps/assessment/api/viewsets.py
+++ b/hawc/apps/assessment/api/viewsets.py
@@ -276,7 +276,7 @@ class Assessment(AssessmentEditViewSet):
         """Get the list of assessments where the user is a team member or project manager."""
         queryset = self.model.objects.filter(
             Q(project_manager=request.user) | Q(team_members=request.user)
-        )
+        ).distinct()
         serializer = serializers.AssessmentSerializer(queryset, many=True)
         return Response(serializer.data)
 

--- a/hawc/apps/assessment/api/viewsets.py
+++ b/hawc/apps/assessment/api/viewsets.py
@@ -271,7 +271,7 @@ class Assessment(AssessmentEditViewSet):
         serializer = serializers.AssessmentSerializer(queryset, many=True)
         return Response(serializer.data)
 
-    @action(detail=False, permission_classes=(permissions.IsAuthenticated,))
+    @action(detail=False, permission_classes=(permissions.IsAuthenticated,), url_path="team-member")
     def team_member(self, request):
         """Get the list of assessments where the user is a team member or project manager."""
         queryset = (

--- a/hawc/apps/assessment/api/viewsets.py
+++ b/hawc/apps/assessment/api/viewsets.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from django.apps import apps
 from django.core.exceptions import ImproperlyConfigured
 from django.db import transaction
-from django.db.models import Count, Model
+from django.db.models import Count, Model, Q
 from django.http import Http404
 from django.urls import reverse
 from django_filters.rest_framework.backends import DjangoFilterBackend
@@ -268,6 +268,15 @@ class Assessment(AssessmentEditViewSet):
     @action(detail=False, permission_classes=(permissions.AllowAny,))
     def public(self, request):
         queryset = self.model.objects.all().public()
+        serializer = serializers.AssessmentSerializer(queryset, many=True)
+        return Response(serializer.data)
+
+    @action(detail=False, permission_classes=(permissions.IsAuthenticated,))
+    def team_member(self, request):
+        """Get the list of assessments where the user is a team member or project manager."""
+        queryset = self.model.objects.filter(
+            Q(project_manager=request.user) | Q(team_members=request.user)
+        )
         serializer = serializers.AssessmentSerializer(queryset, many=True)
         return Response(serializer.data)
 

--- a/hawc/apps/assessment/api/viewsets.py
+++ b/hawc/apps/assessment/api/viewsets.py
@@ -274,9 +274,13 @@ class Assessment(AssessmentEditViewSet):
     @action(detail=False, permission_classes=(permissions.IsAuthenticated,))
     def team_member(self, request):
         """Get the list of assessments where the user is a team member or project manager."""
-        queryset = self.model.objects.filter(
-            Q(project_manager=request.user) | Q(team_members=request.user)
-        ).distinct()
+        queryset = (
+            self.model.objects.filter(
+                Q(project_manager=request.user) | Q(team_members=request.user)
+            )
+            .prefetch_related("project_manager", "team_members", "reviewers", "dtxsids")
+            .distinct()
+        )
         serializer = serializers.AssessmentSerializer(queryset, many=True)
         return Response(serializer.data)
 

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -281,6 +281,12 @@ class TestClient(LiveServerTestCase, TestCase):
         response = client.assessment.public()
         assert isinstance(response, list)
 
+    def test_assessment_team_member(self):
+        client = HawcClient(self.live_server_url)
+        client.authenticate("pm@hawcproject.org", "pw")
+        response = client.assessment.team_member()
+        assert isinstance(response, list)
+
     def test_assessment_create_value(self):
         value_data = {
             "assessment_id": 3,

--- a/tests/hawc/apps/assessment/test_api.py
+++ b/tests/hawc/apps/assessment/test_api.py
@@ -267,6 +267,30 @@ class TestAssessmentViewSet:
         )
         assert resp.status_code == 403
 
+    def test_team_members(self):
+        client = APIClient()
+        url = reverse("assessment:api:assessment-team-member")
+        # Anon client is forbidden
+        resp = client.get(url)
+        assert resp.status_code == 403
+
+        # Reviewer shows 0 assessments
+        assert client.login(username="reviewer@hawcproject.org", password="pw") is True
+        resp = client.get(url)
+        assert resp.status_code == 200
+        assert len(resp.json()) == 0
+
+        # Team member and PM show all 4
+        assert client.login(username="team@hawcproject.org", password="pw") is True
+        resp = client.get(url)
+        assert resp.status_code == 200
+        assert len(resp.json()) == 4
+
+        assert client.login(username="pm@hawcproject.org", password="pw") is True
+        resp = client.get(url)
+        assert resp.status_code == 200
+        assert len(resp.json()) == 4
+
     def test_chemical(self):
         url = reverse("assessment:api:assessment-chemical-search")
 


### PR DESCRIPTION
Adds an API endpoint at `assessment/api/assessment/team_member/` that returns all Assessments where the user is a team member or project manager.