### PR TITLE
Set order for label displays

### DIFF
--- a/hawc/apps/assessment/filterset.py
+++ b/hawc/apps/assessment/filterset.py
@@ -182,7 +182,7 @@ class LabeledItemFilterset(BaseFilterSet):
 
     def filter_queryset(self, queryset):
         queryset = super().filter_queryset(queryset)
-        return queryset.filter(label__assessment=self.assessment)
+        return queryset.filter(label__assessment=self.assessment).order_by("label__path")
 
     def filter_title(self, queryset, name, value):
         if not value:

--- a/hawc/apps/assessment/managers.py
+++ b/hawc/apps/assessment/managers.py
@@ -367,7 +367,7 @@ class LabeledItemQuerySet(QuerySet):
             )
             # filtering for objects matching all labels
             matched = matched.intersection(objects) if i > 0 else set(objects)
-        return qs.filter(object_info__in=matched)
+        return qs.filter(object_info__in=matched).order_by("label__path")
 
 
 class LabeledItemManager(BaseManager):

--- a/hawc/apps/assessment/templates/assessment/labeleditem_list.html
+++ b/hawc/apps/assessment/templates/assessment/labeleditem_list.html
@@ -20,7 +20,7 @@
             {% if obj_perms.edit %}
               <i class="text-secondary fa fa-{{ object.content_object.published|yesno:'eye,eye-slash' }} px-1 mr-2" title="{{object.content_object|model_verbose_name|title}} is {{ object.content_object.published|yesno:'published,unpublished' }}"></i>
             {% endif %}
-            {% for labeled_item in object.content_object.labels.all %}
+            {% for labeled_item in object.content_object.get_ordered_labels.all %}
               {% if labeled_item.label.published or obj_perms.edit %}
                 {% include "assessment/fragments/label.html" with label=labeled_item.label %}
               {% endif %}

--- a/hawc/apps/assessment/views.py
+++ b/hawc/apps/assessment/views.py
@@ -1056,7 +1056,7 @@ class LabelItem(HtmxView):
     def label_indicators(self, request: HttpRequest, *args, **kwargs):
         if not self.assessment.user_can_view_object(request.user):
             raise PermissionDenied()
-        labels = models.Label.objects.get_applied(self.content_object)
+        labels = models.Label.objects.get_applied(self.content_object).order_by("path")
         if not self.assessment.user_can_edit_object(request.user):
             labels = labels.filter(published=True)
         context = dict(

--- a/hawc/apps/summary/filterset.py
+++ b/hawc/apps/summary/filterset.py
@@ -49,7 +49,9 @@ class VisualFilterSet(BaseFilterSet):
         return queryset.prefetch_related(
             Prefetch(
                 "labels",
-                queryset=LabeledItem.objects.filter(query).select_related("label"),
+                queryset=LabeledItem.objects.filter(query)
+                .select_related("label")
+                .order_by("label__path"),
                 to_attr="visible_labels",
             )
         )
@@ -124,12 +126,16 @@ class DataPivotFilterSet(VisualFilterSet):
         return queryset.prefetch_related(
             Prefetch(
                 "datapivotquery__labels",
-                queryset=LabeledItem.objects.filter(filters).select_related("label"),
+                queryset=LabeledItem.objects.filter(filters)
+                .select_related("label")
+                .order_by("label__path"),
                 to_attr="visible_query_labels",
             ),
             Prefetch(
                 "datapivotupload__labels",
-                queryset=LabeledItem.objects.filter(filters).select_related("label"),
+                queryset=LabeledItem.objects.filter(filters)
+                .select_related("label")
+                .order_by("label__path"),
                 to_attr="visible_upload_labels",
             ),
         )

--- a/hawc/apps/summary/models.py
+++ b/hawc/apps/summary/models.py
@@ -97,6 +97,9 @@ class SummaryTable(models.Model):
     def get_api_list_url(cls, assessment_id: int):
         return reverse("summary:api:summary-table-list") + f"?assessment_id={assessment_id}"
 
+    def get_ordered_labels(self):
+        return self.labels.order_by("label__path")
+
     def get_absolute_url(self):
         return reverse(
             "summary:tables_detail",
@@ -264,6 +267,9 @@ class Visual(models.Model):
 
     def get_api_heatmap_datasets(self):
         return reverse("summary:api:assessment-heatmap-datasets", args=(self.assessment_id,))
+
+    def get_ordered_labels(self):
+        return self.labels.order_by("label__path")
 
     def get_visual_type_display(self):
         label = constants.VisualType(self.visual_type).label
@@ -709,6 +715,9 @@ class DataPivotUpload(DataPivot):
     def visual_type(self):
         return "Data pivot (file upload)"
 
+    def get_ordered_labels(self):
+        return self.labels.order_by("label__path")
+
     def get_dataset(self) -> FlatExport:
         worksheet_name = self.worksheet_name if len(self.worksheet_name) > 0 else 0
         df = pd.read_excel(self.excel_file.file, sheet_name=worksheet_name)
@@ -747,6 +756,9 @@ class DataPivotQuery(DataPivot):
     )
     prefilters = models.JSONField(default=dict)
     labels = GenericRelation(LabeledItem, related_query_name="datapivot_queries")
+
+    def get_ordered_labels(self):
+        return self.labels.order_by("label__path")
 
     def clean(self):
         count = self.get_queryset().count()


### PR DESCRIPTION
Applies an order to labeled items based on the label path.
Before:
![image](https://github.com/user-attachments/assets/e20d1f73-e928-4b33-a59d-f39d68445bd5)

After:
![image](https://github.com/user-attachments/assets/82b5e765-bf14-45aa-b92c-b508aba4294f)

Tree:
![image](https://github.com/user-attachments/assets/2c260b7b-c3f7-42e7-b6ef-db616a1902fe)

