### PR TITLE
change legend location based on data direction

### DIFF
--- a/frontend/animal/DRPlot.js
+++ b/frontend/animal/DRPlot.js
@@ -545,7 +545,10 @@ class DRPlot extends D3Plot {
         if (this.legend_left) {
             legend_settings.box_l = this.legend_left;
         } else {
-            const isIncreasing = this.values[0].y < this.values[this.values.length - 1].y;
+            let isIncreasing = true;
+            if (Array.isArray(this.values) && this.values.length > 0) {
+                isIncreasing = this.values[0].y < this.values[this.values.length - 1].y;
+            }
             legend_settings.box_l = isIncreasing ? 10 : this.w - 80;
         }
 


### PR DESCRIPTION
Set legend in top left if data are increasing, or top right if data are decreasing:

Decreasing:
<img width="318" height="358" alt="image" src="https://github.com/user-attachments/assets/ebbea209-963a-4693-b0f6-7871de744d98" />

Increasing:
<img width="316" height="315" alt="image" src="https://github.com/user-attachments/assets/68e60a58-e66e-4ae1-b8af-c8bff39a9b0e" />
