### PR TITLE
add unpublished argument to bmd endpoints client

### DIFF
--- a/client/hawc_client/animal.py
+++ b/client/hawc_client/animal.py
@@ -146,9 +146,10 @@ class AnimalClient(BaseClient):
             data = self._invert_endpoints(data)
         return data
 
-    def bmds_endpoints(self, assessment_id: int) -> pd.DataFrame:
+    def bmds_endpoints(self, assessment_id: int, unpublished: bool = False) -> pd.DataFrame:
         url = f"{self.session.root_url}/ani/api/assessment/{assessment_id}/bmds-export/"
-        response_json = self.session.get(url).json()
+        params = {"unpublished": unpublished}
+        response_json = self.session.get(url, params=params).json()
         return pd.DataFrame(response_json)
 
     def metadata(self) -> dict:

--- a/docs/docs/client.md
+++ b/docs/docs/client.md
@@ -58,6 +58,10 @@ Client tutorials for common operations are below:
 
 ### Changelog
 
+#### [2025-1](https://pypi.org/project/hawc-client/2025.1/) (TBD)
+
+* Add `unpublished` parameter to bmd dataset download
+
 #### [2024-4](https://pypi.org/project/hawc-client/2024.4/) (January 2025)
 
 * Added assessment team member API endpoint to retrieve assessments a user is a member of


### PR DESCRIPTION
Update client so you can request unpublished BMD modeling for an assessment.