### PR TITLE
show publish items regardless of which modules are enabled

### DIFF
--- a/hawc/apps/assessment/templates/assessment/assessment_detail.html
+++ b/hawc/apps/assessment/templates/assessment/assessment_detail.html
@@ -47,8 +47,7 @@
           <a class="dropdown-item" href="{% url 'invitro:endpointcategory_update' object.pk %}">In vitro endpoint categories</a>
         {% endif%}
 
-          <!-- data cleanup -->
-        {% if assessment.enable_data_extraction and obj_perms.edit_assessment or assessment.enable_risk_of_bias and obj_perms.edit_assessment %}
+        {% if obj_perms.edit_assessment %}
           <div class="dropdown-divider"></div>
           <span class="dropdown-header">Data cleanup views</span>
           {% if assessment.enable_data_extraction %}


### PR DESCRIPTION
Fixed bug where publish items is hidden from project managers if data extraction and study evaluation modules are disabled; we want to show that in any case.

This is on the assessment actions menu for a project manager `/assessment/:id/`

