### PR TITLE
Move UDF table on animal group detail page

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -13,9 +13,9 @@ keywords = [
 ]
 classifiers = [
   "Intended Audience :: Science/Research",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 requires-python = ">=3.10"
 dependencies = [

--- a/hawc/apps/animal/templates/animal/animalgroup_detail.html
+++ b/hawc/apps/animal/templates/animal/animalgroup_detail.html
@@ -26,8 +26,8 @@
   </div>
 
   {% if crud == "Read" %}
-    <div id="animalGroupTableMain"></div>
     {% include "udf/fragments/table.html" with object=udf_content %}
+    <div id="animalGroupTableMain"></div>
   {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
Move the UDF table on the animal group detail page to above the endpoint list

![image](https://github.com/user-attachments/assets/a122bd6b-5aea-40b6-a87e-59bd2a8ed650)
 