### PR TITLE
display CI failure based on coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
         fi
         coverage run -m pytest --record-mode=none
         echo "# Python coverage report" >> $GITHUB_STEP_SUMMARY
-        coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
+        coverage report --format=markdown -i >> $GITHUB_STEP_SUMMARY || true
         coverage html -d coverage -i
     - name: loc
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under=99.9
+fail_under=91.8
 precision=1
 
 [tool.flit.sdist]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under=91.5
+fail_under=99.9
 precision=1
 
 [tool.flit.sdist]


### PR DESCRIPTION
If CI fails because our coverage number decreases, it was not previously clear to the developer as to why the pipeline failed.  This PR should better display to the user why a failure occurred.

Now, we see a clear message with the failure:

```
========== 769 passed, 24 skipped, 728 warnings in 143.88s (0:02:23) ===========
Wrote HTML report to coverage/index.html
Coverage failure: total of 91.9 is less than fail-under=99.9
Error: Process completed with exit code 2.
```

In addition, increased our minimum coverage number.