### PR TITLE
Add label reordering

### DIFF
--- a/hawc/apps/assessment/templates/assessment/fragments/label_edit_row.html
+++ b/hawc/apps/assessment/templates/assessment/fragments/label_edit_row.html
@@ -1,5 +1,5 @@
 
-<div hx-target="this" hx-swap="outerHTML" class="label-edit-row list-group-item d-flex {% if action == 'delete' %} bg-pink {% else %} bg-lightblue {% endif %}{% if form and not form.instance.id %} create-row {% endif %}">
+<div hx-target="this" hx-swap="outerHTML" id="label-edit-row-{{object.pk}}" class="label-edit-row list-group-item d-flex {% if action == 'delete' %} bg-pink {% else %} bg-lightblue {% endif %}{% if form and not form.instance.id %} create-row {% endif %}">
   <form method="post" class="d-flex align-items-center p-1 w-100">
     <div class="col-md-auto flex-fill pl-0 py-2">
       {% crispy form %}
@@ -20,7 +20,8 @@
                           id="label-conf-delete"
                           hx-post="{{ object.get_delete_url }}"
                           hx-indicator="#spinner-{{object.pk}}"
-                          hx-swap="outerHTML swap:1s"><i class="fa fa-trash"></i>&nbsp;Delete</button>
+                          hx-target="#label-listgroup"
+                          hx-swap="outerHTML"><i class="fa fa-trash"></i>&nbsp;Delete</button>
                 </div>
               </div>
             </div>
@@ -38,6 +39,8 @@
             <i class="fa fa-spinner fa-spin align-self-center htmx-indicator" id="spinner-{{object.pk}}" aria-hidden="true"></i>
             <button class="btn btn-primary px-4 py-2 ml-2"
                     id="binding-update"
+                    hx-swap="outerHTML"
+                    hx-target="#label-listgroup"
                     hx-post="{% url 'assessment:label-htmx' object.pk 'update' %}"
                     hx-indicator="#spinner-{{object.pk}}">
               <i class="fa fa-fw fa-save"></i>&nbsp;
@@ -55,6 +58,8 @@
         <i class="fa fa-spinner fa-spin htmx-indicator mr-2" id="spinner-{{object.pk}}" aria-hidden="true"></i>
         <button class="btn btn-primary px-4 py-2"
                 id="binding-create"
+                hx-target="#label-listgroup"
+                hx-swap="outerHTML"
                 hx-post="{% url 'assessment:label-htmx' assessment.pk 'create' %}"
                 hx-indicator="#spinner-{{object.pk}}">
           <i class="fa fa-fw fa-save"></i>&nbsp;Create
@@ -69,4 +74,5 @@
     </div>
   </form>
   {{ form.media }}
+  {% include "common/helptext_popup_js.html" %}
 </div>

--- a/hawc/apps/assessment/templates/assessment/fragments/label_list.html
+++ b/hawc/apps/assessment/templates/assessment/fragments/label_list.html
@@ -1,0 +1,7 @@
+<div class="my-2 box-shadow-minor list-group py-0" id="label-listgroup">
+  {% for object in object_list %}
+    {% include "assessment/fragments/label_row.html" with canEdit=True %}
+  {% endfor %}
+  <div class="alert alert-info text-center show-only-child my-0">No labels created (yet).</div>
+  <div class="create-row hidden"></div>
+</div>

--- a/hawc/apps/assessment/templates/assessment/fragments/label_row.html
+++ b/hawc/apps/assessment/templates/assessment/fragments/label_row.html
@@ -11,7 +11,7 @@
     <div class="row">
       {% widthratio object.depth 10 20 as marginLeft %}
       <i class="fa fa-spinner fa-spin htmx-indicator align-self-start m-1" id="spinner-{{object.pk}}" aria-hidden="true"></i>
-      <p class="label align-self-start mt-0" style="background-color: {{object.color}}; color: {{object.text_color}}; {% if object.depth > 0 %} margin-left: {{ marginLeft|add:"-4" }}rem;{% endif %}" label_url="{% url 'assessment:labeled-items' assessment.pk %}?label={{object.id}}">{{object.name}}</p>
+      <p class="label align-self-start mt-0" style="background-color: {{object.color}}; color: {{object.text_color}}; {% if object.depth > 0 %} margin-left: {{ marginLeft|add:"-4" }}rem;{% endif %}" title="Click to view labeled objects" label_url="{% url 'assessment:labeled-items' assessment.pk %}?label={{object.id}}">{{object.name}}</p>
       <div class="card mx-3 d-inline-block align-self-start {{ object.published|yesno:'border-success text-success,text-muted' }}" title="{{ object.published|yesno:'Published,Unpublished' }}">
         <p class="m-0"><i class="fa fa-{{ object.published|yesno:'eye,eye-slash' }} px-1"></i></p>
       </div>
@@ -19,6 +19,3 @@
     </div>
   </div>
 </div>
-{% if action == 'create' %}
-  <div class="create-row hidden"></div>
-{% endif %}

--- a/hawc/apps/assessment/templates/assessment/label_list.html
+++ b/hawc/apps/assessment/templates/assessment/label_list.html
@@ -12,13 +12,7 @@
     </button>
   </div>
   <div>
-    <div class="my-2 box-shadow-minor list-group py-0" id="label-listgroup">
-      {% for object in object_list %}
-        {% include "assessment/fragments/label_row.html" with canEdit=True %}
-      {% endfor %}
-      <div class="alert alert-info text-center show-only-child my-0">No labels created (yet).</div>
-      <div class="create-row hidden"></div>
-    </div>
+    {% include "assessment/fragments/label_list.html" %}
   </div>
 {% endblock content %}
 
@@ -30,7 +24,6 @@
       e.stopPropagation();
     }
     $(window).ready(function() {
-      window.app.HAWCUtils.addScrollHtmx("label-edit-row", "label-row", "label-conf-delete");
       $(".label").on("click", linkLabel);
     });
     $("body").on("htmx:afterSwap", function(evt) {


### PR DESCRIPTION
Add the ability to optionally reorder labels "after" other sibling labels.
- Checks that 'parent' field matches the parent of the 'after' sibling field, if given
- Returns and refreshes entire label list on successful updates, creates, and deletes, so the list is always accurate
- Removes scroll HTMX animation--unnecessary in this case since the forms are so small, and it feels a bit annoying if you're trying to see the entire tree while creating a new label

![image](https://github.com/user-attachments/assets/078edb93-1b54-400a-b3ee-4baabd019af0)
