### PR TITLE
empty long reference export check

### DIFF
--- a/hawc/apps/lit/exports.py
+++ b/hawc/apps/lit/exports.py
@@ -165,6 +165,8 @@ def _long_export(qs: QuerySet, assessment_id: int) -> pd.DataFrame:
             models.Reference.objects.filter(assessment=assessment_id)
         )
     )
+    if refs.empty or ref_tags.empty:
+        return pd.DataFrame({"Result": ["No data available."]})
     return (
         refs.merge(
             ref_tags.merge(tags, left_on="tag_id", right_on="id", how="left").drop(

--- a/tests/hawc/apps/lit/test_exports.py
+++ b/tests/hawc/apps/lit/test_exports.py
@@ -12,3 +12,12 @@ class TestReferenceTagLongExport:
             assessment=Assessment.objects.get(id=2),
         )
         assert exporter.build_df().shape == (5, 10)
+
+    def test_no_data(self):
+        exporter = exports.ReferenceTagLongExport(
+            queryset=models.Reference.objects.filter(assessment_id=5),
+            assessment=Assessment.objects.get(id=5),
+        )
+        df = exporter.build_df()
+        assert df.shape == (1, 1)
+        assert df.Result[0] == "No data available."


### PR DESCRIPTION
If a reference export is requested and an assessment has no references, or no references with tags, it returns an export that indicates that No Data are available. Previously, an error would occur.