### PR TITLE
Show correct datetime timezone for users

### DIFF
--- a/hawc/main/settings/base.py
+++ b/hawc/main/settings/base.py
@@ -86,6 +86,7 @@ MIDDLEWARE = (
     "django.middleware.security.SecurityMiddleware",
     "wagtail.contrib.redirects.middleware.RedirectMiddleware",
     "hawc.apps.common.middleware.MicrosoftOfficeLinkMiddleware",
+    "hawc.apps.common.middleware.ActivateTimezoneMiddleware",
     "hawc.apps.common.middleware.RequestLogMiddleware",
     "hawc.apps.common.middleware.ThreadLocalMiddleware",
 )

--- a/hawc/templates/base.html
+++ b/hawc/templates/base.html
@@ -100,6 +100,9 @@
     <script type="text/javascript" src="{% static 'vendor/jquery/3.7.0/jquery.min.js' %}"></script>
     <script type="text/javascript" src="{% static 'vendor/bootstrap/4.6.2/js/bootstrap.bundle.min.js' %}"></script>
     <script type="text/javascript" src="{% static 'vendor/htmx/2.0.3/htmx.min.js' %}"></script>
+    <script>
+      document.cookie = `timezone=${Intl.DateTimeFormat().resolvedOptions().timeZone}; path=/`;
+    </script>
     {% vite_hmr_client %}
     {% vite_asset 'index.js' %}
     {% if form %}{{ form.media }}{% endif %}


### PR DESCRIPTION
Make all timezones aware. Adapted (adding tests) from https://www.loopwerk.io/articles/2025/django-local-times/