### PR TITLE
drop duplicates for pandas pivots

### DIFF
--- a/hawc/apps/animal/exports.py
+++ b/hawc/apps/animal/exports.py
@@ -525,12 +525,16 @@ class EndpointGroupFlatCompleteExporter(Exporter):
 
 class EndpointGroupFlatComplete(FlatFileExporter):
     def handle_doses(self, df: pd.DataFrame, assessment_id: int) -> pd.DataFrame:
-        df2 = pd.DataFrame(
-            models.DoseGroup.objects.filter(
-                dose_regime__dosed_animals__experiment__study__assessment_id=assessment_id
-            ).values("dose_regime_id", "dose_units__name", "dose_group_id", "dose")
-        ).pivot(
-            index=["dose_regime_id", "dose_group_id"], columns="dose_units__name", values="dose"
+        df2 = (
+            pd.DataFrame(
+                models.DoseGroup.objects.filter(
+                    dose_regime__dosed_animals__experiment__study__assessment_id=assessment_id
+                ).values("dose_regime_id", "dose_units__name", "dose_group_id", "dose")
+            )
+            .drop_duplicates()
+            .pivot(
+                index=["dose_regime_id", "dose_group_id"], columns="dose_units__name", values="dose"
+            )
         )
         df2.columns = [f"doses-{name}" for name in df2.columns]
         # cast to Int64; needed all values in a dataframe are None for this field

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ requires-python = ">=3.12"
 # see https://peps.python.org/pep-0440/#version-specifiers
 dependencies = [
   # web application
-  "Django~=5.1.3",
+  "Django~=5.1.4",
   "django-crispy-forms==2.2",
   "crispy-bootstrap4==2024.1",
   "django-filter==24.2",


### PR DESCRIPTION
We recently switched from groupby to pivot to improve performance of data frame exports (#1099), but pivots can fail if there are duplicated data in the pivot table.  This PR drops duplicates prior to creating the pivot, in the event that there are duplicates.

This was identified in a rare case, where it appears a user entered multiple dosing regime dose groups that all have the same dose units. A subsequent PR will prevent data entry to prevent these issues.


Bonus - upgrade [django](https://www.djangoproject.com/weblog/2024/dec/04/security-releases/)