### PR TITLE
Build wheels in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
       with:
         name: coverage
         path: coverage
-        retention-days: 90
+        retention-days: 7
 
   frontend:
     name: frontend
@@ -176,10 +176,13 @@ jobs:
           exit 1
         fi
     - name: Build wheels
-      # if: startsWith(github.event.ref, 'refs/tags/') || endsWith(github.event.ref, 'refs/heads/main')
       run: |
-        uv run python manage.py set_git_commit
-        uv run flit build --format wheel
+        # activate environment so we can build the client package too using flit
+        source .venv/bin/activate
+        python manage.py set_git_commit
+        flit build --format wheel
+        cd client && flit build --format wheel && cd ..
+        cp client/dist/*.whl dist
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
We previously created an artifact which included python wheels for hawc and hawc-client packages, but this was removed with migration to uv in #1125. Restore this action, as they can be useful, but build for all pull-requests, not just on main or a tag.