### PR TITLE
CI -verbose tests; block network access

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,7 +168,7 @@ jobs:
       id: retry
       continue-on-error: true
       run: |
-        uv run py.test -v --block-network --allowed-hosts=127.0.0.1,::1 tests/integration/ --lf
+        uv run py.test -v --block-network --allowed-hosts=127.0.0.1,::1 --lf tests/integration/
     - name: set status
       if: always()
       run: |


### PR DESCRIPTION
* Globally block network access in CI tests (except for localhost) 
* Turn on verbose mode for tests in GitHub Actions to better show failures in real-time
* Rerun only failed integration tests instead of all integration tests on failure