### PR TITLE
Update Wagtail to LTS 6.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "inflection==0.5.1",
   "pyyaml==6.0.1",
   "gunicorn==22.0.0",
-  "wagtail~=6.1.3",
+  "wagtail==6.3",
   "wagtail-draftail-anchors==0.6.0",
   # tasks
   "celery==5.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,10 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 requires-python = ">=3.12"
+# see https://peps.python.org/pep-0440/#version-specifiers
 dependencies = [
   # web application
-  "Django~=5.1.1",
+  "Django~=5.1.3",
   "django-crispy-forms==2.2",
   "crispy-bootstrap4==2024.1",
   "django-filter==24.2",
@@ -33,7 +34,7 @@ dependencies = [
   "inflection==0.5.1",
   "pyyaml==6.0.1",
   "gunicorn==22.0.0",
-  "wagtail==6.3",
+  "wagtail~=6.3.1",
   "wagtail-draftail-anchors==0.6.0",
   # tasks
   "celery==5.4.0",


### PR DESCRIPTION
Update Wagtail to 6.3. Reviewed 6.3 LTS [Release Notes](https://docs.wagtail.org/en/stable/releases/6.3.html)