### PR TITLE
add ToxRef migration script

### DIFF
--- a/scripts/client/toxref_hawc_migrations.ipynb
+++ b/scripts/client/toxref_hawc_migrations.ipynb
@@ -1,0 +1,626 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Migrate data from ToxRefDB to HAWC\n",
+    "\n",
+    "Resource: User Guide (https://nepis.epa.gov/Exe/ZyPDF.cgi/P1015KWT.PDF?Dockey=P1015KWT.PDF)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "import django\n",
+    "import pandas as pd\n",
+    "import psycopg2\n",
+    "from asgiref.sync import sync_to_async  # access the ORM safely within the notebook\n",
+    "\n",
+    "from hawc.apps.animalv2 import constants\n",
+    "from hawc.apps.animalv2.models import (\n",
+    "    AnimalGroup,\n",
+    "    Chemical,\n",
+    "    DataExtraction,\n",
+    "    DoseGroup,\n",
+    "    DoseResponseGroupLevelData,\n",
+    "    Endpoint,\n",
+    "    Experiment,\n",
+    "    ObservationTime,\n",
+    "    Treatment,\n",
+    ")\n",
+    "from hawc.apps.assessment.models import DoseUnits, DSSTox, Species, Strain\n",
+    "from hawc.apps.study.models import Study\n",
+    "from hawc.apps.vocab.models import Observation\n",
+    "\n",
+    "os.environ.setdefault(\"DJANGO_SETTINGS_MODULE\", \"hawc.main.settings.local\")\n",
+    "django.setup()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Set up database functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 763,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Connected to hawc-fixture successfully!\n"
+     ]
+    }
+   ],
+   "source": [
+    "def connect_to_db(db_name, user, password, host, port):\n",
+    "    conn = psycopg2.connect(dbname=db_name, user=user, password=password, host=host, port=port)\n",
+    "    print(f\"Connected to {db_name} successfully!\")\n",
+    "    return conn\n",
+    "\n",
+    "\n",
+    "def fetch_data_from_source(query, conn):\n",
+    "    with conn.cursor() as cursor:\n",
+    "        cursor.execute(query)\n",
+    "        return cursor.fetchall()\n",
+    "\n",
+    "\n",
+    "async def create_model_objects(model, data):\n",
+    "    for row in data:\n",
+    "        await sync_to_async(model.objects.get_or_create)(**row)\n",
+    "\n",
+    "\n",
+    "# set to toxref db\n",
+    "source_conn = connect_to_db(\"hawc-fixture\", \"hawc\", \"\", \"localhost\", \"5432\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Stream ToxRefDB data to excel\n",
+    "\n",
+    "Done for data manipulation convenience. Split by study type to avoid creating files too large; this may be redundant "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 764,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "### fetching toxref data ###\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Study types are found in the User Guide (https://nepis.epa.gov/Exe/ZyPDF.cgi/P1015KWT.PDF?Dockey=P1015KWT.PDF)\n",
+    "# Data is split by study to avoid reading too much into memory at once\n",
+    "STUDY_TYPES = [\"CHR\", \"SUB\", \"SAC\", \"DEV\", \"MGR\", \"REP\", \"DNT\", \"ACU\", \"OTH\"]\n",
+    "\n",
+    "# Define query for study dose-response data\n",
+    "## left join to get studies without tg or dose info?\n",
+    "query = \"\"\"SELECT * FROM prod_toxrefdb_2_1.chemical\n",
+    "LEFT JOIN prod_toxrefdb_2_1.study ON study.chemical_id=chemical.chemical_id\n",
+    "LEFT JOIN prod_toxrefdb_2_1.tg ON tg.study_id=study.study_id\n",
+    "LEFT JOIN prod_toxrefdb_2_1.dose ON dose.study_id=study.study_id\n",
+    "LEFT JOIN prod_toxrefdb_2_1.dtg ON dtg.tg_id=tg.tg_id AND dose.dose_id=dtg.dose_id\n",
+    "LEFT JOIN prod_toxrefdb_2_1.tg_effect ON tg.tg_id=tg_effect.tg_id\n",
+    "LEFT JOIN prod_toxrefdb_2_1.effect ON effect.effect_id=tg_effect.effect_id\n",
+    "LEFT JOIN prod_toxrefdb_2_1.endpoint ON endpoint.endpoint_id=effect.endpoint_id\n",
+    "LEFT JOIN prod_toxrefdb_2_1.dtg_effect ON tg_effect.tg_effect_id=dtg_effect.tg_effect_id AND dtg.dtg_id=dtg_effect.dtg_id\n",
+    "WHERE study.study_type = %s\"\"\"\n",
+    "\n",
+    "# fetch data from toxref\n",
+    "print(\"### fetching toxref data ###\")\n",
+    "\n",
+    "cur = source_conn.cursor()\n",
+    "\n",
+    "for type in STUDY_TYPES:\n",
+    "    # Define the output CSV file\n",
+    "    output_file = f\"{type}_data.csv\"\n",
+    "\n",
+    "    # Use the COPY command to stream data to the CSV file\n",
+    "    with open(output_file, \"w\") as f_output:\n",
+    "        cur.execute(query, (type,))\n",
+    "        executed_query = cur.query.decode(\"utf-8\")\n",
+    "        cur.copy_expert(f\"COPY ({executed_query}) TO STDOUT WITH CSV HEADER\", f_output)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create Experiment and Chemical objects\n",
+    "Uses info from ToxRefDB study and chemical tables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 765,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "### creating dsstox items ###\n",
+      "[{'dtxsid': 'DTXSID9034496'}, {'dtxsid': 'DTXSID7034676'}, {'dtxsid': 'DTXSID9034496'}, {'dtxsid': 'DTXSID1037806'}, {'dtxsid': 'DTXSID7034676'}, {'dtxsid': 'DTXSID9034496'}, {'dtxsid': 'DTXSID1024174'}, {'dtxsid': 'DTXSID1032640'}, {'dtxsid': 'DTXSID6034928'}, {'dtxsid': 'DTXSID8040222'}, {'dtxsid': 'DTXSID9034496'}, {'dtxsid': 'DTXSID0032572'}, {'dtxsid': 'DTXSID5047299'}, {'dtxsid': 'DTXSID8024151'}, {'dtxsid': 'DTXSID5047320'}, {'dtxsid': 'DTXSID4020791'}, {'dtxsid': 'DTXSID9032610'}, {'dtxsid': 'DTXSID6032354'}, {'dtxsid': 'DTXSID6032358'}]\n"
+     ]
+    }
+   ],
+   "source": [
+    "dsstox_array = []\n",
+    "\n",
+    "# Read in all chemical dsstox_substance_ids and create HAWC objects\n",
+    "for type in STUDY_TYPES:\n",
+    "    data_path = f\"{type}_data.csv\"\n",
+    "    df = pd.read_csv(data_path)\n",
+    "    dsstox = df[\"dsstox_substance_id\"].unique()\n",
+    "\n",
+    "    # add dtxsids to assessment\n",
+    "    dsstox_array.extend([{\"dtxsid\": value} for value in dsstox])\n",
+    "\n",
+    "print(\"### creating dsstox items ###\")\n",
+    "await create_model_objects(DSSTox, dsstox_array)\n",
+    "print(dsstox_array)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "### Create a new HAWC Experiment and Chemical for each ToxRef study item ###\n"
+     ]
+    },
+    {
+     "ename": "IndexError",
+     "evalue": "list index out of range",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "Cell \u001b[1;32mIn[766], line 24\u001b[0m\n\u001b[0;32m     17\u001b[0m row \u001b[38;5;241m=\u001b[39m df[df[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mstudy_id\u001b[39m\u001b[38;5;124m'\u001b[39m] \u001b[38;5;241m==\u001b[39m study_id]\u001b[38;5;241m.\u001b[39miloc[\u001b[38;5;241m0\u001b[39m]\n\u001b[0;32m     19\u001b[0m \u001b[38;5;66;03m# get all studies, label by hero_id?\u001b[39;00m\n\u001b[0;32m     20\u001b[0m \u001b[38;5;66;03m# reference correct one here\u001b[39;00m\n\u001b[0;32m     21\u001b[0m \u001b[38;5;66;03m# for first run, make one if it's not made\u001b[39;00m\n\u001b[0;32m     22\u001b[0m \n\u001b[0;32m     23\u001b[0m \u001b[38;5;66;03m# Create a new experiment object\u001b[39;00m\n\u001b[1;32m---> 24\u001b[0m study \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mawait\u001b[39;00m sync_to_async(Experiment\u001b[38;5;241m.\u001b[39mobjects\u001b[38;5;241m.\u001b[39mget_or_create)(\u001b[38;5;28mid\u001b[39m\u001b[38;5;241m=\u001b[39m\u001b[43mstudy_map\u001b[49m\u001b[43m[\u001b[49m\u001b[43mrow\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mstudy_source_id\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m]\u001b[49m\u001b[38;5;241m.\u001b[39mid)\n\u001b[0;32m     26\u001b[0m experiment \u001b[38;5;241m=\u001b[39m {\n\u001b[0;32m     27\u001b[0m     \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mstudy_id\u001b[39m\u001b[38;5;124m'\u001b[39m: study_map[row[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mstudy_source_id\u001b[39m\u001b[38;5;124m\"\u001b[39m]]\u001b[38;5;241m.\u001b[39mid,\n\u001b[0;32m     28\u001b[0m     \u001b[38;5;66;03m# Experiment name; duration, admin_route, study_type, chemical. Ex: 30 day oral CHR Isazofos\u001b[39;00m\n\u001b[1;32m   (...)\u001b[0m\n\u001b[0;32m     34\u001b[0m     \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mcomments\u001b[39m\u001b[38;5;124m'\u001b[39m: row[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mstudy_comment\u001b[39m\u001b[38;5;124m\"\u001b[39m] \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;124m'\u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[0;32m     35\u001b[0m }\n\u001b[0;32m     37\u001b[0m exp \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mawait\u001b[39;00m sync_to_async(Experiment\u001b[38;5;241m.\u001b[39mobjects\u001b[38;5;241m.\u001b[39mcreate)(\u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mexperiment)\n",
+      "\u001b[1;31mIndexError\u001b[0m: list index out of range"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"### Create a new HAWC Experiment and Chemical for each ToxRef study item ###\")\n",
+    "\n",
+    "# Read the CSV file into a DataFrame\n",
+    "study_to_exp_map = {}\n",
+    "toxref_to_hawc_chem_map = {}\n",
+    "studies = Study.objects.all()\n",
+    "\n",
+    "study_map = await sync_to_async(lambda: [{study.study_identifier: study} for study in studies])()\n",
+    "\n",
+    "for type in STUDY_TYPES:\n",
+    "    data_path = f\"{type}_data.csv\"\n",
+    "    df = pd.read_csv(data_path)\n",
+    "    unique_studies = df[\"study_id\"].unique()\n",
+    "\n",
+    "    for study_id in unique_studies:\n",
+    "        # get the first row for each study\n",
+    "        row = df[df[\"study_id\"] == study_id].iloc[0]\n",
+    "\n",
+    "        # Create a new experiment object\n",
+    "\n",
+    "        # assumption: study_source_id will map to HAWC Study study_identifier\n",
+    "        experiment = {\n",
+    "            \"study_id\": study_map[row[\"study_source_id\"]].id,\n",
+    "            # Experiment name; duration, admin_route, study_type, chemical. Ex: 30 day oral CHR Isazofos\n",
+    "            \"name\": f'{row[\"dose_end\"]} {row[\"dose_end_unit\"]} {row[\"admin_route\"]} {row[\"study_type\"]} {row[\"preferred_name\"]}',\n",
+    "            \"design\": \"\",  # TODO: possibly s['study_type'], unsure.  predefined constants are 'todo' rn\n",
+    "            \"has_multiple_generations\": True if row[\"study_type\"] == \"MGR\" else False,\n",
+    "            \"guideline_compliance\": row[\"study_source\"],  # ask abt this text field\n",
+    "            \"guideline\": row[\"study_type_guideline\"],\n",
+    "            \"comments\": row[\"study_comment\"] or \"\",\n",
+    "        }\n",
+    "\n",
+    "        exp = await sync_to_async(Experiment.objects.create)(**experiment)\n",
+    "\n",
+    "        # map ToxRefDB study to HAWC experiment\n",
+    "        study_to_exp_map[study_id] = exp.id\n",
+    "\n",
+    "        # Create a new HAWC Chemical for each ToxRef study (many-to-one study->chemical to one-to-one)\n",
+    "        # Each toxref study is linked to only one chemical\n",
+    "\n",
+    "        vehicle = row[\"vehicle\"]\n",
+    "        if vehicle is None:\n",
+    "            inhalation_study = row[\"admin_route\"].lower() == \"inhalation\"\n",
+    "            vehicle = \"not reported, assumed clean air.\" if inhalation_study else \"not reported\"\n",
+    "\n",
+    "        chemical = {\n",
+    "            \"name\": row[\"preferred_name\"],\n",
+    "            \"dtxsid_id\": row[\"dsstox_substance_id\"],\n",
+    "            \"cas\": row[\"casrn\"],\n",
+    "            \"experiment_id\": exp.id,\n",
+    "            \"source\": row[\"substance_source_name\"] or \"\",\n",
+    "            \"purity\": row[\"substance_purity\"] or \"\",\n",
+    "            \"comments\": row[\"substance_comment\"] or \"\",\n",
+    "            # TODO: add \"assumed clean air\" for unreported inhalation studies\n",
+    "            \"vehicle\": vehicle,\n",
+    "        }\n",
+    "\n",
+    "        # TODO: bulk create\n",
+    "        chem = await sync_to_async(Chemical.objects.create)(**chemical)\n",
+    "        toxref_to_hawc_chem_map[row[\"chemical_id\"]] = chem.id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create HAWC Animalgroup objects\n",
+    "\n",
+    "Uses info from ToxRefDB tg and study tables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# map ToxRef field values to HAWC constants\n",
+    "\n",
+    "\n",
+    "def map_to_const(value, const):\n",
+    "    if const == constants.Lifestage:\n",
+    "        if \"pregnancy\" in value:\n",
+    "            value = constants.Lifestage.AG.label\n",
+    "        if \"fetal\" in value:\n",
+    "            value = constants.Lifestage.DEV.label  # TODO: is this a valid map\n",
+    "\n",
+    "    elif const == constants.ObservationTimeUnits:\n",
+    "        time_arr = [\"week\", \"month\", \"day\"]\n",
+    "\n",
+    "        if value in time_arr:\n",
+    "            value = f\"{value}s\"\n",
+    "        elif value == \"GD\":\n",
+    "            value = constants.ObservationTimeUnits.GD.label\n",
+    "        elif value == \"PND\":\n",
+    "            value = constants.ObservationTimeUnits.PND.label\n",
+    "        elif value == \"LD\":\n",
+    "            value = constants.ObservationTimeUnits.DAY.label  # does LD map to day?\n",
+    "        elif value == \"lactation week\":\n",
+    "            value = constants.ObservationTimeUnits.WK.label  # confirm\n",
+    "\n",
+    "    for c in const:\n",
+    "        if c.label.lower() == value.lower():\n",
+    "            return c\n",
+    "    return None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create a new HAWC animalgroup, species, and strain for each ToxRef tg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "animalgroup_objects = []\n",
+    "toxref_to_hawc_tg_map = {}\n",
+    "\n",
+    "for type in STUDY_TYPES:\n",
+    "    data_path = f\"{type}_data.csv\"\n",
+    "    df = pd.read_csv(data_path)\n",
+    "    df[\"tg_comment\"] = df[\"tg_comment\"].fillna(\"\")  # clean this field\n",
+    "    df[\"life_stage\"] = df[\"life_stage\"].fillna(\"\")\n",
+    "\n",
+    "    unique_tgs = df[\"tg_id\"].unique()\n",
+    "\n",
+    "    for tg_id in unique_tgs:\n",
+    "        # get the first row for each treatment group\n",
+    "        row = df[df[\"tg_id\"] == tg_id].iloc[0]\n",
+    "\n",
+    "        # not all treatment groups will have an effect\n",
+    "        if not pd.isna(row[\"tg_effect_id\"]):\n",
+    "            # create new species and strain if necessary\n",
+    "            species, created = await sync_to_async(Species.objects.get_or_create)(\n",
+    "                name=row[\"species\"]\n",
+    "            )\n",
+    "            strain, created = await sync_to_async(Strain.objects.get_or_create)(\n",
+    "                name=row[\"strain\"], species_id=species.id\n",
+    "            )\n",
+    "\n",
+    "            # figure out generation question\n",
+    "            if len(row[\"generation\"]) > 2:\n",
+    "                gen = constants.Generation.F1\n",
+    "            else:\n",
+    "                gen = row[\"generation\"]\n",
+    "\n",
+    "            sex = constants.Sex.COMBINED if row[\"sex\"] == \"MF\" else row[\"sex\"]\n",
+    "            experiment_id = study_to_exp_map[row[\"study_id\"]]\n",
+    "\n",
+    "            await sync_to_async(AnimalGroup.objects.create)(\n",
+    "                experiment_id=experiment_id,\n",
+    "                name=f\"{sex} {strain.name} {species.name}\",  # ex: female wistar rat\n",
+    "                sex=sex,\n",
+    "                comments=row[\"tg_comment\"] or \"\",  # TODO: confirm if this mapping is correct\n",
+    "                generation=gen,\n",
+    "                lifestage_at_assessment=map_to_const(\n",
+    "                    row[\"life_stage\"], constants.Lifestage\n",
+    "                ),  # TODO: currently getting life_stage from tg_effect: figure out which one to use\n",
+    "                lifestage_at_exposure=map_to_const(row[\"life_stage\"], constants.Lifestage),\n",
+    "                species_id=species.id,\n",
+    "                strain_id=strain.id,\n",
+    "            )\n",
+    "\n",
+    "        exposure_duration_description = f'{row[\"dose_duration\"]} {row[\"dose_duration_unit\"]}'\n",
+    "\n",
+    "        treatment = await sync_to_async(\n",
+    "            Treatment.objects.create\n",
+    "        )(\n",
+    "            experiment_id=experiment_id,\n",
+    "            name=f'{exposure_duration_description} {row[\"admin_route\"]} {row[\"preferred_name\"]}',  # TODO: ask preferred name. Ex: 13 Day Oral Tebupirimfos\n",
+    "            chemical_id=toxref_to_hawc_chem_map[row[\"chemical_id\"]],\n",
+    "            route_of_exposure=map_to_const(row[\"admin_route\"], constants.RouteExposure),\n",
+    "            exposure_duration=row[\"dose_duration\"],\n",
+    "            exposure_duration_description=exposure_duration_description,\n",
+    "            comments=row[\"tg_comment\"] or \"\",\n",
+    "        )\n",
+    "        toxref_to_hawc_tg_map[tg_id] = treatment.id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create HAWC dosegroup and dataextraction from ToxRef dose, dtg, dtg_effect, tg, tg_effect"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "toxref_to_hawc_endpoint_map = {}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# arbitrary, unsure of the difference btw id and dose_id\n",
+    "dose_group_id = 12000\n",
+    "\n",
+    "for type in STUDY_TYPES:\n",
+    "    data_path = f\"{type}_data.csv\"\n",
+    "    df = pd.read_csv(data_path)\n",
+    "    unique_doses = df[\"dose_id\"].unique()\n",
+    "    # get data for each unique dose\n",
+    "    for dose_id in unique_doses:\n",
+    "        # filter unique doses\n",
+    "        dose_df = df[df[\"dose_id\"] == dose_id]\n",
+    "        dose_df[\"effect_var_type\"] = dose_df[\"effect_var_type\"].fillna(\n",
+    "            constants.VarianceType.NA.label\n",
+    "        )  # set NA to the default\n",
+    "        dose_df[\"dtg_effect_comment\"] = dose_df[\"dtg_effect_comment\"].fillna(\n",
+    "            \"\"\n",
+    "        )  # set this to the default\n",
+    "        dose_df[\"effect_val_unit\"] = dose_df[\"effect_val_unit\"].fillna(\n",
+    "            \"\"\n",
+    "        )  # set this to the default\n",
+    "\n",
+    "        unique_dtg = dose_df[\"dtg_id\"].unique()\n",
+    "        unique_tg_effect = dose_df[\"tg_effect_id\"].unique()\n",
+    "\n",
+    "        # filter dose treatment groups for each dose\n",
+    "        for dtg_id in unique_dtg:\n",
+    "            row = dose_df[dose_df[\"dtg_id\"] == dtg_id].iloc[0]\n",
+    "\n",
+    "            # create a hawc dosegroup\n",
+    "            # TODO: id vs dose_group_id?\n",
+    "            dose_unit = await sync_to_async(DoseUnits.objects.get)(name=\"mg/kg/d\")\n",
+    "\n",
+    "            await sync_to_async(DoseGroup.objects.create)(\n",
+    "                dose=row[\"dose_adjusted\"],\n",
+    "                dose_group_id=dose_group_id,\n",
+    "                dose_units_id=dose_unit.id,  # TODO: see where to store conc ppm\n",
+    "                treatment_id=toxref_to_hawc_tg_map[row[\"tg_id\"]],\n",
+    "            )\n",
+    "            # increment manual dose group id\n",
+    "            dose_group_id += 1\n",
+    "\n",
+    "        for tg_effect_id in unique_tg_effect:\n",
+    "            # filter unique treatment groups\n",
+    "            dtg_effect_df = dose_df[dose_df[\"tg_effect_id\"] == tg_effect_id]\n",
+    "\n",
+    "            for dtg_effect_id in dtg_effect_df[\"dtg_effect_id\"]:\n",
+    "                row = dtg_effect_df[dtg_effect_df[\"dtg_effect_id\"] == dtg_effect_id].iloc[0]\n",
+    "\n",
+    "                # get endpoint mapping\n",
+    "                # TODO: add term ids (or use some api)\n",
+    "                experiment = await sync_to_async(Experiment.objects.get)(\n",
+    "                    id=study_to_exp_map[row[\"study_id\"]]\n",
+    "                )\n",
+    "\n",
+    "                endpoint, created = await sync_to_async(Endpoint.objects.get_or_create)(\n",
+    "                    experiment=experiment,\n",
+    "                    name=row[\"effect_desc\"],\n",
+    "                    system=row[\"endpoint_category\"],\n",
+    "                    effect=row[\"endpoint_type\"],\n",
+    "                    effect_subtype=row[\"endpoint_target\"],\n",
+    "                )\n",
+    "\n",
+    "                toxref_to_hawc_endpoint_map[row[\"endpoint_id\"]] = endpoint.id\n",
+    "\n",
+    "                # Create new observation time model if needed\n",
+    "\n",
+    "                if not pd.isna(row[\"time_unit\"]):\n",
+    "                    obs_time = await sync_to_async(ObservationTime.objects.create)(\n",
+    "                        observation_time_text=row[\"time\"],\n",
+    "                        observation_time_units=map_to_const(\n",
+    "                            row[\"time_unit\"], constants.ObservationTimeUnits\n",
+    "                        ),\n",
+    "                        endpoint_id=endpoint.id,\n",
+    "                    )\n",
+    "\n",
+    "                    # if data extraction info is available, create model\n",
+    "                    dataextraction = await sync_to_async(\n",
+    "                        DataExtraction.objects.create\n",
+    "                    )(\n",
+    "                        experiment_id=study_to_exp_map[row[\"study_id\"]],\n",
+    "                        treatment_id=toxref_to_hawc_tg_map[row[\"tg_id\"]],\n",
+    "                        endpoint_id=endpoint.id,\n",
+    "                        method_to_control_for_litter_effects=constants.MethodToControlForLitterEffects.NR,  # default not reported\n",
+    "                        is_qualitative_only=False if row[\"no_quant_data_reported\"] == \"f\" else True,\n",
+    "                        variance_type=map_to_const(row[\"effect_var_type\"], constants.VarianceType),\n",
+    "                        # values_estimated = row[\"effect_val\"],\n",
+    "                        response_units=str(row[\"effect_val_unit\"])[\n",
+    "                            :32\n",
+    "                        ],  # this is limited to 32 characters, unsure if we standardise somewhere\n",
+    "                        observation_timepoint_id=obs_time.id,\n",
+    "                        result_details=row[\n",
+    "                            \"dtg_effect_comment\"\n",
+    "                        ],  # TODO: effect_comment or dtg_effect_comment here?\n",
+    "                    )\n",
+    "\n",
+    "                    # calculate NOEL: lowest dose with a critical effect (dose_adjusted units are all mg/kg/day)\n",
+    "                    filtered_df = df[df[\"critical_effect\"]]\n",
+    "                    LOEL = filtered_df[\"dose_adjusted\"].min()\n",
+    "\n",
+    "                    # calculate LOEL: highest dose with no critical effect\n",
+    "                    filtered_df = df[not df[\"critical_effect\"]]\n",
+    "                    NOEL = filtered_df[\"dose_adjusted\"].max()\n",
+    "\n",
+    "                    statistically_significant = (\n",
+    "                        constants.StatisticallySignificant.YES\n",
+    "                        if row[\"treatment_related\"] == \"t\"\n",
+    "                        else constants.StatisticallySignificant.NO\n",
+    "                    )\n",
+    "\n",
+    "                    await sync_to_async(\n",
+    "                        DoseResponseGroupLevelData.objects.create\n",
+    "                    )(\n",
+    "                        data_extraction_id=dataextraction.id,\n",
+    "                        treatment_name=f'{row[\"dose_duration\"]} {row[\"dose_duration_unit\"]} {row[\"admin_route\"]} {row[\"preferred_name\"]}',  # from treatment model\n",
+    "                        dose=row[\"dose_adjusted\"],  # TODO: check this out in terms mapping w dtg\n",
+    "                        n=None if pd.isna(row[\"n\"]) else row[\"n\"],\n",
+    "                        response=row[\"effect_val\"],  # TODO verify\n",
+    "                        variance=row[\"effect_var\"],\n",
+    "                        treatment_related_effect=statistically_significant,  # TODO: assumed this would be row['dtg_effect_comment'], but it's controlled\n",
+    "                        statistically_significant=statistically_significant,\n",
+    "                        p_value=0.05\n",
+    "                        if row[\"treatment_related\"] == \"t\"\n",
+    "                        else \"\",  # TODO: ask about default p_value\n",
+    "                        NOEL=NOEL if not pd.isna(NOEL) else -999,\n",
+    "                        LOEL=LOEL if not pd.isna(LOEL) else -999,\n",
+    "                    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Remove extra files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for type in STUDY_TYPES:\n",
+    "    # Define the output CSV file\n",
+    "    output_file = f\"{type}_data.csv\"\n",
+    "    if os.path.exists(output_file):\n",
+    "        os.remove(output_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Migrate observation Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "obs_query = (\n",
+    "    \"\"\"SELECT study_id, endpoint_id, tested_status, reported_status FROM prod_toxrefdb_2_1.obs\"\"\"\n",
+    ")\n",
+    "\n",
+    "obs_data = fetch_data_from_source(obs_query, source_conn)\n",
+    "\n",
+    "obs_mapping = [\n",
+    "    {\n",
+    "        \"study_id\": study_to_exp_map[row[0]],\n",
+    "        \"endpoint_id\": toxref_to_hawc_endpoint_map[row[1]],\n",
+    "        \"tested_status\": row[2],\n",
+    "        \"reported_status\": row[3],\n",
+    "    }\n",
+    "    for row in obs_data\n",
+    "]\n",
+    "await Observation.objects.bulk_create(obs_mapping)\n",
+    "obs_mapping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Close the cursor and connection\n",
+    "cur.close()\n",
+    "source_conn.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "hawc",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Initial pass at a notebook to migrate ToxRef to Hawc. Currently uses HAWC models instead of API. 

The current mapping notes can be found in this file: https://icfonline-my.sharepoint.com/:x:/g/personal/63080_icf_com/EXhl2XGxjYVFnBGbRB8XUPgBv7VOVVx6Y0GbWstKs_AnoA?email=Watford.Sean%40epa.gov&e=5DeEaU

A few points I was unsure:
- Does ToxRef Study_type correlate to HAWC experiment guideline or design? Design is constrained but is "TODO" at the moment
- Mapped ToxRef dtg to HAWC dosegroup for mg/kg/day dose. There is also ToxRef dose 'conc' and the associated units that is just the ppm version: not sure of preference.
- There are also some comments in the notebook