### PR TITLE
generate fake user data; remove faker dependency

### DIFF
--- a/hawc/apps/myuser/synthetic.py
+++ b/hawc/apps/myuser/synthetic.py
@@ -1,0 +1,46 @@
+import random
+from typing import NamedTuple
+
+
+class UserData(NamedTuple):
+    first_name: str
+    last_name: str
+    username: str
+    email: str
+
+
+# fmt: off
+FIRST_NAMES: list[str] = [
+    "Alex", "Amelia", "Andrew", "Ava", "Benjamin", "Charlotte", "Chloe", "Chris", "Daniel", "David", "Emily",
+    "Emma", "Ethan", "Grace", "Harper", "Isabella", "James", "Jane", "John", "Liam", "Lucas", "Matthew", "Mia",
+    "Michael", "Natalie", "Noah", "Olivia", "Sam", "Sophia", "Zoe"
+]
+LAST_NAMES: list[str] = [
+    "Adams", "Allen", "Anderson", "Baker", "Brown", "Carter", "Clark", "Garcia", "Gonzalez", "Hall", "Harris",
+    "Jackson", "Johnson", "King", "Lewis", "Martin", "Martinez", "Mitchell", "Nelson", "Robinson", "Rodriguez",
+    "Scott", "Smith", "Taylor", "Thomas", "Thompson", "Walker", "White", "Wright", "Young"
+]
+EMAIL_DOMAINS: list[str] = [
+    "anonmail.net", "cloudmail.co", "demo.net", "devemail.net", "dummybox.co", "example.com", "fakemail.co",
+    "freemail.org", "hostedmail.com", "instantmail.com", "mail.com", "mailservice.co", "mockmail.com", "myemail.net",
+    "onlinemail.org", "placeholder.org", "protonmail.com", "quickmail.net", "randommail.com", "sample.org",
+    "samplemail.org", "sandbox.io", "securemail.co", "tempdomain.net", "test.org", "testmail.org", "trialmail.com",
+    "virtualmail.com", "webmail.co", "yetanothermail.net"
+]
+# fmt: on
+
+
+def _generate_email(first_name: str, last_name: str) -> tuple[str, str]:
+    # Generate a realistic username and email address from a first and last name
+    domain = random.choice(EMAIL_DOMAINS)  # noqa: S311
+    number = random.randint(1, 8096)  # noqa: S311
+    username = f"{first_name.lower()}.{last_name.lower()}{number}"
+    return username, f"{username}@{domain}"
+
+
+def generate() -> UserData:
+    # Generate synthetic user data
+    first_name = random.choice(FIRST_NAMES)  # noqa: S311
+    last_name = random.choice(LAST_NAMES)  # noqa: S311
+    username, email = _generate_email(first_name, last_name)
+    return UserData(first_name=first_name, last_name=last_name, username=username, email=email)

--- a/hawc/apps/myuser/synthetic.py
+++ b/hawc/apps/myuser/synthetic.py
@@ -1,14 +1,6 @@
 import random
 from typing import NamedTuple
 
-
-class UserData(NamedTuple):
-    first_name: str
-    last_name: str
-    username: str
-    email: str
-
-
 # fmt: off
 FIRST_NAMES: list[str] = [
     "Alex", "Amelia", "Andrew", "Ava", "Benjamin", "Charlotte", "Chloe", "Chris", "Daniel", "David", "Emily",
@@ -28,6 +20,13 @@ EMAIL_DOMAINS: list[str] = [
     "virtualmail.com", "webmail.co", "yetanothermail.net"
 ]
 # fmt: on
+
+
+class UserData(NamedTuple):
+    first_name: str
+    last_name: str
+    username: str
+    email: str
 
 
 def _generate_email(first_name: str, last_name: str) -> tuple[str, str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,6 @@ dev = [
   "django-debug-toolbar==4.4.6",
   "django-browser-reload==1.17.0",
   "django-extensions==3.2.3",
-  "faker==33.3.0",
   # tests
   "coverage==7.6.10",
   "pytest==8.3.4",

--- a/tests/hawc/apps/myuser/test_synthetic.py
+++ b/tests/hawc/apps/myuser/test_synthetic.py
@@ -1,0 +1,9 @@
+from hawc.apps.myuser.synthetic import UserData, generate
+
+
+def test_generate():
+    data = generate()
+    assert isinstance(data, UserData)
+    assert data.first_name.lower() in data.email
+    assert data.last_name.lower() in data.email
+    assert data.username in data.email


### PR DESCRIPTION
The [Faker](https://pypi.org/project/Faker/) package is only used to generate synthetic user data and we're not really taking advantage of the complexities of the package. 

Rewrite, removing the package, using just the standard library.